### PR TITLE
Skip some steps during installation when using Frankenphp

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_LOCALE)', 'en');
     $parameters->set('env(SOLIDINVOICE_APP_SECRET)', null);
     $parameters->set('env(SOLIDINVOICE_INSTALLED)', null);
+    $parameters->set('env(SOLIDINVOICE_RUNTIME)', null);
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');
 
     $parameters->set('env(SOLIDINVOICE_SENTRY_DSN)', null);

--- a/src/InstallBundle/Action/Finish.php
+++ b/src/InstallBundle/Action/Finish.php
@@ -13,19 +13,23 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InstallBundle\Action;
 
-use SolidInvoice\CoreBundle\Templating\Template;
 use SolidInvoice\InstallBundle\Exception\ApplicationInstalledException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-final class Finish
+final class Finish extends AbstractController
 {
     public function __construct(
-        private readonly string $projectDir
+        private readonly string $projectDir,
+        #[Autowire(env: 'SOLIDINVOICE_RUNTIME')]
+        private readonly ?string $runtime = null
     ) {
     }
 
-    public function __invoke(Request $request): Template
+    public function __invoke(Request $request): Response
     {
         $session = $request->getSession();
 
@@ -35,6 +39,12 @@ final class Finish
 
         $binDir = $this->projectDir . '/bin';
 
-        return new Template('@SolidInvoiceInstall/finish.html.twig', ['binDir' => $binDir]);
+        return $this->render(
+            '@SolidInvoiceInstall/finish.html.twig',
+            [
+                'binDir' => $binDir,
+                'runtime' => $this->runtime,
+            ]
+        );
     }
 }

--- a/src/InstallBundle/Action/SystemRequirements.php
+++ b/src/InstallBundle/Action/SystemRequirements.php
@@ -14,13 +14,32 @@ declare(strict_types=1);
 namespace SolidInvoice\InstallBundle\Action;
 
 use SolidInvoice\AppRequirements;
-use SolidInvoice\CoreBundle\Templating\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Response;
 
-final class SystemRequirements
+final class SystemRequirements extends AbstractController
 {
-    public function __invoke(): Template
+    public function __construct(
+        #[Autowire(env: 'SOLIDINVOICE_RUNTIME')]
+        private readonly ?string $runtime = null
+    ) {
+    }
+
+    public function __invoke(): Response
     {
-        return new Template(
+        if ('frankenphp' === $this->runtime) {
+            /*
+             * When running with Frankenphp, the correct php version,
+             * all the required extensions and php.ini config is already set,
+             * so no need to check the system requirements (which should always be valid).
+             * It will also confuse the user since they can't change anything
+             * that this page would display.
+             */
+            return $this->redirectToRoute('_install_config');
+        }
+
+        return $this->render(
             '@SolidInvoiceInstall/system_check.html.twig',
             [
                 'requirements' => new AppRequirements(),

--- a/src/InstallBundle/Resources/views/finish.html.twig
+++ b/src/InstallBundle/Resources/views/finish.html.twig
@@ -23,18 +23,22 @@
                         {{ "installation.finish.success_message"|trans }}
                     </h4>
 
-                    <div>
-                        <div class="alert alert-info">
-                            As a final step, you must add a scheduled task to run every 5 minutes.
+                    {% if runtime is same as('frankenphp') %}
+                        {# When running using Frankenphp, a Cron is automatically set up, #}
+                        {# so this step is not needed for the user. #}
+                        <div>
+                            <div class="alert alert-info">
+                                As a final step, you must add a scheduled task to run every minute.
+                            </div>
+                            <p>
+                                Add the following cron job:
+                                <br />
+                            <pre style="color: #c7254e;">
+    * * * * * php {{ binDir }}/console cron:run -e prod -n
+                            </pre>
+                            </p>
                         </div>
-                        <p>
-                            Add the following cron job:
-                            <br />
-                        <pre style="color: #c7254e;">
-* * * * * php {{ binDir }}/console cron:run -e prod -n
-                        </pre>
-                        </p>
-                    </div>
+                    {% endif %}
                 </div>
                 <div class="card-footer" id="next_button">
                     <a id="login" href="{{ path('_login') }}" class="btn-block btn btn-success">


### PR DESCRIPTION
Some steps during installation is not necessary when using Frankenphp since it might either be set up already of configured correctly and might cause confusion for the user or be something that they can't change (E.G system requirements, cron job etc)