### PR TITLE
Merge release 2.2.6 into 2.3.x

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
 
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Bump version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "./scripts/bump_version.sh ${{ github.event.milestone.title }}"
+
       - name: Release
         uses: laminas/automatic-releases@12dde9b998d13e6721e5d000cf0c6a513ebdb98b
         with:
@@ -118,3 +126,8 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: Bump version to next dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "./scripts/bump_version_dev.sh

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -130,4 +130,4 @@ jobs:
       - name: Bump version to next dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "./scripts/bump_version_dev.sh
+        run: "./scripts/bump_version_dev.sh"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "authors": [
         {
-            "name": "Pierre du Plessis",
-            "email": "info@solidinvoice.co"
+            "name": "SolidWorx",
+            "email": "open-source@solidworx.co"
         }
     ],
     "homepage": "https://solidinvoice.co",

--- a/composer.lock
+++ b/composer.lock
@@ -2221,7 +2221,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T17:26:14+00:00"
+            "time": "2023-06-01T07:04:22+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",

--- a/config/services.php
+++ b/config/services.php
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(mailer_password)', null);
     $parameters->set('env(mailer_port)', null);
     $parameters->set('env(mailer_encryption)', null);
-    $parameters->set('env(locale)', 'en_US');
+    $parameters->set('env(locale)', 'en');
     $parameters->set('env(secret)', 'SecretToken');
     $parameters->set('env(installed)', null);
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# GitHub Actions setup for Git
+if [ -n "$GITHUB_ACTIONS" ]; then
+  git config --local user.email "action@github.com"
+  git config --local user.name "GitHub Action"
+  git remote set-url origin https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+fi
+
+# File path
+FILE="./src/CoreBundle/SolidInvoiceCoreBundle.php"
+PACKAGE_JSON="./package.json"
+
+# Function to bump semver
+bump_version() {
+  local version=$1
+  local field=$2
+  local increment=$3
+
+  IFS='.' read -ra parts <<< "$version"
+  ((parts[$field]+=increment))
+
+  if [ $field -lt 2 ]; then
+    for i in $(seq $((field+1)) 2); do
+      parts[$i]=0
+    done
+  fi
+
+  echo "${parts[0]}.${parts[1]}.${parts[2]}"
+}
+
+# Check for version argument
+if [ "$1" ]; then
+  next_version="$1"
+else
+  current_version=$(awk -F\' '/public const VERSION/ {print $2}' $FILE)
+  clean_version="${current_version%-dev}"
+  next_version=$(bump_version $clean_version 2 1)  # bumping minor version
+fi
+
+# Update file with bumped version
+sed -i "s/public const VERSION = '.*';/public const VERSION = '$next_version';/" $FILE
+jq --arg version "$next_version" '.version=$version' --indent 4 $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+
+git add $FILE $PACKAGE_JSON
+git commit -m "Release version $next_version"
+git push

--- a/scripts/bump_version_dev.sh
+++ b/scripts/bump_version_dev.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# GitHub Actions setup for Git
+if [ -n "$GITHUB_ACTIONS" ]; then
+  git config --local user.email "action@github.com"
+  git config --local user.name "GitHub Action"
+  git remote set-url origin https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+fi
+
+# File path
+FILE="./src/CoreBundle/SolidInvoiceCoreBundle.php"
+PACKAGE_JSON="./package.json"
+
+# Function to bump semver
+bump_version() {
+  local version=$1
+  local field=$2
+  local increment=$3
+
+  IFS='.' read -ra parts <<< "$version"
+  ((parts[$field]+=increment))
+
+  if [ $field -lt 2 ]; then
+    for i in $(seq $((field+1)) 2); do
+      parts[$i]=0
+    done
+  fi
+
+  echo "${parts[0]}.${parts[1]}.${parts[2]}"
+}
+
+# Read current version
+current_version=$(awk -F\' '/public const VERSION/ {print $2}' $FILE)
+
+# Remove '-dev' suffix if exists
+clean_version="${current_version%-dev}"
+
+# Bump to next dev version
+dev_version=$(bump_version $clean_version 2 1)-dev
+
+# Update file with next dev version
+sed -i "s/public const VERSION = '.*';/public const VERSION = '$dev_version';/" $FILE
+jq --arg version "$dev_version" '.version=$version' --indent 4 $PACKAGE_JSON > tmp.json && mv tmp.json $PACKAGE_JSON
+
+git add $FILE $PACKAGE_JSON
+git commit -m "Bump to dev version $dev_version"
+git push

--- a/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
+++ b/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
@@ -39,7 +39,7 @@ class ViewTransformer implements DataTransformerInterface
 
     public function reverseTransform($value): Money
     {
-        if (null === $value) {
+        if (!is_numeric($value)) {
             $value = 0;
         }
 

--- a/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
+++ b/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
@@ -31,10 +31,10 @@ class ViewTransformer implements DataTransformerInterface
     public function transform($value)
     {
         if ($value instanceof Money) {
-            return $value->getAmount() / 100;
+            return (float) ($value->getAmount() / 100);
         }
 
-        return 0;
+        return 0.0;
     }
 
     public function reverseTransform($value): Money
@@ -43,6 +43,6 @@ class ViewTransformer implements DataTransformerInterface
             $value = 0;
         }
 
-        return new Money(((int) $value * 100), $this->currency);
+        return new Money($value * 100, $this->currency);
     }
 }

--- a/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
+++ b/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
@@ -28,7 +28,7 @@ class ViewTransformer implements DataTransformerInterface
     ) {
     }
 
-    public function transform($value)
+    public function transform($value): float
     {
         if ($value instanceof Money) {
             return (float) ($value->getAmount() / 100);

--- a/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
+++ b/src/MoneyBundle/Form/DataTransformer/ViewTransformer.php
@@ -39,7 +39,7 @@ class ViewTransformer implements DataTransformerInterface
 
     public function reverseTransform($value): Money
     {
-        if (!is_numeric($value)) {
+        if (! is_numeric($value)) {
             $value = 0;
         }
 

--- a/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
+++ b/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
@@ -55,6 +55,9 @@ final class ViewTransformerTest extends TestCase
         self::assertSame($expected, $value);
     }
 
+    /**
+     * @return iterable<array<float|int|null>>
+     */
     public function reverseTransformDataProvider(): iterable
     {
         yield [null, 0];
@@ -72,6 +75,9 @@ final class ViewTransformerTest extends TestCase
         yield [0.99, 99];
     }
 
+    /**
+     * @return iterable<array<Money|string|float|null>>
+     */
     public function transformDataProvider(): iterable
     {
         yield [null, 0.0];

--- a/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
+++ b/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SolidInvoice\MoneyBundle\Tests\Form\DataTransformer;
+
+use Money\Currency;
+use Money\Money;
+use SolidInvoice\MoneyBundle\Form\DataTransformer\ViewTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SolidInvoice\MoneyBundle\Form\DataTransformer\ViewTransformer
+ */
+final class ViewTransformerTest extends TestCase
+{
+    private ViewTransformer $viewTransformer;
+
+    private Currency $currency;
+
+    protected function setUp(): void
+    {
+        $this->currency = new Currency("USD");
+        $this->viewTransformer = new ViewTransformer($this->currency);
+    }
+
+    /**
+     * @dataProvider reverseTransformDataProvider
+     */
+    public function testReverseTransform(?float $value, int $expected): void
+    {
+        $expectedResult = new Money($expected, $this->currency);
+        $result = $this->viewTransformer->reverseTransform($value);
+
+        self::assertTrue($result->equals($expectedResult));
+    }
+
+    /**
+     * @param Money|string|null $money
+     * @param int|float $expected
+     *
+     * @dataProvider transformDataProvider
+     */
+    public function testTransformsMoneyObjectToFloat($money, $expected): void
+    {
+        $value = $this->viewTransformer->transform($money);
+
+        self::assertSame($expected, $value);
+    }
+
+    public function reverseTransformDataProvider(): iterable
+    {
+        yield [null, 0];
+        yield [10, 1000];
+        yield [10.00, 1000];
+        yield [10.01, 1001];
+        yield [10.10, 1010];
+        yield [10.11, 1011];
+        yield [10.99, 1099];
+        yield [111, 11100];
+        yield [111.11, 11111];
+        yield [0.01, 1];
+        yield [0.10, 10];
+        yield [0.11, 11];
+        yield [0.99, 99];
+    }
+
+    public function transformDataProvider(): iterable
+    {
+        yield [null, 0.0];
+        yield ['something else', 0.0];
+        yield [1.0, 0.0];
+        yield [new Money(1500, new Currency('USD')), 15.0];
+        yield [new Money(1000, new Currency('USD')), 10.0];
+        yield [new Money(100, new Currency('USD')), 1.0];
+        yield [new Money(10, new Currency('USD')), 0.10];
+        yield [new Money(1, new Currency('USD')), 0.01];
+        yield [new Money(0, new Currency('USD')), 0.0];
+    }
+}

--- a/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
+++ b/src/MoneyBundle/Tests/Form/DataTransformer/ViewTransformerTest.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace SolidInvoice\MoneyBundle\Tests\Form\DataTransformer;
 
 use Money\Currency;
 use Money\Money;
-use SolidInvoice\MoneyBundle\Form\DataTransformer\ViewTransformer;
 use PHPUnit\Framework\TestCase;
+use SolidInvoice\MoneyBundle\Form\DataTransformer\ViewTransformer;
 
 /**
  * @covers \SolidInvoice\MoneyBundle\Form\DataTransformer\ViewTransformer
@@ -18,7 +27,7 @@ final class ViewTransformerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->currency = new Currency("USD");
+        $this->currency = new Currency('USD');
         $this->viewTransformer = new ViewTransformer($this->currency);
     }
 

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -71,7 +71,6 @@ class ItemType extends AbstractType
                 'tax',
                 TaxEntityType::class,
                 [
-                    'class' => Tax::class,
                     'placeholder' => 'No Tax',
                     'attr' => [
                         'class' => 'select2 input-mini quote-item-tax',

--- a/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\QuoteBundle\Tests\Form\Type;
+
+use Money\Currency;
+use Money\Money;
+use SolidInvoice\CoreBundle\Tests\FormTestCase;
+use SolidInvoice\QuoteBundle\Entity\Item;
+use SolidInvoice\QuoteBundle\Form\Type\ItemType;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+
+final class ItemTypeTest extends FormTestCase
+{
+    public function testSubmit(): void
+    {
+        $description = $this->faker->text;
+        $price = $this->faker->randomNumber(3);
+        $qty = $this->faker->randomFloat(2);
+
+        $formData = [
+            'description' => $description,
+            'price' => $price,
+            'qty' => $qty,
+        ];
+
+        $currency = new Currency('USD');
+
+        $object = new Item();
+        $object->setDescription($description);
+        $object->setQty($qty);
+        $object->setPrice(new Money($price * 100, $currency));
+
+        $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    /**
+     * @return array<FormExtensionInterface>
+     */
+    protected function getExtensions(): array
+    {
+        $itemType = new ItemType($this->registry);
+
+        return [
+            // register the type instances with the PreloadedExtension
+            new PreloadedExtension([$itemType], []),
+        ];
+    }
+}

--- a/src/UserBundle/Entity/User.php
+++ b/src/UserBundle/Entity/User.php
@@ -280,9 +280,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Stringa
         return $this;
     }
 
-    public function setPlainPassword(string $password): self
+    public function setPlainPassword(?string $password): self
     {
-        $this->plainPassword = $password;
+        $this->plainPassword = (string) $password;
 
         return $this;
     }


### PR DESCRIPTION
### Release Notes for [2.2.6](https://github.com/SolidInvoice/SolidInvoice/milestone/19)

2.2.x bugfix release (patch)

### 2.2.6

- Total issues resolved: **4**
- Total pull requests resolved: **7**
- Total contributors: **4**

#### bug

 - [982: Fix incorrect option when adding TaxType to item](https://github.com/SolidInvoice/SolidInvoice/pull/982) thanks to @pierredup and @sentry-io[bot]
 - [980: Fix Money DataTransformer discarding cent values](https://github.com/SolidInvoice/SolidInvoice/pull/980) thanks to @pierredup and @pkoniecz
 - [968: Fix error when saving contact details with an empty type](https://github.com/SolidInvoice/SolidInvoice/pull/968) thanks to @pierredup and @sentry-io[bot]
 - [937: Add env config to a new separate path](https://github.com/SolidInvoice/SolidInvoice/pull/937) thanks to @pierredup
 - [934: Add email subject to password reset request email](https://github.com/SolidInvoice/SolidInvoice/pull/934) thanks to @pierredup

#### InvoiceBundle,bug

 - [967: Reset entity manager when it is closed](https://github.com/SolidInvoice/SolidInvoice/pull/967) thanks to @pierredup

#### enhancement

 - [938: Add additional configuration for Sentry](https://github.com/SolidInvoice/SolidInvoice/pull/938) thanks to @pierredup
