### PR TITLE
Fix saving contacts on invoices and quotes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,6 +37,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
+          MYSQL_ROOT_PASSWORD:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: solidinvoice_test
         ports:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,8 +32,6 @@ jobs:
       database_user: root
       database_password:
       database_version: 8.0
-      MYSQL_ALLOW_EMPTY_PASSWORD: yes
-      MYSQL_DATABASE: solidinvoice_test
 
     services:
       mysql:
@@ -43,12 +41,7 @@ jobs:
           MYSQL_DATABASE: solidinvoice_test
         ports:
           - 3306:3306
-        options: >-
-            --health-cmd="mysqladmin ping"
-            --health-interval=10s
-            --health-timeout=5s
-            --health-retries=3
-            --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,16 +25,28 @@ jobs:
       PANTHER_NO_SANDBOX: 1
       PANTHER_CHROME_ARGUMENTS: --disable-dev-shm-usage
       COVERAGE: 0
+      database_driver: pdo_mysql
+      database_host: 127.0.0.1
+      database_port: 3306
+      database_name: solidinvoice
+      database_user: root
+      database_password:
+      database_version: 8.0
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: solidinvoice_test
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+            --health-cmd="mysqladmin ping"
+            --health-interval=10s
+            --health-timeout=5s
+            --health-retries=3
+            --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
     steps:
       - name: Harden Runner
@@ -57,7 +69,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           ini-values: date.timezone=Africa/Johannesburg, opcache.enable=1, opcache.enable_cli=1, opcache.memory_consumption=256, opcache.max_accelerated_files=32531, opcache.interned_strings_buffer=8, opcache.validate_timestamps=0, opcache.save_comments=1, opcache.fast_shutdown=0, memory_limit=-1
-          extensions: intl, gd, opcache, pdo_sqlite, soap, zip, :xdebug
+          extensions: intl, gd, opcache, mysql, pdo_mysql, soap, zip, :xdebug
           coverage: ${{ steps.coverage_driver.outputs.value }}
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,13 +32,14 @@ jobs:
       database_user: root
       database_password:
       database_version: 8.0
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_DATABASE: solidinvoice_test
 
     services:
       mysql:
         image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: ''
           MYSQL_DATABASE: solidinvoice_test
         ports:
           - 3306:3306

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,6 +38,7 @@ jobs:
         image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: ''
           MYSQL_DATABASE: solidinvoice_test
         ports:
           - 3306:3306

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
         "zenstruck/schedule-bundle": "^1.5"
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^7.2",
         "dbrekelmans/bdi": "^1.0",
         "doctrine/doctrine-fixtures-bundle": "^3.3",
         "ergebnis/composer-normalize": "^2.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdd6ba1da70bfb9017b700f8b83e13e3",
+    "content-hash": "c8917472372ec186f8a9e0a5a39611ac",
     "packages": [
         {
             "name": "alcohol/iso4217",
@@ -13223,6 +13223,73 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "175b47153609a369117d97d36049b8a8c3b69dc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/175b47153609a369117d97d36049b8a8c3b69dc1",
+                "reference": "175b47153609a369117d97d36049b8a8c3b69dc1",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3",
+                "doctrine/doctrine-bundle": "^2.2.2",
+                "ext-json": "*",
+                "php": "^7.3 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^5.4 || ^6.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "doctrine/cache": "^1.12",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0",
+                "symfony/phpunit-bridge": "^6.0",
+                "symfony/process": "^5.4 || ^6.0",
+                "symfony/yaml": "^5.4 || ^6.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src/DAMA/DoctrineTestBundle"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v7.2.1"
+            },
+            "time": "2023-02-07T10:02:27+00:00"
+        },
         {
             "name": "dbrekelmans/bdi",
             "version": "1.0.4",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -47,4 +47,5 @@ return [
     SolidWorx\Toggler\Symfony\TogglerBundle::class => ['all' => true],
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
     Zenstruck\ScheduleBundle\ZenstruckScheduleBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/packages/test/dama_doctrine_test_bundle.yaml
+++ b/config/packages/test/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,4 @@
+dama_doctrine_test:
+    enable_static_connection: true
+    enable_static_meta_data_cache: true
+    enable_static_query_cache: true

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,4 +1,9 @@
 doctrine:
     dbal:
-        driver: 'pdo_sqlite'
-        url: 'sqlite:///%kernel.project_dir%/var/db/sqlite.db'
+        driver: '%env(database_driver)%'
+        host: '%env(database_host)%'
+        port: '%env(int:database_port)%'
+        dbname: '%env(database_name)%_test'
+        user: '%env(database_user)%'
+        password: '%env(database_password)%'
+        server_version: '%env(database_version)%'

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('quote_contact')
+            ->dropPrimaryKey();
+
+        $schema->getTable('invoice_contact')
+            ->dropPrimaryKey();
+
+        $schema->getTable('recurringinvoice_contact')
+            ->dropPrimaryKey();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('quote_contact')
+            ->setPrimaryKey(['quote_id', 'contact_id']);
+
+        $schema->getTable('invoice_contact')
+            ->setPrimaryKey(['invoice_id', 'contact_id']);
+
+        $schema->getTable('recurringinvoice_contact')
+            ->setPrimaryKey(['recurringinvoice_id', 'contact_id']);
+    }
+}

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -28,17 +28,38 @@ final class Version20201 extends AbstractMigration
 
         $schema->getTable('recurringinvoice_contact')
             ->dropPrimaryKey();
+
+        $invoiceContact = $schema->getTable('invoice_contact');
+        $invoiceContact->addColumn('company_id', 'uuid_binary_ordered_time', ['notnull' => false]);
+        $invoiceContact->addIndex(['invoice_id', 'company_id']);
+        $invoiceContact->setPrimaryKey(['invoice_id', 'contact_id', 'company_id']);
+
+        $recurringInvoiceContact = $schema->getTable('recurringinvoice_contact');
+        $recurringInvoiceContact->addColumn('company_id', 'uuid_binary_ordered_time', ['notnull' => false]);
+        $recurringInvoiceContact->addIndex(['recurringinvoice_id', 'company_id']);
+        $recurringInvoiceContact->setPrimaryKey(['recurringinvoice_id', 'contact_id', 'company_id']);
+
+        $quoteContact = $schema->getTable('quote_contact');
+        $quoteContact->addColumn('company_id', 'uuid_binary_ordered_time', ['notnull' => false]);
+        $quoteContact->addIndex(['quote_id', 'company_id']);
+        $quoteContact->setPrimaryKey(['quote_id', 'contact_id', 'company_id']);
     }
 
     public function down(Schema $schema): void
     {
-        $schema->getTable('quote_contact')
-            ->setPrimaryKey(['quote_id', 'contact_id']);
+        $quoteContact = $schema->getTable('quote_contact');
+        $quoteContact->dropPrimaryKey();
+        $quoteContact->setPrimaryKey(['quote_id', 'contact_id']);
+        $quoteContact->dropColumn('company_id');
 
-        $schema->getTable('invoice_contact')
-            ->setPrimaryKey(['invoice_id', 'contact_id']);
+        $invoiceContact = $schema->getTable('invoice_contact');
+        $invoiceContact->dropPrimaryKey();
+        $invoiceContact->setPrimaryKey(['invoice_id', 'contact_id']);
+        $invoiceContact->dropColumn('company_id');
 
-        $schema->getTable('recurringinvoice_contact')
-            ->setPrimaryKey(['recurringinvoice_id', 'contact_id']);
+        $recurringInvoiceContact = $schema->getTable('recurringinvoice_contact');
+        $recurringInvoiceContact->dropPrimaryKey();
+        $recurringInvoiceContact->setPrimaryKey(['recurringinvoice_id', 'contact_id']);
+        $recurringInvoiceContact->dropColumn('company_id');
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -636,11 +636,6 @@ parameters:
 			path: src/InstallBundle/Tests/Form/Step/SystemInformationFormTest.php
 
 		-
-			message: "#^Method SolidInvoice\\\\InstallBundle\\\\Tests\\\\Functional\\\\InstallationTest\\:\\:continue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/InstallBundle/Tests/Functional/InstallationTest.php
-
-		-
 			message: "#^Call to an undefined method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\BaseInvoice\\:\\:getId\\(\\)\\.$#"
 			count: 1
 			path: src/InvoiceBundle/Action/CloneInvoice.php
@@ -1814,13 +1809,3 @@ parameters:
 			message: "#^Property SolidInvoice\\\\UserBundle\\\\Tests\\\\Form\\\\Handler\\\\ProfileEditHandlerTest\\:\\:\\$userRepository has no type specified\\.$#"
 			count: 1
 			path: src/UserBundle/Tests/Form/Handler/ProfileEditHandlerTest.php
-
-		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getEmail\\(\\)\\.$#"
-			count: 1
-			path: src/UserBundle/Tests/Repository/UserRepositoryTest.php
-
-		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/UserBundle/Tests/Repository/UserRepositoryTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,56 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestDelete\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestGet\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestGet\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPost\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPost\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPost\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPut\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPut\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ApiBundle\\\\Test\\\\ApiTestCase\\:\\:requestPut\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ApiBundle/Test/ApiTestCase.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with 123 and SolidInvoice\\\\ClientBundle\\\\Entity\\\\Credit will always evaluate to false\\.$#"
 			count: 1
 			path: src/ApiBundle/Tests/Serializer/Normalizer/CreditNormalizerTest.php
@@ -164,26 +114,6 @@ parameters:
 			message: "#^PHPDoc tag @return with type \\$this\\(SolidInvoice\\\\ClientBundle\\\\Entity\\\\Client\\)\\|SolidInvoice\\\\CoreBundle\\\\Traits\\\\Entity\\\\Archivable is not subtype of native type SolidInvoice\\\\ClientBundle\\\\Entity\\\\Client\\.$#"
 			count: 1
 			path: src/ClientBundle/Entity/Client.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/ClientBundle/Entity/Contact.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ClientBundle\\\\Entity\\\\Contact\\:\\:getInvoices\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/ClientBundle/Entity/Contact.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ClientBundle\\\\Entity\\\\Contact\\:\\:getQuotes\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/ClientBundle/Entity/Contact.php
-
-		-
-			message: "#^Method SolidInvoice\\\\ClientBundle\\\\Entity\\\\Contact\\:\\:getRecurringInvoices\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/ClientBundle/Entity/Contact.php
 
 		-
 			message: "#^Method SolidInvoice\\\\ClientBundle\\\\Entity\\\\ContactType\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -826,22 +756,7 @@ parameters:
 			path: src/InvoiceBundle/Entity/BaseInvoice.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/Invoice.php
-
-		-
 			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Invoice\\:\\:archive\\(\\) has invalid return type SolidInvoice\\\\CoreBundle\\\\Traits\\\\Entity\\\\Archivable\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/Invoice.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Invoice\\:\\:getItems\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/Invoice.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Invoice\\:\\:getUsers\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
 			count: 1
 			path: src/InvoiceBundle/Entity/Invoice.php
 
@@ -851,32 +766,12 @@ parameters:
 			path: src/InvoiceBundle/Entity/Invoice.php
 
 		-
-			message: "#^Instanceof between SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Invoice\\|null and SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice will always evaluate to false\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/Item.php
-
-		-
 			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\:\\:archive\\(\\) has invalid return type SolidInvoice\\\\CoreBundle\\\\Traits\\\\Entity\\\\Archivable\\.$#"
 			count: 1
 			path: src/InvoiceBundle/Entity/RecurringInvoice.php
 
 		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\:\\:getItems\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/RecurringInvoice.php
-
-		-
-			message: "#^Method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\:\\:getUsers\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/RecurringInvoice.php
-
-		-
 			message: "#^PHPDoc tag @return with type \\$this\\(SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\)\\|SolidInvoice\\\\CoreBundle\\\\Traits\\\\Entity\\\\Archivable is not subtype of native type SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\.$#"
-			count: 1
-			path: src/InvoiceBundle/Entity/RecurringInvoice.php
-
-		-
-			message: "#^Parameter \\#1 \\$invoice of method SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Item\\:\\:setInvoice\\(\\) expects SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\Invoice\\|null, \\$this\\(SolidInvoice\\\\InvoiceBundle\\\\Entity\\\\RecurringInvoice\\) given\\.$#"
 			count: 1
 			path: src/InvoiceBundle/Entity/RecurringInvoice.php
 
@@ -1404,11 +1299,6 @@ parameters:
 			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Email\\\\QuoteEmail\\:\\:getContext\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/QuoteBundle/Email/QuoteEmail.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/QuoteBundle/Entity/Quote.php
 
 		-
 			message: "#^Method SolidInvoice\\\\QuoteBundle\\\\Entity\\\\Quote\\:\\:archive\\(\\) has invalid return type SolidInvoice\\\\CoreBundle\\\\Traits\\\\Entity\\\\Archivable\\.$#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
         convertDeprecationsToExceptions="false"
         processIsolation="false"
         stopOnFailure="false"
-        bootstrap="vendor/autoload.php"
+        bootstrap="tests/bootstrap.php"
 >
     <coverage>
         <include>
@@ -53,5 +53,6 @@
     </listeners>
     <extensions>
         <extension class="Symfony\Component\Panther\ServerExtension"/>
+        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
     </extensions>
 </phpunit>

--- a/src/ApiBundle/Serializer/Normalizer/AdditionalContactDetailsNormalizer.php
+++ b/src/ApiBundle/Serializer/Normalizer/AdditionalContactDetailsNormalizer.php
@@ -72,6 +72,6 @@ class AdditionalContactDetailsNormalizer implements NormalizerInterface, Denorma
 
     public function supportsNormalization($data, $format = null)
     {
-        return is_object($data) && $data instanceof AdditionalContactDetail;
+        return $data instanceof AdditionalContactDetail;
     }
 }

--- a/src/ClientBundle/Test/Factory/ClientFactory.php
+++ b/src/ClientBundle/Test/Factory/ClientFactory.php
@@ -44,11 +44,11 @@ final class ClientFactory extends ModelFactory
     protected function getDefaults(): array
     {
         return [
-            'name' => self::faker()->text(),
+            'name' => self::faker()->company(),
             'website' => self::faker()->url(),
-            'status' => self::faker()->text(),
+            'status' => self::faker()->word(),
             'currency' => self::faker()->currencyCode(),
-            'vatNumber' => self::faker()->text(),
+            'vatNumber' => self::faker()->word(),
             'archived' => self::faker()->boolean(),
             'created' => self::faker()->dateTime(),
             'updated' => self::faker()->dateTime(),

--- a/src/ClientBundle/Tests/Form/Handler/ContactAddFormHandlerTest.php
+++ b/src/ClientBundle/Tests/Form/Handler/ContactAddFormHandlerTest.php
@@ -26,13 +26,6 @@ class ContactAddFormHandlerTest extends FormHandlerTestCase
 {
     use SymfonyKernelTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        static::bootKernel();
-    }
-
     public function getHandler(): ContactAddFormHandler
     {
         $handler = new ContactAddFormHandler();

--- a/src/ClientBundle/Tests/Form/Handler/ContactEditFormHandlerTest.php
+++ b/src/ClientBundle/Tests/Form/Handler/ContactEditFormHandlerTest.php
@@ -31,8 +31,6 @@ class ContactEditFormHandlerTest extends FormHandlerTestCase
     {
         parent::setUp();
 
-        static::bootKernel();
-
         $this->firstName = $this->faker->firstName;
         $this->email = $this->faker->email;
     }
@@ -73,7 +71,7 @@ class ContactEditFormHandlerTest extends FormHandlerTestCase
     {
         self::assertInstanceOf(JsonResponse::class, $response);
         self::assertInstanceOf(Contact::class, $data);
-        self::assertCount(2, $this->em->getRepository(Contact::class)->findAll());
+        self::assertCount(1, $this->em->getRepository(Contact::class)->findAll());
         self::assertSame($this->firstName, $data->getFirstName());
         self::assertSame($this->email, $data->getEmail());
     }

--- a/src/ClientBundle/Tests/Functional/Api/ClientTest.php
+++ b/src/ClientBundle/Tests/Functional/Api/ClientTest.php
@@ -20,15 +20,13 @@ use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData;
 /**
  * @group functional
  */
-class ClientTest extends ApiTestCase
+final class ClientTest extends ApiTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
 
-        self::bootKernel();
-
-        $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
+        $databaseTool = self::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([
             LoadData::class,

--- a/src/ClientBundle/Tests/Functional/Api/ContactTest.php
+++ b/src/ClientBundle/Tests/Functional/Api/ContactTest.php
@@ -29,8 +29,6 @@ class ContactTest extends ApiTestCase
     {
         parent::setUp();
 
-        self::bootKernel();
-
         $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([

--- a/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
+++ b/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
@@ -64,7 +64,7 @@ class CompanyFilter extends SQLFilter
                     $this->getConnection()->getDatabasePlatform()
                 );
 
-            return sprintf('%s.company_id = "%s"', $targetTableAlias, $companyId);
+            return sprintf('%s.company_id = %s', $targetTableAlias, $this->getConnection()->quote($companyId));
         }
 
         return '';

--- a/src/CoreBundle/Doctrine/Listener/CompanyListener.php
+++ b/src/CoreBundle/Doctrine/Listener/CompanyListener.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\CoreBundle\Doctrine\Listener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Events;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Company;
@@ -41,7 +41,7 @@ class CompanyListener implements EventSubscriber
     /**
      * Maps additional metadata.
      */
-    public function prePersist(LifecycleEventArgs $eventArgs): void
+    public function prePersist(PrePersistEventArgs $eventArgs): void
     {
         $object = $eventArgs->getObject();
         $em = $eventArgs->getObjectManager();

--- a/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
+++ b/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
@@ -63,7 +63,8 @@ final class UserToContactTransformer implements DataTransformerInterface
             $users = [];
 
             foreach ($value as $item) {
-                $contact = new ($this->class)();
+                $class = $this->class;
+                $contact = new $class();
                 $contact->setContact($item);
 
                 switch (true) {

--- a/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
+++ b/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
@@ -51,11 +51,20 @@ final class UserToContactTransformer implements DataTransformerInterface
         $this->class = $class;
     }
 
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
     public function transform($value)
     {
         return $value;
     }
 
+    /**
+     * @param mixed $value
+     * @return array<int, T>|mixed
+     */
     public function reverseTransform($value)
     {
         if (is_iterable($value)) {

--- a/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
+++ b/src/CoreBundle/Form/Transformer/UserToContactTransformer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Form\Transformer;
+
+use Doctrine\Common\Collections\Collection;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\InvoiceBundle\Entity\BaseInvoice;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\InvoiceContact;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceContact;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use SolidInvoice\QuoteBundle\Entity\QuoteContact;
+use Symfony\Component\Form\DataTransformerInterface;
+use function is_iterable;
+
+/**
+ * @template T of InvoiceContact|QuoteContact|RecurringInvoiceContact
+ * @implements DataTransformerInterface<array<int, T>, array<int, T>>
+ */
+final class UserToContactTransformer implements DataTransformerInterface
+{
+    /**
+     * @var Quote|BaseInvoice|object
+     */
+    private object $entity;
+
+    /**
+     * @var class-string<T>
+     */
+    private string $class;
+
+    /**
+     * @param Quote|BaseInvoice|object $entity
+     * @param class-string<T> $class
+     */
+    public function __construct(object $entity, string $class)
+    {
+        $this->entity = $entity;
+        $this->class = $class;
+    }
+
+    public function transform($value)
+    {
+        return $value;
+    }
+
+    public function reverseTransform($value)
+    {
+        if (is_iterable($value)) {
+            /** @var Collection<int, Contact> $value */
+            $users = [];
+
+            foreach ($value as $item) {
+                $contact = new ($this->class)();
+                $contact->setContact($item);
+
+                switch (true) {
+                    case $this->entity instanceof Invoice:
+                        $contact->setInvoice($this->entity);
+                        break;
+                    case $this->entity instanceof RecurringInvoice:
+                        $contact->setRecurringInvoice($this->entity);
+                        break;
+                    case $this->entity instanceof Quote:
+                        $contact->setQuote($this->entity);
+                        break;
+                }
+
+                $users[] = $contact;
+            }
+
+            return $users;
+        }
+
+        return $value;
+    }
+}

--- a/src/CoreBundle/Tests/Form/Transformer/UserToContactTransformerTest.php
+++ b/src/CoreBundle/Tests/Form/Transformer/UserToContactTransformerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Form\Transformer;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Form\Transformer\UserToContactTransformer;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\InvoiceContact;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceContact;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use SolidInvoice\QuoteBundle\Entity\QuoteContact;
+
+/**
+ * @coversDefaultClass \SolidInvoice\CoreBundle\Form\Transformer\UserToContactTransformer
+ */
+final class UserToContactTransformerTest extends TestCase
+{
+    public function testReverseTransform(): void
+    {
+        $entity = new Quote();
+        $transformer = new UserToContactTransformer($entity, QuoteContact::class);
+
+        self::assertNull($transformer->transform(null));
+        self::assertTrue($transformer->transform(true));
+        self::assertFalse($transformer->transform(false));
+        self::assertSame(1, $transformer->transform(1));
+        self::assertSame(1.0, $transformer->transform(1.0));
+        self::assertSame('foo', $transformer->transform('foo'));
+        self::assertSame([], $transformer->transform([]));
+        self::assertSame([1, 'b', true], $transformer->transform([1, 'b', true]));
+        self::assertSame($entity, $transformer->transform($entity));
+    }
+
+    public function testTransform(): void
+    {
+        $entity = new Quote();
+        $transformer = new UserToContactTransformer(new Quote(), QuoteContact::class);
+
+        self::assertNull($transformer->reverseTransform(null));
+        self::assertTrue($transformer->reverseTransform(true));
+        self::assertFalse($transformer->reverseTransform(false));
+        self::assertSame(1, $transformer->reverseTransform(1));
+        self::assertSame(1.0, $transformer->reverseTransform(1.0));
+        self::assertSame('foo', $transformer->reverseTransform('foo'));
+        self::assertSame([], $transformer->reverseTransform([]));
+        self::assertSame($entity, $transformer->reverseTransform($entity));
+
+        self::assertContainsOnlyInstancesOf(
+            QuoteContact::class,
+            (new UserToContactTransformer(new Quote(), QuoteContact::class))->reverseTransform([new Contact()])
+        );
+
+        self::assertContainsOnlyInstancesOf(
+            InvoiceContact::class,
+            (new UserToContactTransformer(new Invoice(), InvoiceContact::class))->reverseTransform([new Contact()])
+        );
+
+        self::assertContainsOnlyInstancesOf(
+            RecurringInvoiceContact::class,
+            (new UserToContactTransformer(new RecurringInvoice(), RecurringInvoiceContact::class))->reverseTransform([new Contact()])
+        );
+
+        $entity = new Quote();
+        $contact = new Contact();
+
+        foreach ((new UserToContactTransformer($entity, QuoteContact::class))->reverseTransform([$contact]) as $quoteContact) {
+            self::assertSame($entity, $quoteContact->getQuote());
+            self::assertSame($contact, $quoteContact->getContact());
+        }
+
+        $entity = new Invoice();
+        $contact = new Contact();
+
+        foreach ((new UserToContactTransformer($entity, InvoiceContact::class))->reverseTransform([$contact]) as $invoiceContact) {
+            self::assertSame($entity, $invoiceContact->getInvoice());
+            self::assertSame($contact, $invoiceContact->getContact());
+        }
+
+        $entity = new RecurringInvoice();
+        $contact = new Contact();
+
+        foreach ((new UserToContactTransformer($entity, RecurringInvoiceContact::class))->reverseTransform([$contact]) as $recurringInvoice) {
+            self::assertSame($entity, $recurringInvoice->getRecurringInvoice());
+            self::assertSame($contact, $recurringInvoice->getContact());
+        }
+    }
+}

--- a/src/CronBundle/Tests/Command/CronRunCommandTest.php
+++ b/src/CronBundle/Tests/Command/CronRunCommandTest.php
@@ -28,7 +28,7 @@ final class CronRunCommandTest extends TestCase
 
     public function testCronRunCommand(): void
     {
-        $kernel = self::bootKernel();
+        $kernel = self::$kernel;
         $container = self::getContainer();
 
         $doctrine = $container->get('doctrine');

--- a/src/InstallBundle/Test/EnsureApplicationInstalled.php
+++ b/src/InstallBundle/Test/EnsureApplicationInstalled.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\InstallBundle\Test;
 
 use DateTimeInterface;
 use Doctrine\ORM\Tools\SchemaTool;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Entity\Version;
 use SolidInvoice\CoreBundle\Repository\VersionRepository;
 use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
@@ -42,6 +44,15 @@ trait EnsureApplicationInstalled
         static::getContainer()->get(Migration::class)->migrate();
         // @phpstan-ignore-next-line Ignore this line in PHPStan, since it sees the SystemConfig service as private
         static::getContainer()->get(SystemConfig::class)->set(SystemConfig::CURRENCY_CONFIG_PATH, 'USD');
+
+        // @phpstan-ignore-next-line Ignore this line in PHPStan, since it sees the SystemConfig service as private
+        static::getContainer()->get(CompanySelector::class)
+            ->switchCompany(
+                static::getContainer()->get('doctrine')
+                    ->getRepository(Company::class)
+                    ->findOneBy([])
+                    ->getId()
+            );
 
         /** @var VersionRepository $version */
         $version = $entityManager->getRepository(Version::class);

--- a/src/InstallBundle/Tests/Functional/InstallationTest.php
+++ b/src/InstallBundle/Tests/Functional/InstallationTest.php
@@ -48,12 +48,6 @@ class InstallationTest extends PantherTestCase
     {
         parent::setUp();
 
-        $dbFile = realpath(static::$defaultOptions['webServerDir'] . '/../') . '/var/db/sqlite.db';
-
-        if (file_exists($dbFile)) {
-            unlink($dbFile);
-        }
-
         unset($_SERVER['locale'], $_ENV['locale'], $_SERVER['installed'], $_ENV['installed']);
     }
 
@@ -116,7 +110,7 @@ class InstallationTest extends PantherTestCase
                 'system_information[currency]' => 'USD',
             ];
 
-            if (0 === (is_countable($crawler->filter('.callout.callout-warning')) ? count($crawler->filter('.callout.callout-warning')) : 0)) {
+            if (0 === count($crawler->filter('.callout.callout-warning'))) {
                 $formData += [
                     'system_information[username]' => 'admin',
                     'system_information[email_address]' => 'foo@bar.com',
@@ -137,7 +131,10 @@ class InstallationTest extends PantherTestCase
         }
     }
 
-    private function continue(Client $client, Crawler $crawler)
+    /**
+     * @throws Exception
+     */
+    private function continue(Client $client, Crawler $crawler): Crawler
     {
         if (0 !== count($crawler->filter('#continue_step'))) {
             return $client->clickLink('Next');

--- a/src/InvoiceBundle/Api/BillingUserNormalizer.php
+++ b/src/InvoiceBundle/Api/BillingUserNormalizer.php
@@ -59,6 +59,7 @@ final class BillingUserNormalizer implements ContextAwareDenormalizerInterface, 
     public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return is_array($data) &&
+            isset($context['resource_class']) &&
             (
                 $context['resource_class'] === Invoice::class ||
                 $context['resource_class'] === RecurringInvoice::class ||

--- a/src/InvoiceBundle/Api/BillingUserNormalizer.php
+++ b/src/InvoiceBundle/Api/BillingUserNormalizer.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Api;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use function in_array;
+use function is_a;
+use function is_array;
+
+final class BillingUserNormalizer implements ContextAwareDenormalizerInterface, DenormalizerAwareInterface, ContextAwareNormalizerInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+
+    private IriConverterInterface $iriConverter;
+
+    public function __construct(IriConverterInterface $iriConverter)
+    {
+        $this->iriConverter = $iriConverter;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $this->denormalizer->denormalize($data, $class, $format, $context + [__CLASS__ => true]);
+    }
+
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+    {
+        return in_array($format, ['json', 'jsonld'], true) &&
+            (
+                is_a($type, Invoice::class, true) ||
+                is_a($type, RecurringInvoice::class, true) ||
+                is_a($type, Quote::class, true)
+            ) &&
+            ! empty($data['users']) &&
+            ! isset($context[__CLASS__]);
+    }
+
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    {
+        return is_array($data) &&
+            (
+                $context['resource_class'] === Invoice::class ||
+                $context['resource_class'] === RecurringInvoice::class ||
+                $context['resource_class'] === Quote::class
+            ) &&
+            isset($data['users']) &&
+            is_array($data['users']) &&
+            ! isset($context[__CLASS__]);
+    }
+
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        $users = $object['users'];
+
+        foreach ($users as $i => $user) {
+            $object['users'][$i] = $this->iriConverter->getIriFromItem($user);
+        }
+
+        return $this->normalizer->normalize($object, $format, $context + [__CLASS__ => true]);
+    }
+}

--- a/src/InvoiceBundle/DataFixtures/ORM/LoadData.php
+++ b/src/InvoiceBundle/DataFixtures/ORM/LoadData.php
@@ -17,28 +17,41 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Exception;
 use Money\Currency;
 use Money\Money;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Entity\Contact;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\Item;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Model\Graph;
+use function assert;
 
 /**
  * @codeCoverageIgnore
  */
 class LoadData extends Fixture
 {
+    /**
+     * @throws Exception
+     */
     public function load(ObjectManager $manager): void
     {
         $invoice = new Invoice();
-        $invoice->setClient($this->getReference('client'));
-        $invoice->addUser($this->getReference('contact'));
+        $client = $this->getReference('client');
+        assert($client instanceof Client);
+
+        $contact = $this->getReference('contact');
+        assert($contact instanceof Contact);
+
+        $invoice->setClient($client);
+        $invoice->addUser($contact);
         $invoice->setStatus(Graph::STATUS_DRAFT);
 
         $recurringInvoice = new RecurringInvoice();
-        $recurringInvoice->setClient($this->getReference('client'));
-        $recurringInvoice->addUser($this->getReference('contact'));
+        $recurringInvoice->setClient($client);
+        $recurringInvoice->addUser($contact);
         $recurringInvoice->setStatus(Graph::STATUS_DRAFT);
         $recurringInvoice->setFrequency('* * * * *');
         $recurringInvoice->setDateStart(new DateTimeImmutable('2012-01-01 15:30:00', new DateTimeZone('Europe/Paris')));

--- a/src/InvoiceBundle/Entity/Invoice.php
+++ b/src/InvoiceBundle/Entity/Invoice.php
@@ -133,13 +133,14 @@ class Invoice extends BaseInvoice
     protected $items;
 
     /**
-     * @var Collection<int, Contact>
+     * @var Collection<int, InvoiceContact>
      *
-     * @ORM\ManyToMany(targetEntity="SolidInvoice\ClientBundle\Entity\Contact", cascade={"persist"}, fetch="EXTRA_LAZY", inversedBy="invoices")
+     * @ORM\OneToMany(targetEntity=InvoiceContact::class, cascade={"persist", "remove"}, fetch="EXTRA_LAZY", mappedBy="invoice")
      * @Assert\Count(min=1, minMessage="You need to select at least 1 user to attach to the Invoice")
      * @Serialize\Groups({"invoice_api", "recurring_invoice_api", "client_api", "create_invoice_api", "create_recurring_invoice_api"})
+     * @ApiProperty(writableLink=true)
      */
-    protected $users;
+    protected Collection $users;
 
     public function __construct()
     {
@@ -259,7 +260,7 @@ class Invoice extends BaseInvoice
     }
 
     /**
-     * @return Collection|ItemInterface[]
+     * @return Collection<int, Item>
      */
     public function getItems(): Collection
     {
@@ -271,10 +272,8 @@ class Invoice extends BaseInvoice
      */
     public function updateItems(): void
     {
-        if ((is_countable($this->items) ? count($this->items) : 0) > 0) {
-            foreach ($this->items as $item) {
-                $item->setInvoice($this);
-            }
+        foreach ($this->items as $item) {
+            $item->setInvoice($this);
         }
     }
 
@@ -320,28 +319,44 @@ class Invoice extends BaseInvoice
     }
 
     /**
-     * Return users array.
-     *
-     * @return Collection|Contact[]
+     * @return array<Contact>
      */
-    public function getUsers(): Collection
+    public function getUsers(): array
     {
-        return $this->users;
+        return $this->users->map(static fn (InvoiceContact $invoiceContact) => $invoiceContact->getContact())->toArray();
     }
 
     /**
-     * @param Contact[] $users
+     * @param (Contact|InvoiceContact)[] $users
      */
     public function setUsers(array $users): self
     {
-        $this->users = new ArrayCollection($users);
+        $contacts = [];
+
+        foreach ($users as $user) {
+            if ($user instanceof InvoiceContact) {
+                $contacts[] = $user;
+            } elseif ($user instanceof Contact) {
+                $invoiceContact = new InvoiceContact();
+                $invoiceContact->setContact($user);
+                $invoiceContact->setInvoice($this);
+
+                $contacts[] = $invoiceContact;
+            }
+        }
+
+        $this->users = new ArrayCollection($contacts);
 
         return $this;
     }
 
     public function addUser(Contact $user): self
     {
-        $this->users[] = $user;
+        $invoiceContact = new InvoiceContact();
+        $invoiceContact->setContact($user);
+        $invoiceContact->setInvoice($this);
+
+        $this->users[] = $invoiceContact;
 
         return $this;
     }

--- a/src/InvoiceBundle/Entity/Invoice.php
+++ b/src/InvoiceBundle/Entity/Invoice.php
@@ -319,11 +319,11 @@ class Invoice extends BaseInvoice
     }
 
     /**
-     * @return array<Contact>
+     * @return Collection<int, Contact>
      */
-    public function getUsers(): array
+    public function getUsers(): Collection
     {
-        return $this->users->map(static fn (InvoiceContact $invoiceContact) => $invoiceContact->getContact())->toArray();
+        return $this->users->map(static fn (InvoiceContact $invoiceContact) => $invoiceContact->getContact());
     }
 
     /**

--- a/src/InvoiceBundle/Entity/InvoiceContact.php
+++ b/src/InvoiceBundle/Entity/InvoiceContact.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="invoice_contact")
+ * @ApiResource(collectionOperations={}, itemOperations={})
+ */
+class InvoiceContact
+{
+    use CompanyAware;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=Invoice::class, inversedBy="users", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(name="invoice_id", referencedColumnName="id")
+     */
+    private Invoice $invoice;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=Contact::class, cascade={"persist", "remove"}, inversedBy="invoices")
+     * @ORM\JoinColumn(name="contact_id", referencedColumnName="id")
+     */
+    private Contact $contact;
+
+    public function getInvoice(): Invoice
+    {
+        return $this->invoice;
+    }
+
+    public function getContact(): Contact
+    {
+        return $this->contact;
+    }
+
+    public function setInvoice(Invoice $invoice): self
+    {
+        $this->invoice = $invoice;
+
+        return $this;
+    }
+
+    public function setContact(Contact $contact): self
+    {
+        $this->contact = $contact;
+
+        return $this;
+    }
+}

--- a/src/InvoiceBundle/Entity/Item.php
+++ b/src/InvoiceBundle/Entity/Item.php
@@ -176,7 +176,7 @@ class Item implements ItemInterface
     }
 
     /**
-     * @param Invoice|null $invoice
+     * @param Invoice|RecurringInvoice|null $invoice
      */
     public function setInvoice(?BaseInvoice $invoice): ItemInterface
     {

--- a/src/InvoiceBundle/Entity/RecurringInvoiceContact.php
+++ b/src/InvoiceBundle/Entity/RecurringInvoiceContact.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="recurringinvoice_contact")
+ * @ApiResource(itemOperations={}, collectionOperations={})
+ */
+class RecurringInvoiceContact
+{
+    use CompanyAware;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=RecurringInvoice::class, inversedBy="users", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(name="recurringinvoice_id", referencedColumnName="id")
+     */
+    private RecurringInvoice $recurringInvoice;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=Contact::class, cascade={"persist", "remove"}, inversedBy="recurringInvoices")
+     * @ORM\JoinColumn(name="contact_id", referencedColumnName="id")
+     */
+    private Contact $contact;
+
+    public function getRecurringInvoice(): RecurringInvoice
+    {
+        return $this->recurringInvoice;
+    }
+
+    public function getContact(): Contact
+    {
+        return $this->contact;
+    }
+
+    public function setRecurringInvoice(RecurringInvoice $recurringInvoice): self
+    {
+        $this->recurringInvoice = $recurringInvoice;
+
+        return $this;
+    }
+
+    public function setContact(Contact $contact): self
+    {
+        $this->contact = $contact;
+
+        return $this;
+    }
+}

--- a/src/InvoiceBundle/Form/EventListener/InvoiceUsersSubscriber.php
+++ b/src/InvoiceBundle/Form/EventListener/InvoiceUsersSubscriber.php
@@ -15,16 +15,33 @@ namespace SolidInvoice\InvoiceBundle\Form\EventListener;
 
 use Doctrine\ORM\EntityRepository;
 use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Form\Transformer\UserToContactTransformer;
+use SolidInvoice\InvoiceBundle\Entity\BaseInvoice;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\InvoiceContact;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class InvoiceUsersSubscriber implements EventSubscriberInterface
+final class InvoiceUsersSubscriber implements EventSubscriberInterface
 {
+    private FormBuilderInterface $builder;
+
+    private BaseInvoice $invoice;
+
+    public function __construct(FormBuilderInterface $builder, BaseInvoice $invoice)
+    {
+        $this->builder = $builder;
+        $this->invoice = $invoice;
+    }
+
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -50,13 +67,16 @@ class InvoiceUsersSubscriber implements EventSubscriberInterface
         if (! empty($clientId)) {
             $form = $event->getForm();
 
-            $form->add(
+            $invoice = $this->invoice;
+
+            $users = $this->builder->create(
                 'users',
                 EntityType::class,
                 [
                     'constraints' => new NotBlank(),
                     'multiple' => true,
                     'expanded' => true,
+                    'auto_initialize' => false,
                     'class' => Contact::class,
                     'query_builder' => function (EntityRepository $repo) use ($clientId) {
                         return $repo->createQueryBuilder('c')
@@ -64,7 +84,9 @@ class InvoiceUsersSubscriber implements EventSubscriberInterface
                             ->setParameter('client', $clientId);
                     },
                 ]
-            );
+            )->addModelTransformer(new UserToContactTransformer($invoice, InvoiceContact::class));
+
+            $form->add($users->getForm());
         }
     }
 }

--- a/src/InvoiceBundle/Form/Type/InvoiceType.php
+++ b/src/InvoiceBundle/Form/Type/InvoiceType.php
@@ -80,7 +80,7 @@ class InvoiceType extends AbstractType
         $builder->add('baseTotal', HiddenMoneyType::class, ['currency' => $options['currency']]);
         $builder->add('tax', HiddenMoneyType::class, ['currency' => $options['currency']]);
 
-        $builder->addEventSubscriber(new InvoiceUsersSubscriber());
+        $builder->addEventSubscriber(new InvoiceUsersSubscriber($builder, $options['data']));
     }
 
     public function getBlockPrefix(): string

--- a/src/InvoiceBundle/Form/Type/RecurringInvoiceType.php
+++ b/src/InvoiceBundle/Form/Type/RecurringInvoiceType.php
@@ -75,7 +75,7 @@ class RecurringInvoiceType extends AbstractType
         $builder->add('baseTotal', HiddenMoneyType::class, ['currency' => $options['currency']]);
         $builder->add('tax', HiddenMoneyType::class, ['currency' => $options['currency']]);
 
-        $builder->addEventSubscriber(new InvoiceUsersSubscriber());
+        $builder->addEventSubscriber(new InvoiceUsersSubscriber($builder, $options['data']));
 
         $builder->add('frequency', CronType::class);
 

--- a/src/InvoiceBundle/Resources/config/services/services.yml
+++ b/src/InvoiceBundle/Resources/config/services/services.yml
@@ -40,3 +40,6 @@ services:
         tags: ['doctrine.fixture.orm']
 
     SolidInvoice\InvoiceBundle\Schedule\ScheduleBuilder: ~
+
+    SolidInvoice\InvoiceBundle\Api\:
+        resource: '%kernel.project_dir%/src/InvoiceBundle/Api/*'

--- a/src/InvoiceBundle/Test/Factory/InvoiceFactory.php
+++ b/src/InvoiceBundle/Test/Factory/InvoiceFactory.php
@@ -51,7 +51,7 @@ final class InvoiceFactory extends ModelFactory
             'uuid' => Uuid::fromString(self::faker()->uuid()),
             'due' => self::faker()->dateTime(),
             'paidDate' => self::faker()->dateTime(),
-            'status' => self::faker()->text(),
+            'status' => self::faker()->word(),
             'terms' => self::faker()->text(),
             'notes' => self::faker()->text(),
             'archived' => self::faker()->boolean(),

--- a/src/InvoiceBundle/Tests/Api/BillingUserNormalizerTest.php
+++ b/src/InvoiceBundle/Tests/Api/BillingUserNormalizerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\Api;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\InvoiceBundle\Api\BillingUserNormalizer;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use stdClass;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+
+/**
+ * @coversDefaultClass \SolidInvoice\InvoiceBundle\Api\BillingUserNormalizer
+ */
+final class BillingUserNormalizerTest extends TestCase
+{
+    private BillingUserNormalizer $billingUserNormalizer;
+
+    /**
+     * @var IriConverterInterface&MockObject
+     */
+    private IriConverterInterface $iriConverter;
+
+    /**
+     * @var ContextAwareDenormalizerInterface&MockObject
+     */
+    private ContextAwareDenormalizerInterface $denormalizer;
+
+    /**
+     * @var ContextAwareNormalizerInterface&MockObject
+     */
+    private ContextAwareNormalizerInterface $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->iriConverter = $this->createMock(IriConverterInterface::class);
+        $this->denormalizer = $this->createMock(ContextAwareDenormalizerInterface::class);
+        $this->normalizer = $this->createMock(ContextAwareNormalizerInterface::class);
+
+        $this->billingUserNormalizer = new BillingUserNormalizer($this->iriConverter);
+        $this->billingUserNormalizer->setDenormalizer($this->denormalizer);
+        $this->billingUserNormalizer->setNormalizer($this->normalizer);
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        $data = ['users' => [
+            new Contact()
+        ]];
+        $supportedClasses = [Invoice::class, RecurringInvoice::class, Quote::class];
+
+        foreach ($supportedClasses as $class) {
+            self::assertTrue($this->billingUserNormalizer->supportsDenormalization($data, $class, 'json'));
+            self::assertTrue($this->billingUserNormalizer->supportsDenormalization($data, $class, 'jsonld'));
+        }
+
+        self::assertFalse($this->billingUserNormalizer->supportsDenormalization($data, stdClass::class, 'json'));
+        self::assertFalse($this->billingUserNormalizer->supportsDenormalization([], Invoice::class, 'xml'));
+    }
+
+    public function testSupportsNormalization(): void
+    {
+        $context = ['resource_class' => Invoice::class];
+        $data = ['users' => []];
+        $supportedClasses = [Invoice::class, RecurringInvoice::class, Quote::class];
+
+        foreach ($supportedClasses as $class) {
+            self::assertTrue($this->billingUserNormalizer->supportsNormalization($data, 'json', ['resource_class' => $class]));
+            self::assertTrue($this->billingUserNormalizer->supportsNormalization($data, 'jsonld', ['resource_class' => $class]));
+        }
+
+        self::assertTrue($this->billingUserNormalizer->supportsNormalization($data, 'xml', $context));
+        self::assertFalse($this->billingUserNormalizer->supportsNormalization([], 'json', $context));
+    }
+
+    public function testDenormalize(): void
+    {
+        $data = ['users' => []];
+        $class = Invoice::class;
+        $invoice = new Invoice();
+
+        $this->denormalizer
+            ->expects(self::once())
+            ->method('denormalize')
+            ->with($data, $class, 'json', [BillingUserNormalizer::class => true])
+            ->willReturn($invoice);
+
+        self::assertSame($invoice, $this->billingUserNormalizer->denormalize($data, $class, 'json'));
+    }
+
+    public function testNormalize(): void
+    {
+        $object = ['users' => [$user = new stdClass()]];
+        $format = 'json';
+        $context = ['resource_class' => Invoice::class];
+
+        $iri = '/some/iri';
+        $this->iriConverter
+            ->expects(self::once())
+            ->method('getIriFromItem')
+            ->with($user)
+            ->willReturn($iri);
+
+        $this->normalizer
+            ->expects(self::once())
+            ->method('normalize')
+            ->with(['users' => [$iri]], $format, ['resource_class' => Invoice::class, BillingUserNormalizer::class => true])
+            ->willReturn($normalized = ['users' => [$iri]]);
+
+        $result = $this->billingUserNormalizer->normalize($object, $format, $context);
+
+        self::assertSame($normalized, $result);
+    }
+}

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
@@ -14,14 +14,16 @@ declare(strict_types=1);
 namespace SolidInvoice\InvoiceBundle\Tests\Functional\Api;
 
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Ramsey\Uuid\Uuid;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
-use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData;
+use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData as LoadClientData;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\InvoiceBundle\DataFixtures\ORM\LoadData as LoadInvoiceData;
 
 /**
  * @group functional
  */
-class InvoiceTest extends ApiTestCase
+final class InvoiceTest extends ApiTestCase
 {
     use EnsureApplicationInstalled;
 
@@ -29,13 +31,11 @@ class InvoiceTest extends ApiTestCase
     {
         parent::setUp();
 
-        self::bootKernel();
-
-        $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
+        $databaseTool = self::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([
-            LoadData::class,
-            \SolidInvoice\InvoiceBundle\DataFixtures\ORM\LoadData::class,
+            LoadClientData::class,
+            LoadInvoiceData::class,
         ], true);
     }
 
@@ -60,6 +60,8 @@ class InvoiceTest extends ApiTestCase
         ];
 
         $result = $this->requestPost('/api/invoices', $data);
+
+        self::assertTrue(Uuid::isValid($result['uuid']));
 
         unset($result['uuid']);
 
@@ -103,6 +105,8 @@ class InvoiceTest extends ApiTestCase
     public function testGet(): void
     {
         $data = $this->requestGet('/api/invoices/1');
+
+        self::assertTrue(Uuid::isValid($data['uuid']));
 
         unset($data['uuid']);
 
@@ -156,6 +160,8 @@ class InvoiceTest extends ApiTestCase
                 ],
             ]
         );
+
+        self::assertTrue(Uuid::isValid($data['uuid']));
 
         unset($data['uuid']);
 

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -15,14 +15,16 @@ namespace SolidInvoice\InvoiceBundle\Tests\Functional\Api;
 
 use DateTimeInterface;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Ramsey\Uuid\Uuid;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
-use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData;
+use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData as LoadClientData;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\InvoiceBundle\DataFixtures\ORM\LoadData as LoadInvoiceData;
 
 /**
  * @group functional
  */
-class RecurringInvoiceTest extends ApiTestCase
+final class RecurringInvoiceTest extends ApiTestCase
 {
     use EnsureApplicationInstalled;
 
@@ -30,13 +32,11 @@ class RecurringInvoiceTest extends ApiTestCase
     {
         parent::setUp();
 
-        self::bootKernel();
-
-        $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
+        $databaseTool = self::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([
-            LoadData::class,
-            \SolidInvoice\InvoiceBundle\DataFixtures\ORM\LoadData::class,
+            LoadClientData::class,
+            LoadInvoiceData::class,
         ], true);
     }
 
@@ -108,6 +108,8 @@ class RecurringInvoiceTest extends ApiTestCase
     {
         $data = $this->requestGet('/api/recurring_invoices/1');
 
+        self::assertTrue(Uuid::isValid($data['uuid']));
+
         unset($data['uuid']);
 
         self::assertSame([
@@ -161,6 +163,8 @@ class RecurringInvoiceTest extends ApiTestCase
                 ],
             ]
         );
+
+        self::assertTrue(Uuid::isValid($data['uuid']));
 
         unset($data['uuid']);
 

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -15,7 +15,6 @@ namespace SolidInvoice\InvoiceBundle\Tests\Functional\Api;
 
 use DateTimeInterface;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
-use Ramsey\Uuid\Uuid;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
 use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData as LoadClientData;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -108,10 +108,6 @@ final class RecurringInvoiceTest extends ApiTestCase
     {
         $data = $this->requestGet('/api/recurring_invoices/1');
 
-        self::assertTrue(Uuid::isValid($data['uuid']));
-
-        unset($data['uuid']);
-
         self::assertSame([
             'id' => 1,
             'client' => '/api/clients/1',
@@ -163,10 +159,6 @@ final class RecurringInvoiceTest extends ApiTestCase
                 ],
             ]
         );
-
-        self::assertTrue(Uuid::isValid($data['uuid']));
-
-        unset($data['uuid']);
 
         self::assertSame([
             'id' => 1,

--- a/src/PaymentBundle/Repository/PaymentRepository.php
+++ b/src/PaymentBundle/Repository/PaymentRepository.php
@@ -194,7 +194,7 @@ class PaymentRepository extends ServiceEntityRepository
         }
 
         $queryBuilder
-            ->groupBy('p.created')
+            ->groupBy('p.created, p.totalAmount')
             ->orderBy('p.created', Criteria::ASC);
 
         $query = $queryBuilder->getQuery();
@@ -247,7 +247,7 @@ class PaymentRepository extends ServiceEntityRepository
         )
             ->where('p.created >= :date')
             ->setParameter('date', new DateTime('-1 Year'))
-            ->groupBy('p.created')
+            ->groupBy('p.created, p.totalAmount')
             ->orderBy('p.created', Criteria::ASC);
 
         $query = $queryBuilder->getQuery();

--- a/src/PaymentBundle/Test/Factory/PaymentFactory.php
+++ b/src/PaymentBundle/Test/Factory/PaymentFactory.php
@@ -51,7 +51,7 @@ final class PaymentFactory extends ModelFactory
             'totalAmount' => self::faker()->randomNumber(),
             'currencyCode' => self::faker()->currencyCode(),
             'details' => [],
-            'status' => self::faker()->text(),
+            'status' => self::faker()->word(),
             'message' => self::faker()->text(),
             'completed' => self::faker()->dateTime(),
             'created' => self::faker()->dateTime(),

--- a/src/PaymentBundle/Test/Factory/PaymentMethodFactory.php
+++ b/src/PaymentBundle/Test/Factory/PaymentMethodFactory.php
@@ -45,8 +45,8 @@ final class PaymentMethodFactory extends ModelFactory
     {
         return [
             'name' => self::faker()->text(),
-            'gatewayName' => self::faker()->text(),
-            'factoryName' => self::faker()->text(),
+            'gatewayName' => self::faker()->name(),
+            'factoryName' => self::faker()->name(),
             'config' => [],
             'internal' => self::faker()->boolean(),
             'enabled' => self::faker()->boolean(),

--- a/src/PaymentBundle/Tests/Functional/Api/PaymentTest.php
+++ b/src/PaymentBundle/Tests/Functional/Api/PaymentTest.php
@@ -15,8 +15,9 @@ namespace SolidInvoice\PaymentBundle\Tests\Functional\Api;
 
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
-use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData;
+use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData as LoadClientData;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\PaymentBundle\DataFixtures\ORM\LoadData as LoadPaymentData;
 
 /**
  * @group functional
@@ -29,13 +30,11 @@ class PaymentTest extends ApiTestCase
     {
         parent::setUp();
 
-        self::bootKernel();
-
         $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([
-            LoadData::class,
-            \SolidInvoice\PaymentBundle\DataFixtures\ORM\LoadData::class,
+            LoadClientData::class,
+            LoadPaymentData::class,
         ], true);
     }
 

--- a/src/PaymentBundle/Tests/Repository/PaymentRepositoryTest.php
+++ b/src/PaymentBundle/Tests/Repository/PaymentRepositoryTest.php
@@ -323,12 +323,12 @@ final class PaymentRepositoryTest extends KernelTestCase
         self::assertEquals(
             [
                 new Money(
-                    500123,
-                    new Currency('EUR')
-                ),
-                new Money(
                     500123 * 3,
                     new Currency('USD')
+                ),
+                new Money(
+                    500123,
+                    new Currency('EUR')
                 ),
             ],
             $this

--- a/src/PaymentBundle/Tests/Repository/PaymentRepositoryTest.php
+++ b/src/PaymentBundle/Tests/Repository/PaymentRepositoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\PaymentBundle\Tests\Repository;
 
+use DateTime;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Money\Currency;
@@ -230,11 +231,12 @@ final class PaymentRepositoryTest extends KernelTestCase
     {
         $client = ClientFactory::createOne(['currency' => 'USD']);
 
-        $created = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
-        $completed = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
+        $created = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
+        $completed = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
 
-        PaymentFactory::createOne([
-            'invoice' => InvoiceFactory::new(['client' => $client, 'archived' => null]),
+        $invoice = InvoiceFactory::createOne(['client' => $client, 'archived' => null])->disableAutoRefresh();
+        $payment = PaymentFactory::createOne([
+            'invoice' => $invoice,
             'client' => $client,
             'currencyCode' => 'USD',
             'totalAmount' => 500123,
@@ -242,19 +244,19 @@ final class PaymentRepositoryTest extends KernelTestCase
             'message' => 'test',
             'created' => $created,
             'completed' => $completed,
-            'method' => PaymentMethodFactory::createOne(['name' => 'test-payment']),
+            'method' => PaymentMethodFactory::new(['name' => 'test-payment']),
         ]);
 
         self::assertEquals(
             [
                 [
-                    'id' => 1,
+                    'id' => $payment->getId(),
                     'totalAmount' => 500123,
                     'currencyCode' => 'USD',
                     'created' => $created,
                     'completed' => $completed,
                     'status' => Status::STATUS_CAPTURED,
-                    'invoice' => 1,
+                    'invoice' => $invoice->object()->getId(),
                     'method' => 'test-payment',
                     'message' => 'test',
                 ]
@@ -346,10 +348,10 @@ final class PaymentRepositoryTest extends KernelTestCase
             ->create()
             ->disableAutoRefresh();
 
-        $created = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
-        $completed = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
+        $created = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
+        $completed = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
 
-        PaymentFactory::createOne([
+        $payment = PaymentFactory::createOne([
             'invoice' => $invoice,
             'client' => $client,
             'currencyCode' => 'USD',
@@ -364,13 +366,13 @@ final class PaymentRepositoryTest extends KernelTestCase
         self::assertEquals(
             [
                 [
-                    'id' => 1,
+                    'id' => $payment->getId(),
                     'totalAmount' => 500123,
                     'currencyCode' => 'USD',
                     'created' => $created,
                     'completed' => $completed,
                     'status' => Status::STATUS_CAPTURED,
-                    'invoice' => 1,
+                    'invoice' => $invoice->object()->getId(),
                     'method' => 'test-payment',
                     'message' => 'test',
                 ]
@@ -463,7 +465,7 @@ final class PaymentRepositoryTest extends KernelTestCase
 
         $this->em->clear();
 
-        $payment = $this->em->getRepository(Payment::class)->find(1);
+        $payment = $this->em->getRepository(Payment::class)->find($payment->getId());
 
         self::assertSame(Status::STATUS_CAPTURED, $payment->getStatus());
     }
@@ -475,10 +477,10 @@ final class PaymentRepositoryTest extends KernelTestCase
             ->create()
             ->disableAutoRefresh();
 
-        $created = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
-        $completed = DateTimeImmutable::createFromFormat('Y-m-d', date('Y-m-d'));
+        $created = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
+        $completed = DateTime::createFromFormat('Y-m-d', date('Y-m-d'));
 
-        PaymentFactory::createOne([
+        $payment = PaymentFactory::createOne([
             'invoice' => $invoice,
             'client' => $client,
             'currencyCode' => 'USD',
@@ -493,7 +495,7 @@ final class PaymentRepositoryTest extends KernelTestCase
         self::assertEquals(
             [
                 [
-                    'id' => 1,
+                    'id' => $payment->getId(),
                     'totalAmount' => 500123,
                     'currencyCode' => 'USD',
                     'created' => $created,

--- a/src/QuoteBundle/DataFixtures/ORM/LoadData.php
+++ b/src/QuoteBundle/DataFixtures/ORM/LoadData.php
@@ -17,9 +17,12 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Money\Currency;
 use Money\Money;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Entity\Contact;
 use SolidInvoice\QuoteBundle\Entity\Item;
 use SolidInvoice\QuoteBundle\Entity\Quote;
 use SolidInvoice\QuoteBundle\Model\Graph;
+use function assert;
 
 /**
  * @codeCoverageIgnore
@@ -28,9 +31,15 @@ class LoadData extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
+        $client = $this->getReference('client');
+        assert($client instanceof Client);
+
+        $contact = $this->getReference('contact');
+        assert($contact instanceof Contact);
+
         $quote = new Quote();
-        $quote->setClient($this->getReference('client'));
-        $quote->addUser($this->getReference('contact'));
+        $quote->setClient($client);
+        $quote->addUser($contact);
         $quote->setStatus(Graph::STATUS_DRAFT);
 
         $item = new Item();

--- a/src/QuoteBundle/Entity/QuoteContact.php
+++ b/src/QuoteBundle/Entity/QuoteContact.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\QuoteBundle\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="quote_contact")
+ * @ApiResource(collectionOperations={}, itemOperations={})
+ */
+class QuoteContact
+{
+    use CompanyAware;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=Quote::class, inversedBy="users", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(name="quote_id", referencedColumnName="id")
+     */
+    private Quote $quote;
+
+    /**
+     * @ORM\Id()
+     * @ORM\ManyToOne(targetEntity=Contact::class, cascade={"persist", "remove"}, inversedBy="quotes")
+     * @ORM\JoinColumn(name="contact_id", referencedColumnName="id")
+     */
+    private Contact $contact;
+
+    public function getQuote(): Quote
+    {
+        return $this->quote;
+    }
+
+    public function getContact(): Contact
+    {
+        return $this->contact;
+    }
+
+    public function setQuote(Quote $quote): self
+    {
+        $this->quote = $quote;
+
+        return $this;
+    }
+
+    public function setContact(Contact $contact): self
+    {
+        $this->contact = $contact;
+
+        return $this;
+    }
+}

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
@@ -14,14 +14,16 @@ declare(strict_types=1);
 namespace SolidInvoice\QuoteBundle\Tests\Functional\Api;
 
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Ramsey\Uuid\Uuid;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
-use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData;
+use SolidInvoice\ClientBundle\DataFixtures\ORM\LoadData as LoadClientData;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\QuoteBundle\DataFixtures\ORM\LoadData as LoadQuoteData;
 
 /**
  * @group functional
  */
-class QuoteTest extends ApiTestCase
+final class QuoteTest extends ApiTestCase
 {
     use EnsureApplicationInstalled;
 
@@ -29,13 +31,11 @@ class QuoteTest extends ApiTestCase
     {
         parent::setUp();
 
-        self::bootKernel();
-
-        $databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
+        $databaseTool = self::getContainer()->get(DatabaseToolCollection::class)->get();
 
         $databaseTool->loadFixtures([
-            LoadData::class,
-            \SolidInvoice\QuoteBundle\DataFixtures\ORM\LoadData::class,
+            LoadClientData::class,
+            LoadQuoteData::class,
         ], true);
     }
 
@@ -60,6 +60,8 @@ class QuoteTest extends ApiTestCase
         ];
 
         $result = $this->requestPost('/api/quotes', $data);
+
+        self::assertTrue(Uuid::isValid($result['uuid']));
 
         unset($result['uuid']);
 
@@ -101,6 +103,8 @@ class QuoteTest extends ApiTestCase
     public function testGet(): void
     {
         $data = $this->requestGet('/api/quotes/1');
+
+        self::assertTrue(Uuid::isValid($data['uuid']));
 
         unset($data['uuid']);
 
@@ -152,6 +156,8 @@ class QuoteTest extends ApiTestCase
                 ],
             ]
         );
+
+        self::assertTrue(Uuid::isValid($data['uuid']));
 
         unset($data['uuid']);
 

--- a/src/SettingsBundle/Resources/config/services/services.yml
+++ b/src/SettingsBundle/Resources/config/services/services.yml
@@ -8,6 +8,7 @@ services:
         arguments:
             $installed: '%env(installed)%'
         lazy: true
+        public: true
 
     settings:
         alias: SolidInvoice\SettingsBundle\SystemConfig

--- a/src/SettingsBundle/Tests/Form/Handler/SettingsFormHandlerTest.php
+++ b/src/SettingsBundle/Tests/Form/Handler/SettingsFormHandlerTest.php
@@ -29,12 +29,6 @@ use function iterator_to_array;
 
 final class SettingsFormHandlerTest extends FormHandlerTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        self::bootKernel();
-    }
-
     public function getHandler(): SettingsFormHandler
     {
         $repository = $this->registry->getRepository(Setting::class);

--- a/src/UserBundle/DataFixtures/ORM/LoadData.php
+++ b/src/UserBundle/DataFixtures/ORM/LoadData.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\UserBundle\DataFixtures\ORM;
 use DateTime;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\UserBundle\Entity\User;
 
 /**
@@ -25,18 +26,24 @@ class LoadData extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
+        $company = $manager->getRepository(Company::class)->findOneBy([]);
+
         $user1 = (new User())
             ->setUsername('test1')
             ->setEmail('test1@test.com')
             ->setPassword('test1')
             ->setConfirmationToken(base64_encode(bin2hex(random_bytes(24))))
-            ->setPasswordRequestedAt(new DateTime());
+            ->setPasswordRequestedAt(new DateTime())
+            ->addCompany($company)
+        ;
 
         $user2 = (new User())
             ->setUsername('test2')
             ->setEmail('test2@test.com')
             ->setPassword('test2')
-            ->setEnabled(true);
+            ->setEnabled(true)
+            ->addCompany($company)
+        ;
 
         $manager->persist($user1);
         $manager->persist($user2);

--- a/src/UserBundle/Repository/UserRepository.php
+++ b/src/UserBundle/Repository/UserRepository.php
@@ -41,7 +41,11 @@ class UserRepository extends ServiceEntityRepository implements UserRepositoryIn
 
         $qb->select('COUNT(u.id)');
 
-        return (int) $qb->getQuery()->getSingleScalarResult();
+        try {
+            return (int) $qb->getQuery()->getSingleScalarResult();
+        } catch (NoResultException|NonUniqueResultException $e) {
+            return 0;
+        }
     }
 
     public function loadUserByUsername(string $username): UserInterface

--- a/src/UserBundle/Tests/Form/Handler/ApiFormHandlerTest.php
+++ b/src/UserBundle/Tests/Form/Handler/ApiFormHandlerTest.php
@@ -25,6 +25,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ApiFormHandlerTest extends FormHandlerTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->em->getRepository(ApiToken::class)->findAll() as $user) {
+            $this->em->remove($user);
+        }
+    }
+
     /**
      * @return string|FormHandlerInterface
      */

--- a/src/UserBundle/Tests/Repository/UserRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserRepositoryTest.php
@@ -36,15 +36,9 @@ class UserRepositoryTest extends KernelTestCase
     use EnsureApplicationInstalled;
     use FakerTestTrait;
 
-    /**
-     * @var Generator
-     */
-    private $faker;
+    private Generator $faker;
 
-    /**
-     * @var UserRepository
-     */
-    private $repository;
+    private UserRepository $repository;
 
     protected AbstractDatabaseTool $databaseTool;
 
@@ -53,10 +47,22 @@ class UserRepositoryTest extends KernelTestCase
         parent::setUp();
 
         $kernel = self::$kernel;
-        $this->repository = $kernel->getContainer()->get('doctrine')->getRepository(User::class);
+        $registry = $kernel->getContainer()->get('doctrine');
+        $em = $registry->getManager();
+        $this->repository = $registry->getRepository(User::class);
         $this->faker = $this->getFaker();
 
         $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
+
+        // Ensure there are no users set, to make the tests a bit more predicable,
+        // since users can be added by api tests
+        foreach ($this->repository->findAll() as $user) {
+            foreach ($user->getApiTokens() as $token) {
+                $em->remove($token);
+            }
+
+            $em->remove($user);
+        }
     }
 
     public function testSave(): void
@@ -77,6 +83,7 @@ class UserRepositoryTest extends KernelTestCase
         $executor = $this->databaseTool->loadFixtures([LoadData::class], true);
         $user = $executor->getReferenceRepository()->getReference('user2');
         $newUser = $this->repository->refreshUser($user);
+        self::assertInstanceOf(User::class, $newUser);
         self::assertSame($user->getId(), $newUser->getId());
         self::assertSame($user->getUsername(), $newUser->getUsername());
         self::assertSame($user->getEmail(), $newUser->getEmail());
@@ -141,7 +148,7 @@ class UserRepositoryTest extends KernelTestCase
 
     public function testGetUserCount(): void
     {
-        self::assertSame(0, $this->repository->getUserCount());
+        self::assertLessThanOrEqual(1, $this->repository->getUserCount());
 
         $this->databaseTool->loadFixtures([LoadData::class], true);
 

--- a/src/UserBundle/Tests/Repository/UserRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserRepositoryTest.php
@@ -52,11 +52,9 @@ class UserRepositoryTest extends KernelTestCase
     {
         parent::setUp();
 
-        $kernel = self::bootKernel();
+        $kernel = self::$kernel;
         $this->repository = $kernel->getContainer()->get('doctrine')->getRepository(User::class);
         $this->faker = $this->getFaker();
-
-        self::bootKernel();
 
         $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -31,6 +31,18 @@
     "composer/package-versions-deprecated": {
         "version": "1.10.99"
     },
+    "dama/doctrine-test-bundle": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "4.0",
+            "ref": "56eaa387b5e48ebcc7c95a893b47dfa1ad51449c"
+        },
+        "files": [
+            "config/packages/test/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "dbrekelmans/bdi": {
         "version": "1.0"
     },

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,12 +9,49 @@
  * with this source code in the file LICENSE.
  */
 
-use Symfony\Component\Dotenv\Dotenv;
+use Doctrine\Deprecations\Deprecation;
+use SolidInvoice\CoreBundle\Entity\Version;
+use SolidInvoice\CoreBundle\Repository\VersionRepository;
+use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
+use SolidInvoice\Kernel;
+use SolidInvoice\SettingsBundle\SystemConfig;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__) . '/config/bootstrap.php')) {
-    require dirname(__DIR__) . '/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
+if (class_exists(Deprecation::class)) {
+    Deprecation::enableWithTriggerError();
 }
+
+(static function (): void {
+    $kernel = new Kernel('test', true);
+    $kernel->boot();
+
+    $application = new Application($kernel);
+    $application->setAutoExit(false);
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:database:drop',
+        '--if-exists' => '1',
+        '--force' => '1',
+    ]));
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:database:create',
+    ]));
+
+    $application->run(new ArrayInput([
+        'command' => 'doctrine:migrations:migrate',
+        '--allow-no-migration' => '1',
+        '--no-interaction' => '1',
+    ]));
+
+    $kernel->getContainer()->get(SystemConfig::class)->set(SystemConfig::CURRENCY_CONFIG_PATH, 'USD');
+
+    /** @var VersionRepository $version */
+    $version = $kernel->getContainer()->get('doctrine')->getManager()->getRepository(Version::class);
+    $version->updateVersion(SolidInvoiceCoreBundle::VERSION);
+
+    $kernel->shutdown();
+})();


### PR DESCRIPTION
Set CompanyId to invoice and quote contacts to ensure the related values are only saved for the current company. This prevents issues with the current primary key when the invoice/contact combination already exists in the DB, and also ensure contacts are only loaded for the specific invoice|quote for the current company instead of loaded cross-company