### PR TITLE
Remove default values from env file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,17 +1,2 @@
 SOLIDINVOICE_ENV=dev
 SOLIDINVOICE_DEBUG=1
-###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=doctrine://default
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
-###< symfony/messenger ###
-
-###> sentry/sentry-symfony ###
-SENTRY_DSN=
-SENTRY_SEND_DEFAULT_PII=
-###< sentry/sentry-symfony ###
-
-###> symfony/mailer ###
-MAILER_DSN=
-###< symfony/mailer ###


### PR DESCRIPTION
The values in the `.env.dist` file already have defaults set in the service config. These values are overwritten from the env config, which can cause errors (E.G #1014)

closes #1014