### PR TITLE
Clear discount type when no discount is set

### DIFF
--- a/src/CoreBundle/Form/Type/DiscountType.php
+++ b/src/CoreBundle/Form/Type/DiscountType.php
@@ -21,6 +21,8 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -81,6 +83,14 @@ class DiscountType extends AbstractType
             public function reverseTransform($value)
             {
                 return $value;
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            /** @var Discount $discount */
+            $discount = $event->getForm()->getData();
+            if (!$discount->getValue()) {
+                $discount->setType(null);
             }
         });
     }

--- a/src/CoreBundle/Form/Type/DiscountType.php
+++ b/src/CoreBundle/Form/Type/DiscountType.php
@@ -89,7 +89,7 @@ class DiscountType extends AbstractType
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             /** @var Discount $discount */
             $discount = $event->getForm()->getData();
-            if (!$discount->getValue()) {
+            if ($discount instanceof Discount && !$discount->getValue()) {
                 $discount->setType(null);
             }
         });

--- a/src/InvoiceBundle/Entity/Invoice.php
+++ b/src/InvoiceBundle/Entity/Invoice.php
@@ -209,6 +209,7 @@ class Invoice
 
     public function __construct()
     {
+        $this->discount = new Discount();
         $this->items = new ArrayCollection();
         $this->payments = new ArrayCollection();
         $this->users = new ArrayCollection();
@@ -393,7 +394,7 @@ class Invoice
      *
      * @return Discount
      */
-    public function getDiscount(): ?Discount
+    public function getDiscount(): Discount
     {
         return $this->discount;
     }
@@ -405,7 +406,7 @@ class Invoice
      *
      * @return Invoice
      */
-    public function setDiscount(?Discount $discount): self
+    public function setDiscount(Discount $discount): self
     {
         $this->discount = $discount;
 

--- a/src/InvoiceBundle/Resources/views/invoice_template.html.twig
+++ b/src/InvoiceBundle/Resources/views/invoice_template.html.twig
@@ -167,7 +167,7 @@
                                 </tr>
                             {% endif %}
 
-                            {% if invoice.discount is not empty and invoice.discount.type is not empty %}
+                            {% if invoice.discount.type is not empty %}
                                 <tr>
                                     <td class="no-line"></td>
                                     <td colspan="{{ footerSpan }}" class="no-line text-right">

--- a/src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
+++ b/src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
@@ -102,7 +102,12 @@ class InvoiceCreateHandlerTest extends FormHandlerTestCase
     public function getFormData(): array
     {
         return [
-            'invoice' => [],
+            'invoice' => [
+                'discount' => [
+                    'value' => 20,
+                    'type' => 'percentage'
+                ],
+            ],
         ];
     }
 

--- a/src/QuoteBundle/Entity/Quote.php
+++ b/src/QuoteBundle/Entity/Quote.php
@@ -163,6 +163,7 @@ class Quote
 
     public function __construct()
     {
+        $this->discount = new Discount();
         $this->items = new ArrayCollection();
         $this->users = new ArrayCollection();
         $this->setUuid(Uuid::uuid1());
@@ -327,7 +328,7 @@ class Quote
     /**
      * @return Discount
      */
-    public function getDiscount(): ?Discount
+    public function getDiscount(): Discount
     {
         return $this->discount;
     }
@@ -337,7 +338,7 @@ class Quote
      *
      * @return Quote
      */
-    public function setDiscount(?Discount $discount): self
+    public function setDiscount(Discount $discount): self
     {
         $this->discount = $discount;
 

--- a/src/QuoteBundle/Resources/views/quote_template.html.twig
+++ b/src/QuoteBundle/Resources/views/quote_template.html.twig
@@ -166,7 +166,7 @@
                                         </td>
                                     </tr>
                                 {% endif %}
-                                {% if quote.discount is not empty and quote.discount.type is not empty %}
+                                {% if quote.discount.type is not empty %}
                                     <tr>
                                         <td class="no-line"></td>
                                         <td colspan="{{ footerSpan }}" class="no-line text-right">

--- a/src/QuoteBundle/Tests/Form/Handler/QuoteCreateHandlerTest.php
+++ b/src/QuoteBundle/Tests/Form/Handler/QuoteCreateHandlerTest.php
@@ -90,7 +90,10 @@ class QuoteCreateHandlerTest extends FormHandlerTestCase
     {
         return [
             'quote' => [
-                'discount' => 20,
+                'discount' => [
+                    'value' => 20,
+                    'type' => 'percentage'
+                ],
             ],
         ];
     }


### PR DESCRIPTION
When no discount is set, then the discount type should not be saved so that an empty discount doesn't show up when viewing a quote or invoice