### PR TITLE
Remove gmp extension

### DIFF
--- a/frankenphp/build-static.sh
+++ b/frankenphp/build-static.sh
@@ -58,7 +58,8 @@ if [ -z "${PHP_VERSION}" ]; then
 	export PHP_VERSION
 fi
 # default extension set
-defaultExtensions="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,gmp,gettext,iconv,igbinary,imagick,intl,ldap,libxml,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,parallel,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,ssh2,sysvmsg,sysvsem,sysvshm,tidy,tokenizer,xlswriter,xml,xmlreader,xmlwriter,xsl,zip,zlib,yaml,zstd"
+# gmp causes crashes on older CPU archs, so we cannot include it
+defaultExtensions="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,gettext,iconv,igbinary,imagick,intl,ldap,libxml,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,parallel,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,ssh2,sysvmsg,sysvsem,sysvshm,tidy,tokenizer,xlswriter,xml,xmlreader,xmlwriter,xsl,zip,zlib,yaml,zstd"
 # if [ "${os}" != "linux" ] || [ "${SPC_LIBC}" = "glibc" ]; then
 # 	defaultExtensions="${defaultExtensions},ffi"
 # fi


### PR DESCRIPTION
GMP causes illegal instruction errors on older CPU archs, so we can't reliable bundle the gmp extension (`brick/math` uses gmp if it's available and falls back to `bcmath`, so for all instances we will be using `bcmath`).

Reference: https://github.com/dunglas/frankenphp/issues/1346

Fixes: https://github.com/SolidInvoice/SolidInvoice/issues/1736, https://github.com/SolidInvoice/SolidInvoice/issues/1648

gdb dump:

```
Thread 2.17 "php-0" received signal SIGILL, Illegal instruction.
[Switching to LWP 110]
0x00007fffed6dd10f in __gmpn_mul_1 ()
(gdb) bt
#0  0x00007fffed6dd10f in __gmpn_mul_1 ()
#1  0x00007fffed6d5851 in __gmpz_mul ()
#2  0x00007fffec5f1199 in gmp_zval_binary_ui_op (return_value=return_value@entry=0x7fff9f4130c0, a_arg=<optimized out>, b_arg=0x7fff9f413190, 
    gmp_op=gmp_op@entry=0x7fffed6d5717 <__gmpz_mul>, gmp_ui_op=gmp_ui_op@entry=0x7fffed6d5d46 <__gmpz_mul_ui>, check_b_zero=check_b_zero@entry=false, is_operator=false)
    at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/ext/gmp/gmp.c:816
#3  0x00007fffec5f46fd in _gmp_binary_ui_op (return_value=0x7fff9f4130c0, gmp_op=0x7fffed6d5717 <__gmpz_mul>, gmp_ui_op=0x7fffed6d5d46 <__gmpz_mul_ui>, check_b_zero=0, 
    execute_data=<optimized out>) at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/ext/gmp/gmp.c:885
#4  0x00007fffec4d351a in ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER () at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/Zend/zend_vm_execute.h:1337
#5  execute_ex (ex=<optimized out>) at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/Zend/zend_vm_execute.h:57246
#6  0x00007fffec4dd4cc in zend_execute (op_array=0x7fff9f460100, return_value=0x0) at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/Zend/zend_vm_execute.h:61634
#7  0x00007fffec479067 in zend_execute_scripts (type=type@entry=8, retval=retval@entry=0x0, file_count=file_count@entry=3)
    at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/Zend/zend.c:1895
#8  0x00007fffec42e157 in php_execute_script (primary_file=0x7fff9ffdd540) at /go/src/app/frankenphp/dist/static-php-cli/source/php-src/main/main.c:2545
#9  0x00007fffec3ab8d2 in frankenphp_execute_script (file_name=0xc000883630 "/root/.SolidInvoice/app_b6b7b58fd7b8dc5a81a725becc17b512/public/index.php") at frankenphp.c:987
#10 0x00007fffec3ab4a8 in php_thread (arg=0x0) at frankenphp.c:858
#11 0x00007fffec9d5306 in start (p=0x7fff9ffdd6f8) at src/thread/pthread_create.c:207
#12 0x00007fffec9d6a16 in __clone () at src/thread/x86_64/clone.s:22
Backtrace stopped: frame did not save the PC

```