### PR TITLE
Fix saving lines with decimal quantity

### DIFF
--- a/src/ApiBundle/Serializer/Normalizer/CreditNormalizer.php
+++ b/src/ApiBundle/Serializer/Normalizer/CreditNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Serializer\Normalizer;
 
+use Brick\Math\BigNumber;
 use SolidInvoice\ClientBundle\Entity\Credit;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
@@ -34,7 +35,8 @@ final class CreditNormalizer implements NormalizerAwareInterface, NormalizerInte
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if ($type === Credit::class) {
-            return (new Credit())->setValue($data);
+            $value = BigNumber::of($data)->toBigDecimal()->multipliedBy(100);
+            return (new Credit())->setValue($value);
         }
 
         return $this->denormalizer->denormalize($data, $type, $format, $context);

--- a/src/ApiBundle/Tests/Serializer/Normalizer/CreditNormalizerTest.php
+++ b/src/ApiBundle/Tests/Serializer/Normalizer/CreditNormalizerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\ApiBundle\Tests\Serializer\Normalizer;
 
 use ArrayObject;
+use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\ApiBundle\Serializer\Normalizer\CreditNormalizer;
@@ -170,6 +171,6 @@ final class CreditNormalizerTest extends TestCase
         $normalizer = new CreditNormalizer();
         $normalizer->setDenormalizer($parentNormalizer);
 
-        self::assertEquals((new Credit())->setValue(123), $normalizer->denormalize(123, Credit::class));
+        self::assertTrue(BigNumber::of(12300)->isEqualTo($normalizer->denormalize(123, Credit::class)->getValue()));
     }
 }

--- a/src/CoreBundle/Doctrine/Type/BigIntegerType.php
+++ b/src/CoreBundle/Doctrine/Type/BigIntegerType.php
@@ -11,7 +11,6 @@
 
 namespace SolidInvoice\CoreBundle\Doctrine\Type;
 
-use Brick\Math\BigDecimal;
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
@@ -56,16 +55,6 @@ final class BigIntegerType extends Type
 
         if ($value instanceof BigNumber) {
             try {
-
-                if (($value instanceof BigDecimal) && $value->getScale() > 0) {
-                    return $value->multipliedBy(
-                        100
-                        /*str_pad('1', $value->getScale() + 1, '0', STR_PAD_RIGHT)*/
-                    )
-                        ->toScale(0, RoundingMode::HALF_EVEN)
-                        ->toInt();
-                }
-
                 return $value->toScale(0, RoundingMode::HALF_EVEN)->toInt();
             } catch (MathException $e) {
                 throw ConversionException::conversionFailedSerialization($value, $this->getName(), $e::class, $e);

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -21,7 +21,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use Brick\Math\BigInteger;
+use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
 use Doctrine\DBAL\Types\Types;
@@ -150,8 +150,8 @@ class Line implements LineInterface, Stringable
 
     public function __construct()
     {
-        $this->total = BigInteger::zero();
-        $this->price = BigInteger::zero();
+        $this->total = BigDecimal::zero();
+        $this->price = BigDecimal::zero();
     }
 
     public function getId(): Ulid

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -69,7 +69,7 @@ final class RecurringInvoiceTest extends ApiTestCase
             ],
             'lines' => [
                 [
-                    'price' => 100.10,
+                    'price' => 100.1,
                     'qty' => 1.0,
                     'description' => 'Foo Line',
                 ],
@@ -111,8 +111,8 @@ final class RecurringInvoiceTest extends ApiTestCase
                 'endOccurrence' => 1,
             ],
             'status' => 'draft',
-            'total' => 9009,
-            'baseTotal' => 10010,
+            'total' => 90.09,
+            'baseTotal' => 100.1,
             'tax' => 0,
             'discount' => [
                 'type' => 'percentage',

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -21,7 +21,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use Brick\Math\BigInteger;
+use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\RoundingNecessaryException;
@@ -147,8 +147,8 @@ class Line implements LineInterface, Stringable
 
     public function __construct()
     {
-        $this->total = BigInteger::zero();
-        $this->price = BigInteger::zero();
+        $this->total = BigDecimal::zero();
+        $this->price = BigDecimal::zero();
     }
 
     public function getId(): Ulid


### PR DESCRIPTION
When saving lines with a decimal qty (E.G 0.5), then the price is incorrectly multiplied by 100 (E.G saving `100 * 0.5` gets saved as `5000.00` instead of `50.00`)