### PR TITLE
Don't set quote items by reference

### DIFF
--- a/src/QuoteBundle/Form/Type/QuoteType.php
+++ b/src/QuoteBundle/Form/Type/QuoteType.php
@@ -63,7 +63,7 @@ class QuoteType extends AbstractType
                 'entry_type' => ItemType::class,
                 'allow_add' => true,
                 'allow_delete' => true,
-                'by_reference' => true,
+                'by_reference' => false,
                 'required' => false,
                 'entry_options' => [
                     'currency' => $options['currency']->getCode(),


### PR DESCRIPTION
When setting quote items by reference, the addItem method is never called on the entity, which causes the item to never be attached to the specific quote