### PR TITLE
Fix migrating uuid to ulid

### DIFF
--- a/migrations/Version20300.php
+++ b/migrations/Version20300.php
@@ -25,12 +25,12 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\Uuid;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
 use SolidInvoice\CoreBundle\Form\Type\BillingIdConfigurationType;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Uid\Ulid;
-use Symfony\Component\Uid\UuidV1;
 
 final class Version20300 extends AbstractMigration
 {
@@ -359,11 +359,11 @@ final class Version20300 extends AbstractMigration
                             continue;
                         }
 
-                        $originalId = $type->convertToPHPValue($id, $this->platform);
+                        $originalId = Uuid::fromBytes($id);
 
-                        $convertedId = Ulid::fromRfc4122(UuidV1::fromString($originalId->toString())->toV7()->toRfc4122())->toBinary();
+                        $convertedId = Ulid::fromString($originalId->toString());
 
-                        $this->connection->update($table, [$column => $convertedId], [$column => $id]);
+                        $this->connection->update($table, [$column => $convertedId->toBinary()], [$column => $id]);
                     }
                 }
             }


### PR DESCRIPTION
Fix migration when an UUID is invalid (E.G v8 instead of the expected v1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the conversion process from UUID to ULID during data migration for improved reliability and clarity. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->