### PR TITLE
Fix sending of quotes and invoices

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -871,19 +871,9 @@ parameters:
 			path: src/InvoiceBundle/Action/RecurringTransition.php
 
 		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Action\\\\Transition\\:\\:__invoke\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Action/Transition.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/InvoiceBundle/Action/Transition.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Action\\\\Transition\\\\Send\\:\\:__invoke\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Action/Transition/Send.php
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
@@ -1069,31 +1059,6 @@ parameters:
 			message: "#^Call to an undefined method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\BaseInvoice\\:\\:getUuid\\(\\)\\.$#"
 			count: 1
 			path: src/InvoiceBundle/Tests/Cloner/InvoiceClonerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Tests\\\\Form\\\\Handler\\\\InvoiceCreateHandlerTest\\:\\:getFormData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Tests\\\\Form\\\\Handler\\\\InvoiceCreateHandlerTest\\:\\:getHandlerOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Tests\\\\Form\\\\Handler\\\\InvoiceEditHandlerTest\\:\\:getFormData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Tests/Form/Handler/InvoiceEditHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Tests\\\\Form\\\\Handler\\\\InvoiceEditHandlerTest\\:\\:getHandlerOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Tests/Form/Handler/InvoiceEditHandlerTest.php
-
-		-
-			message: "#^Property SolidInvoice\\\\InvoiceBundle\\\\Tests\\\\Form\\\\Handler\\\\InvoiceEditHandlerTest\\:\\:\\$invoice has no type specified\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Tests/Form/Handler/InvoiceEditHandlerTest.php
 
 		-
 			message: "#^Method SolidInvoice\\\\MailerBundle\\\\Configurator\\\\ConfiguratorInterface\\:\\:configure\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
@@ -1611,16 +1576,6 @@ parameters:
 			path: src/QuoteBundle/Action/Index.php
 
 		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Action\\\\Transition\\:\\:__invoke\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/QuoteBundle/Action/Transition.php
-
-		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Action\\\\Transition\\\\Send\\:\\:__invoke\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/QuoteBundle/Action/Transition/Send.php
-
-		-
 			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Cloner\\\\QuoteCloner\\:\\:addItems\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
 			count: 1
 			path: src/QuoteBundle/Cloner/QuoteCloner.php
@@ -1684,31 +1639,6 @@ parameters:
 			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Repository\\\\QuoteRepository\\:\\:getRecentQuotes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/QuoteBundle/Repository/QuoteRepository.php
-
-		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Tests\\\\Form\\\\Handler\\\\QuoteCreateHandlerTest\\:\\:getFormData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/QuoteBundle/Tests/Form/Handler/QuoteCreateHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Tests\\\\Form\\\\Handler\\\\QuoteCreateHandlerTest\\:\\:getHandlerOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/QuoteBundle/Tests/Form/Handler/QuoteCreateHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Tests\\\\Form\\\\Handler\\\\QuoteEditHandlerTest\\:\\:getFormData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/QuoteBundle/Tests/Form/Handler/QuoteEditHandlerTest.php
-
-		-
-			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Tests\\\\Form\\\\Handler\\\\QuoteEditHandlerTest\\:\\:getHandlerOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/QuoteBundle/Tests/Form/Handler/QuoteEditHandlerTest.php
-
-		-
-			message: "#^Property SolidInvoice\\\\QuoteBundle\\\\Tests\\\\Form\\\\Handler\\\\QuoteEditHandlerTest\\:\\:\\$quote has no type specified\\.$#"
-			count: 1
-			path: src/QuoteBundle/Tests/Form/Handler/QuoteEditHandlerTest.php
 
 		-
 			message: "#^Method SolidInvoice\\\\SettingsBundle\\\\Action\\\\Index\\:\\:__invoke\\(\\) has no return type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1106,16 +1106,6 @@ parameters:
 			path: src/MailerBundle/Factory/MailerConfigFactory.php
 
 		-
-			message: "#^Property SolidInvoice\\\\MailerBundle\\\\Factory\\\\MailerConfigFactory\\:\\:\\$config has no type specified\\.$#"
-			count: 1
-			path: src/MailerBundle/Factory/MailerConfigFactory.php
-
-		-
-			message: "#^Property SolidInvoice\\\\MailerBundle\\\\Factory\\\\MailerConfigFactory\\:\\:\\$inner has no type specified\\.$#"
-			count: 1
-			path: src/MailerBundle/Factory/MailerConfigFactory.php
-
-		-
 			message: "#^Method SolidInvoice\\\\MoneyBundle\\\\Calculator\\:\\:calculateDiscount\\(\\) has parameter \\$entity with no type specified\\.$#"
 			count: 1
 			path: src/MoneyBundle/Calculator.php

--- a/src/InvoiceBundle/Action/Transition.php
+++ b/src/InvoiceBundle/Action/Transition.php
@@ -42,7 +42,7 @@ final class Transition
         $this->stateMachine = $stateMachine;
     }
 
-    public function __invoke(Request $request, string $action, Invoice $invoice)
+    public function __invoke(Request $request, string $action, Invoice $invoice): RedirectResponse
     {
         if (! $this->stateMachine->can($invoice, $action)) {
             throw new InvalidTransitionException($action);

--- a/src/InvoiceBundle/Action/Transition/Send.php
+++ b/src/InvoiceBundle/Action/Transition/Send.php
@@ -28,20 +28,11 @@ final class Send
 {
     use SaveableTrait;
 
-    /**
-     * @var StateMachine
-     */
-    private $stateMachine;
+    private StateMachine $stateMachine;
 
-    /**
-     * @var MailerInterface
-     */
-    private $mailer;
+    private MailerInterface $mailer;
 
-    /**
-     * @var RouterInterface
-     */
-    private $router;
+    private RouterInterface $router;
 
     public function __construct(StateMachine $stateMachine, MailerInterface $mailer, RouterInterface $router)
     {
@@ -50,7 +41,7 @@ final class Send
         $this->router = $router;
     }
 
-    public function __invoke(Request $request, Invoice $invoice)
+    public function __invoke(Request $request, Invoice $invoice): RedirectResponse
     {
         if (Graph::STATUS_PENDING !== $invoice->getStatus() && $this->stateMachine->can($invoice, Graph::TRANSITION_ACCEPT)) {
             $this->stateMachine->apply($invoice, Graph::TRANSITION_ACCEPT);

--- a/src/InvoiceBundle/Manager/InvoiceManager.php
+++ b/src/InvoiceBundle/Manager/InvoiceManager.php
@@ -118,6 +118,10 @@ class InvoiceManager implements ContainerAwareInterface
             $invoice->addItem($invoiceItem);
         }
 
+        if ($object instanceof Quote) {
+            $invoice->setQuote($object);
+        }
+
         return $invoice;
     }
 

--- a/src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
+++ b/src/InvoiceBundle/Tests/Form/Handler/InvoiceCreateHandlerTest.php
@@ -27,15 +27,19 @@ use SolidWorx\FormHandler\FormRequest;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Component\Workflow\Transition;
 
-class InvoiceCreateHandlerTest extends FormHandlerTestCase
+/**
+ * @covers \SolidInvoice\InvoiceBundle\Form\Handler\InvoiceCreateHandler
+ */
+final class InvoiceCreateHandlerTest extends FormHandlerTestCase
 {
-    public function getHandler()
+    public function getHandler(): InvoiceCreateHandler
     {
         $dispatcher = new EventDispatcher();
         $notification = M::mock(NotificationManager::class);
@@ -69,16 +73,17 @@ class InvoiceCreateHandlerTest extends FormHandlerTestCase
             ->withAnyArgs()
             ->andReturn('/invoices/1');
 
-        $handler = new InvoiceCreateHandler($stateMachine, $recurringStateMachine, $router);
+        $handler = new InvoiceCreateHandler($stateMachine, $recurringStateMachine, $router, M::mock(MailerInterface::class));
         $handler->setDoctrine($this->registry);
 
         return $handler;
     }
 
+    /**
+     * @param Invoice $invoice
+     */
     protected function assertOnSuccess(?Response $response, FormRequest $form, $invoice): void
     {
-        /** @var Invoice $invoice */
-
         self::assertSame(Graph::STATUS_DRAFT, $invoice->getStatus());
         self::assertInstanceOf(RedirectResponse::class, $response);
         self::assertInstanceOf(FlashResponse::class, $response);
@@ -91,6 +96,9 @@ class InvoiceCreateHandlerTest extends FormHandlerTestCase
         self::assertInstanceOf(Template::class, $formRequest->getResponse());
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getHandlerOptions(): array
     {
         return [
@@ -101,6 +109,9 @@ class InvoiceCreateHandlerTest extends FormHandlerTestCase
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getFormData(): array
     {
         return [

--- a/src/InvoiceBundle/Tests/Form/Handler/InvoiceEditHandlerTest.php
+++ b/src/InvoiceBundle/Tests/Form/Handler/InvoiceEditHandlerTest.php
@@ -20,6 +20,7 @@ use SolidInvoice\CoreBundle\Entity\Discount;
 use SolidInvoice\CoreBundle\Response\FlashResponse;
 use SolidInvoice\CoreBundle\Templating\Template;
 use SolidInvoice\FormBundle\Test\FormHandlerTestCase;
+use SolidInvoice\InvoiceBundle\Email\InvoiceEmail;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Form\Handler\InvoiceEditHandler;
 use SolidInvoice\InvoiceBundle\Listener\WorkFlowSubscriber;
@@ -92,7 +93,12 @@ final class InvoiceEditHandlerTest extends FormHandlerTestCase
             ->withAnyArgs()
             ->andReturn('/invoices/1');
 
-        $handler = new InvoiceEditHandler($stateMachine, $recurringStateMachine, $router, M::mock(MailerInterface::class));
+        $mailer = M::mock(MailerInterface::class);
+        $mailer->shouldReceive('send')
+            ->zeroOrMoreTimes()
+            ->with(M::type(InvoiceEmail::class));
+
+        $handler = new InvoiceEditHandler($stateMachine, $recurringStateMachine, $router, $mailer);
         $handler->setDoctrine($this->registry);
 
         return $handler;

--- a/src/MoneyBundle/Twig/Extension/MoneyFormatterExtension.php
+++ b/src/MoneyBundle/Twig/Extension/MoneyFormatterExtension.php
@@ -48,7 +48,7 @@ class MoneyFormatterExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('formatCurrency', function (?Money $money): string {
+            new TwigFilter('formatCurrency', function (?Money $money, ?Currency $currency = null): string {
                 if (null === $money) {
                     if (null !== $currency) {
                         return $this->formatter->format(new Money(0, $currency));

--- a/src/MoneyBundle/Twig/Extension/MoneyFormatterExtension.php
+++ b/src/MoneyBundle/Twig/Extension/MoneyFormatterExtension.php
@@ -48,7 +48,7 @@ class MoneyFormatterExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('formatCurrency', function (?Money $money, ?Currency $currency = null): string {
+            new TwigFilter('formatCurrency', function (?Money $money): string {
                 if (null === $money) {
                     if (null !== $currency) {
                         return $this->formatter->format(new Money(0, $currency));

--- a/src/QuoteBundle/Action/Transition/Send.php
+++ b/src/QuoteBundle/Action/Transition/Send.php
@@ -44,7 +44,6 @@ final class Send
             $this->mailer->send($quote);
         } catch (JsonException | InvalidTransitionException | TransportExceptionInterface $e) {
             return new class($route, $e->getMessage()) extends RedirectResponse implements FlashResponse {
-
                 private string $message;
 
                 public function __construct(string $route, string $message)

--- a/src/QuoteBundle/Listener/WorkFlowSubscriber.php
+++ b/src/QuoteBundle/Listener/WorkFlowSubscriber.php
@@ -40,6 +40,7 @@ final class WorkFlowSubscriber implements EventSubscriberInterface
     private ManagerRegistry $registry;
 
     private NotificationManager $notification;
+
     private QuoteMailer $quoteMailer;
 
     public function __construct(

--- a/src/QuoteBundle/Listener/WorkFlowSubscriber.php
+++ b/src/QuoteBundle/Listener/WorkFlowSubscriber.php
@@ -14,50 +14,52 @@ declare(strict_types=1);
 namespace SolidInvoice\QuoteBundle\Listener;
 
 use Doctrine\Persistence\ManagerRegistry;
+use JsonException;
 use SolidInvoice\InvoiceBundle\Manager\InvoiceManager;
 use SolidInvoice\InvoiceBundle\Model\Graph as InvoiceGraph;
 use SolidInvoice\NotificationBundle\Notification\NotificationManager;
 use SolidInvoice\QuoteBundle\Entity\Quote;
+use SolidInvoice\QuoteBundle\Exception\InvalidTransitionException;
+use SolidInvoice\QuoteBundle\Mailer\QuoteMailer;
 use SolidInvoice\QuoteBundle\Model\Graph as QuoteGraph;
 use SolidInvoice\QuoteBundle\Notification\QuoteStatusNotification;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\StateMachine;
 
 /**
  * @see \SolidInvoice\QuoteBundle\Tests\Listener\WorkFlowSubscriberTest
  */
-class WorkFlowSubscriber implements EventSubscriberInterface
+final class WorkFlowSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var InvoiceManager
-     */
-    private $invoiceManager;
+    private InvoiceManager $invoiceManager;
 
-    /**
-     * @var StateMachine
-     */
-    private $invoiceStateMachine;
+    private StateMachine $invoiceStateMachine;
 
-    /**
-     * @var ManagerRegistry
-     */
-    private $registry;
+    private ManagerRegistry $registry;
 
-    /**
-     * @var NotificationManager
-     */
-    private $notification;
+    private NotificationManager $notification;
+    private QuoteMailer $quoteMailer;
 
-    public function __construct(ManagerRegistry $registry, InvoiceManager $invoiceManager, StateMachine $invoiceStateMachine, NotificationManager $notification)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        InvoiceManager $invoiceManager,
+        StateMachine $invoiceStateMachine,
+        NotificationManager $notification,
+        QuoteMailer $quoteMailer
+    ) {
         $this->invoiceManager = $invoiceManager;
         $this->invoiceStateMachine = $invoiceStateMachine;
         $this->registry = $registry;
         $this->notification = $notification;
+        $this->quoteMailer = $quoteMailer;
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return [
             'workflow.quote.entered.accepted' => 'onQuoteAccepted',
@@ -74,6 +76,9 @@ class WorkFlowSubscriber implements EventSubscriberInterface
         $this->invoiceStateMachine->apply($invoice, InvoiceGraph::TRANSITION_NEW);
     }
 
+    /**
+     * @throws JsonException|InvalidTransitionException|TransportExceptionInterface
+     */
     public function onWorkflowTransitionApplied(Event $event): void
     {
         /** @var Quote $quote */
@@ -87,6 +92,10 @@ class WorkFlowSubscriber implements EventSubscriberInterface
 
         $em->persist($quote);
         $em->flush();
+
+        if (null !== ($transition = $event->getTransition()) && QuoteGraph::TRANSITION_SEND === $transition->getName()) {
+            $this->quoteMailer->send($quote);
+        }
 
         if (QuoteGraph::STATUS_NEW !== $quote->getStatus()) {
             $this->notification->sendNotification('quote_status_update', new QuoteStatusNotification(['quote' => $quote]));

--- a/src/QuoteBundle/Resources/config/services/services.yml
+++ b/src/QuoteBundle/Resources/config/services/services.yml
@@ -1,5 +1,5 @@
 services:
-    SolidInvoice\QuoteBundle\Manager\QuoteManager:
+    SolidInvoice\QuoteBundle\Mailer\QuoteMailer:
         autowire: true
         autoconfigure: true
         arguments:

--- a/src/QuoteBundle/Tests/Listener/WorkFlowSubscriberTest.php
+++ b/src/QuoteBundle/Tests/Listener/WorkFlowSubscriberTest.php
@@ -22,13 +22,18 @@ use SolidInvoice\InvoiceBundle\Manager\InvoiceManager;
 use SolidInvoice\NotificationBundle\Notification\NotificationManager;
 use SolidInvoice\QuoteBundle\Entity\Quote;
 use SolidInvoice\QuoteBundle\Listener\WorkFlowSubscriber;
+use SolidInvoice\QuoteBundle\Mailer\QuoteMailer;
+use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
-class WorkFlowSubscriberTest extends TestCase
+/**
+ * @covers \SolidInvoice\QuoteBundle\Listener\WorkFlowSubscriber
+ */
+final class WorkFlowSubscriberTest extends TestCase
 {
     use DoctrineTestTrait;
     use MockeryPHPUnitIntegration;
@@ -56,7 +61,13 @@ class WorkFlowSubscriberTest extends TestCase
         $notification->shouldReceive('sendNotification')
             ->zeroOrMoreTimes();
 
-        $subscriber = new WorkFlowSubscriber($this->registry, $invoiceManager, $stateMachine, $notification);
+        $subscriber = new WorkFlowSubscriber(
+            $this->registry,
+            $invoiceManager,
+            $stateMachine,
+            $notification,
+            new QuoteMailer($stateMachine, M::mock(MailerInterface::class), $notification)
+        );
 
         $subscriber->onQuoteAccepted(new Event($quote, new Marking(['pending' => 1]), new Transition('archive', 'pending', 'archived'), M::mock(WorkflowInterface::class)));
     }
@@ -72,7 +83,13 @@ class WorkFlowSubscriberTest extends TestCase
         $notification->shouldReceive('sendNotification')
             ->zeroOrMoreTimes();
 
-        $subscriber = new WorkFlowSubscriber($this->registry, $invoiceManager, $stateMachine, $notification);
+        $subscriber = new WorkFlowSubscriber(
+            $this->registry,
+            $invoiceManager,
+            $stateMachine,
+            $notification,
+            new QuoteMailer($stateMachine, M::mock(MailerInterface::class), $notification)
+        );
 
         $subscriber->onWorkflowTransitionApplied(new Event($quote, new Marking(['pending' => 1]), new Transition('archive', 'pending', 'archived'), M::mock(WorkflowInterface::class)));
 


### PR DESCRIPTION
When using the "Save and Send" button for quotes and invoices, they were never sent out.
Also fix attaching an invoice to a quote when accepting a quote.