### PR TITLE
Add xsl, GD and SOAP extensions to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,25 @@ RUN echo "date.timezone=$TIMEZONE" >> /usr/local/etc/php/php.ini && \
     echo "max_execution_time = 60;" >> /usr/local/etc/php/php.ini && \
     echo "memory_limit = 512M;" >> /usr/local/etc/php/php.ini
 
+# Install XSL
+RUN apt-get install -y libxslt-dev && \
+    docker-php-ext-install xsl
+
+# Install GD2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev && \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+    docker-php-ext-install -j$(nproc) gd && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install SOAP
+RUN apt-get update -y \
+  && apt-get install -y libxml2-dev \
+  && apt-get clean -y \
+  && docker-php-ext-install soap
+
 WORKDIR /opt/srv
 
 EXPOSE 80

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,12 @@ RUN apt-get update && \
         libpng-dev \
         libjpeg-dev \
         autoconf \
-        supervisor && \
+        supervisor \
+        libxslt-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libxml2-dev && \
     pecl install apcu && \
     pecl install xdebug && \
     ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a /usr/lib && \
@@ -60,6 +65,10 @@ RUN apt-get update && \
     docker-php-ext-install -j$(nproc) opcache && \
     docker-php-ext-install -j$(nproc) bcmath && \
     docker-php-ext-install -j$(nproc) intl && \
+    docker-php-ext-install -j$(nproc) xsl && \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+    docker-php-ext-install -j$(nproc) gd && \
+    docker-php-ext-install soap && \
         docker-php-ext-enable apcu && \
         curl -sS https://get.symfony.com/cli/installer | bash && \
         mv ~/.symfony/bin/symfony /usr/bin/symfony && \
@@ -77,25 +86,6 @@ RUN apt-get update && \
 RUN echo "date.timezone=$TIMEZONE" >> /usr/local/etc/php/php.ini && \
     echo "max_execution_time = 60;" >> /usr/local/etc/php/php.ini && \
     echo "memory_limit = 512M;" >> /usr/local/etc/php/php.ini
-
-# Install XSL
-RUN apt-get install -y libxslt-dev && \
-    docker-php-ext-install xsl
-
-# Install GD2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
-    libpng-dev && \
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-install -j$(nproc) gd && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install SOAP
-RUN apt-get update -y \
-  && apt-get install -y libxml2-dev \
-  && apt-get clean -y \
-  && docker-php-ext-install soap
 
 WORKDIR /opt/srv
 


### PR DESCRIPTION
The current docker setup is missing some extensions to be able to run the application.
This PR adds the installation of these extensions to the Dockerfile.