### PR TITLE
Add error message to grid.js

### DIFF
--- a/src/DataGridBundle/Resources/public/js/grid.js
+++ b/src/DataGridBundle/Resources/public/js/grid.js
@@ -52,7 +52,7 @@ define([
                 var gridOptions = {
                     collection: collection,
                     className: 'backgrid table table-bordered table-hover',
-                    emptyText: "There currently is no data to display."
+                    emptyText: "There currently are no data to display."
                 };
 
                 if (!_.isUndefined(options.properties.route)) {

--- a/src/DataGridBundle/Resources/public/js/grid.js
+++ b/src/DataGridBundle/Resources/public/js/grid.js
@@ -52,7 +52,7 @@ define([
                 var gridOptions = {
                     collection: collection,
                     className: 'backgrid table table-bordered table-hover',
-                    emptyText: "no data"
+                    emptyText: "There currently is no data to display."
                 };
 
                 if (!_.isUndefined(options.properties.route)) {


### PR DESCRIPTION
Added a more user friendly error message to DataGridBundle/Resources/public/grid.js
This appears to be the only place where the error is handled.

Fixes #137 