### PR TITLE
Fix totals not updating if no values are set

### DIFF
--- a/src/CoreBundle/Resources/public/js/billing/model/collection.js
+++ b/src/CoreBundle/Resources/public/js/billing/model/collection.js
@@ -16,6 +16,10 @@ define(['backbone', 'lodash'], function(Backbone, _) {
                 let rowTotal = model.get('total'),
                     rowTax = model.get('tax');
 
+                if (_.isUndefined(rowTotal)) {
+                    return;
+                }
+
                 total += rowTotal;
                 subTotal += rowTotal;
 

--- a/src/CoreBundle/Resources/public/js/billing/view/item_row.js
+++ b/src/CoreBundle/Resources/public/js/billing/view/item_row.js
@@ -51,7 +51,8 @@ define(['marionette', 'template', 'lodash', 'accounting'], function(Mn, Template
                 this.model.set(type, val);
             }, this));
 
-            var amount = parseFloat(this.model.get('qty')) * this.model.get('price');
+            let qty = this.model.get('qty');
+            let amount = parseFloat(qty || 0) * this.model.get('price');
 
             this.model.set('total', amount);
             this.$('.column-total').html(Accounting.formatMoney(this.model.get('total')));


### PR DESCRIPTION
When adding a new row to a quote or invoice and no values are set (qty or amount), then the totals would change to 0 even if there are other rows with values.