### PR TITLE
Uses uuid to show in quotes and invoices

### DIFF
--- a/src/InvoiceBundle/Action/View.php
+++ b/src/InvoiceBundle/Action/View.php
@@ -53,7 +53,7 @@ final class View
     public function __invoke(Request $request, Invoice $invoice)
     {
         if ('pdf' === $request->getRequestFormat() && $this->pdfGenerator->canPrintPdf()) {
-            return new PdfResponse($this->pdfGenerator->generate($this->twig->render('@SolidInvoiceInvoice/Pdf/invoice.html.twig', ['invoice' => $invoice])), "invoice_{$invoice->getId()}.pdf");
+            return new PdfResponse($this->pdfGenerator->generate($this->twig->render('@SolidInvoiceInvoice/Pdf/invoice.html.twig', ['invoice' => $invoice])), "invoice_{$invoice->getUuid()}.pdf");
         }
 
         return new Template(

--- a/src/InvoiceBundle/Resources/views/Default/create.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/create.html.twig
@@ -80,7 +80,7 @@
                     <div class="title">
                         <h3 class="page-header">
                             {% if invoice is defined %}
-                                {{ 'invoice.title'|trans({'%id%' : invoice.id}) }}
+                                {{ 'invoice.title'|trans({'%id%' : invoice.uuid}) }}
                             {% else %}
                                 {{ 'invoice.action.create'|trans }}
                             {% endif %}

--- a/src/InvoiceBundle/Resources/views/Default/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view.html.twig
@@ -12,7 +12,7 @@
 {% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
 
 {% block page_title %}
-    {{ "invoice.title"|trans({"%id%" : invoice.id}) }}
+    {{ "invoice.title"|trans({"%id%" : invoice.uuid}) }}
 {% endblock page_title %}
 
 {% block sidebar %}

--- a/src/InvoiceBundle/Resources/views/Email/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Email/invoice.html.twig
@@ -11,7 +11,7 @@
 {% set invoicePath = url("_view_invoice_external", {"uuid" : invoice.uuid}) %}
 
 {%- block title -%}
-    {{ "invoice.title"|trans({"%id%" : invoice.id}) }}
+    {{ "invoice.title"|trans({"%id%" : invoice.uuid}) }}
 {%- endblock -%}
 
 {%- block header -%}
@@ -83,7 +83,7 @@
                 <strong>Invoice #</strong>
             </columns>
             <columns>
-                {{ invoice.id }}
+                {{ invoice.uuid }}
             </columns>
         </row>
 

--- a/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
+++ b/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
@@ -10,5 +10,5 @@
 {{ 'invoice.status_change.heading'|trans({}, 'email') }}
 -------------------
 
-{{ 'invoice.status_change.id'|trans({}, 'email') }}: {{ invoice.id }}
+{{ 'invoice.status_change.id'|trans({}, 'email') }}: {{ invoice.uuid }}
 {{ 'invoice.status_change.status'|trans({}, 'email') }}: {{ invoice.status }}

--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -10,7 +10,7 @@
 <html>
 <head>
     <style type="text/css">
-        {{ file('css/pdf.css') }}
+        {{ asset('static/pdf.css') }}
 
         @page {
             margin-top: 2.5cm;
@@ -47,7 +47,7 @@
 
 <div class="row">
     <div class="col-12 text-right">
-        <h3 style="font-weight: bold">Invoice #{{ invoice.id }}</h3>
+        <h3 style="font-weight: bold">Invoice #{{ invoice.uuid }}</h3>
     </div>
 </div>
 

--- a/src/InvoiceBundle/Resources/views/invoice_template.html.twig
+++ b/src/InvoiceBundle/Resources/views/invoice_template.html.twig
@@ -17,7 +17,7 @@
                 <div class="col-12">
                     {% block title %}
                         <h2 class="page-header">
-                            {{ "invoice.title"|trans({"%id%" : invoice.id}) }} {{ invoice_label(invoice.status) }}
+                            {{ "invoice.title"|trans({"%id%" : invoice.uuid}) }} {{ invoice_label(invoice.status) }}
                         </h2>
                     {% endblock %}
                     <div class="row invoice-info">
@@ -90,7 +90,7 @@
                         <div class="col-sm-4 invoice-col">
                             <dl class="dl-horizontal">
                                 <dt>{{ "invoice.title"|trans({"%id%" : ''}) }}</dt>
-                                <dd>{{ invoice.id }}</dd>
+                                <dd>{{ invoice.uuid }}</dd>
                                 <dt>{{ "invoice.total"|trans }}</dt>
                                 <dd>{{ invoice.total|formatCurrency }}</dd>
                                 <dt>{{ "invoice.created"|trans }}</dt>

--- a/src/QuoteBundle/Action/View.php
+++ b/src/QuoteBundle/Action/View.php
@@ -46,7 +46,7 @@ final class View
     public function __invoke(Request $request, Quote $quote)
     {
         if ('pdf' === $request->getRequestFormat() && $this->pdfGenerator->canPrintPdf()) {
-            return new PdfResponse($this->pdfGenerator->generate($this->engine->render('@SolidInvoiceQuote/Pdf/quote.html.twig', ['quote' => $quote])), "quote_{$quote->getId()}.pdf");
+            return new PdfResponse($this->pdfGenerator->generate($this->engine->render('@SolidInvoiceQuote/Pdf/quote.html.twig', ['quote' => $quote])), "quote_{$quote->getUuid()}.pdf");
         }
 
         return new Template('@SolidInvoiceQuote/Default/view.html.twig', ['quote' => $quote]);

--- a/src/QuoteBundle/Resources/views/Default/create.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/create.html.twig
@@ -76,7 +76,7 @@
         <div class="card-header">
             <h3 class="card-title">
                 {% if quote is defined %}
-                    {{ 'quote.title'|trans({'%id%' : quote.id}) }}
+                    {{ 'quote.title'|trans({'%id%' : quote.uuid}) }}
                 {% else %}
                     {{ 'quote.create'|trans }}
                 {% endif %}

--- a/src/QuoteBundle/Resources/views/Default/view.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/view.html.twig
@@ -12,7 +12,7 @@
 {% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
 
 {% block page_title %}
-    {{ "quote.title"|trans({"%id%" : quote.id}) }}
+    {{ "quote.title"|trans({"%id%" : quote.uuid}) }}
 {% endblock page_title %}
 
 {% block sidebar %}

--- a/src/QuoteBundle/Resources/views/Email/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Email/quote.html.twig
@@ -11,7 +11,7 @@
 {% set quotePath = url("_view_quote_external", {"uuid" : quote.uuid}) %}
 
 {%- block title -%}
-    {{ "quote.title"|trans({"%id%" : quote.id}) }}
+    {{ "quote.title"|trans({"%id%" : quote.uuid}) }}
 {%- endblock -%}
 
 {%- block header -%}
@@ -64,7 +64,7 @@
                 <strong>Quote #</strong>
             </columns>
             <columns>
-                {{ quote.id }}
+                {{ quote.uuid }}
             </columns>
         </row>
 

--- a/src/QuoteBundle/Resources/views/Email/status_change.text.twig
+++ b/src/QuoteBundle/Resources/views/Email/status_change.text.twig
@@ -10,5 +10,5 @@
 {{ 'quote.status_change.heading'|trans({}, 'email') }}
 -------------------
 
-{{ 'quote.status_change.id'|trans({}, 'email') }}: {{ quote.id }}
+{{ 'quote.status_change.id'|trans({}, 'email') }}: {{ quote.uuid }}
 {{ 'quote.status_change.new_status'|trans({}, 'email') }}: {{ quote.status }}

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -10,7 +10,7 @@
 <html>
 <head>
     <style type="text/css">
-        {{ file('css/pdf.css') }}
+        {{ asset('static/pdf.css') }}
 
         @page {
             margin-top: 2.5cm;
@@ -47,7 +47,7 @@
 
 <div class="row">
     <div class="col-12 text-right">
-        <h3 style="font-weight: bold">Quote #{{ quote.id }}</h3>
+        <h3 style="font-weight: bold">Quote #{{ quote.uuid }}</h3>
     </div>
 </div>
 

--- a/src/QuoteBundle/Resources/views/quote_template.html.twig
+++ b/src/QuoteBundle/Resources/views/quote_template.html.twig
@@ -17,7 +17,7 @@
                 <div class="col-12">
                     {% block title %}
                         <h2 class="page-header">
-                            {{ "quote.title"|trans({"%id%" : quote.id}) }} {{ quote_label(quote.status) }}
+                            {{ "quote.title"|trans({"%id%" : quote.uuid}) }} {{ quote_label(quote.status) }}
                         </h2>
                     {% endblock %}
                     <div class="row invoice-info">
@@ -90,7 +90,7 @@
                         <div class="col-sm-4 invoice-col">
                             <dl class="dl-horizontal">
                                 <dt>{{ "quote.title"|trans({"%id%" : ''}) }}</dt>
-                                <dd>{{ quote.id }}</dd>
+                                <dd>{{ quote.uuid }}</dd>
                                 <dt>{{ "quote.total"|trans }}</dt>
                                 <dd>{{ quote.total|formatCurrency }}</dd>
                                 <dt>{{ "quote.created"|trans }}</dt>


### PR DESCRIPTION
Avoid to show internal information about entities database identifier and amount of
quotes and/or invoices generated.

One place i was not able to find was when viewing the quote/invoice through the public url. May i ask you were in code is that?

![Bildschirmfoto 2020-10-12 um 17 03 56](https://user-images.githubusercontent.com/210742/95763645-972c3900-0caf-11eb-80d9-b13500e65f38.png)

thanks in advance,
David

Address #338 