### PR TITLE
Remove unneeded env vars from docker-compose.yml config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,6 @@ services:
     restart: always
     volumes:
       - app_data:/etc/solidinvoice
-    environment:
-      SOLIDINVOICE_DATABASE_DRIVER: pdo_mysql
-      SOLIDINVOICE_DATABASE_HOST: db
-      SOLIDINVOICE_DATABASE_PORT: 3306
-      SOLIDINVOICE_DATABASE_NAME: solidinvoice
-      SOLIDINVOICE_DATABASE_USER: root
-      SOLIDINVOICE_DATABASE_PASSWORD:
 
 volumes:
   db_data: {}


### PR DESCRIPTION
The DB env vars has been combined into a single value, so it's not needed to specify all the individual values anymore