### PR TITLE
Fix email templates

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -417,12 +417,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method SolidInvoice\\\\QuoteBundle\\\\Email\\\\QuoteEmail\\:\\:getContext\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/QuoteBundle/Email/QuoteEmail.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method SolidInvoice\\\\SettingsBundle\\\\Collection\\\\ConfigCollection\\:\\:add\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/SettingsBundle/Collection/ConfigCollection.php',
@@ -550,12 +544,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: method.notFound
 	'message' => '#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getEmail\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/UserBundle/Email/ResetPasswordEmail.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method SolidInvoice\\\\UserBundle\\\\Email\\\\ResetPasswordEmail\\:\\:getContext\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/UserBundle/Email/ResetPasswordEmail.php',
 ];

--- a/src/InvoiceBundle/Email/InvoiceEmail.php
+++ b/src/InvoiceBundle/Email/InvoiceEmail.php
@@ -22,23 +22,13 @@ final class InvoiceEmail extends TemplatedEmail
         private readonly Invoice $invoice
     ) {
         parent::__construct();
+
+        $this->htmlTemplate('@SolidInvoiceInvoice/Email/invoice.html.twig');
+        $this->context(['invoice' => $this->invoice]);
     }
 
     public function getInvoice(): Invoice
     {
         return $this->invoice;
-    }
-
-    public function getHtmlTemplate(): string
-    {
-        return '@SolidInvoiceInvoice/Email/invoice.html.twig';
-    }
-
-    /**
-     * @return array{invoice: Invoice}
-     */
-    public function getContext(): array
-    {
-        return \array_merge(['invoice' => $this->invoice], parent::getContext());
     }
 }

--- a/src/QuoteBundle/Email/QuoteEmail.php
+++ b/src/QuoteBundle/Email/QuoteEmail.php
@@ -22,20 +22,13 @@ final class QuoteEmail extends TemplatedEmail
         private readonly Quote $quote
     ) {
         parent::__construct();
+
+        $this->htmlTemplate('@SolidInvoiceQuote/Email/quote.html.twig');
+        $this->context(['quote' => $this->quote]);
     }
 
     public function getQuote(): Quote
     {
         return $this->quote;
-    }
-
-    public function getHtmlTemplate(): string
-    {
-        return '@SolidInvoiceQuote/Email/quote.html.twig';
-    }
-
-    public function getContext(): array
-    {
-        return \array_merge(['quote' => $this->quote], parent::getContext());
     }
 }

--- a/src/UserBundle/Email/ResetPasswordEmail.php
+++ b/src/UserBundle/Email/ResetPasswordEmail.php
@@ -24,20 +24,8 @@ final class ResetPasswordEmail extends TemplatedEmail
         parent::__construct();
         $this->to($user->getEmail());
         $this->subject('Password Reset Request');
-    }
-
-    public function getHtmlTemplate(): string
-    {
-        return '@SolidInvoiceUser/Email/reset_password.html.twig';
-    }
-
-    public function getTextTemplate(): string
-    {
-        return '@SolidInvoiceUser/Email/reset_password.txt.twig';
-    }
-
-    public function getContext(): array
-    {
-        return \array_merge(['user' => $this->user], parent::getContext());
+        $this->htmlTemplate('@SolidInvoiceUser/Email/reset_password.html.twig');
+        $this->textTemplate('@SolidInvoiceUser/Email/reset_password.txt.twig');
+        $this->context(['user' => $this->user]);
     }
 }


### PR DESCRIPTION
When sending an email, a log of the checks (E.G `isRendered`) depends on the actual properties in the object, so just overriding `getHtmlTemplate` doesn't work and causes the email to be not rendered. Instead we need to ensure the actual properties are set when sending the emails