### PR TITLE
Set logo size

### DIFF
--- a/src/CoreBundle/Listener/CompanyEventSubscriber.php
+++ b/src/CoreBundle/Listener/CompanyEventSubscriber.php
@@ -34,10 +34,10 @@ use function in_array;
 final class CompanyEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ?string $installed = null,
         private readonly RouterInterface $router,
         private readonly CompanySelector $companySelector,
-        private readonly Security $security
+        private readonly Security $security,
+        private readonly ?string $installed = null,
     ) {
     }
 

--- a/src/CoreBundle/Listener/CompanyEventSubscriber.php
+++ b/src/CoreBundle/Listener/CompanyEventSubscriber.php
@@ -34,6 +34,7 @@ use function in_array;
 final class CompanyEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
+        private readonly ?string $installed = null,
         private readonly RouterInterface $router,
         private readonly CompanySelector $companySelector,
         private readonly Security $security
@@ -51,7 +52,7 @@ final class CompanyEventSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (! $event->isMainRequest() || $request->attributes->get('_stateless')) {
+        if (null === $this->installed || ! $event->isMainRequest() || $request->attributes->get('_stateless')) {
             return;
         }
 

--- a/src/CoreBundle/Resources/views/Layout/Email/base.html.twig
+++ b/src/CoreBundle/Resources/views/Layout/Email/base.html.twig
@@ -37,7 +37,7 @@
                             <td class="pad">
                                 {% apply inky_to_html %}
                                     <row>
-                                        <columns large="6" style="padding:16px">{{- app_logo() -}}</columns>
+                                        <columns large="6" style="padding:16px">{{- app_logo(100) -}}</columns>
                                         <columns large="6" style="padding:16px;">
                                             <p class="text-right" style="font-size: 24px; font-weight: bold">
                                                 {{- setting('system/company/company_name') -}}

--- a/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
+++ b/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Uid\Ulid;
+use function date;
 use function strtoupper;
 
 /**
@@ -71,7 +72,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber($router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -110,7 +111,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber($router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -141,7 +142,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request->setSession($session);
         $request->attributes->set('_route', $route);
 
-        $listener = new CompanyEventSubscriber($router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -169,7 +170,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber($router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -198,7 +199,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber($router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);

--- a/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
+++ b/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
@@ -72,7 +72,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, date('Y'));
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -111,7 +111,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, date('Y'));
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -142,7 +142,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request->setSession($session);
         $request->attributes->set('_route', $route);
 
-        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, date('Y'));
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -170,7 +170,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, date('Y'));
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
@@ -199,7 +199,7 @@ final class CompanyEventSubscriberTest extends TestCase
         $request = new Request();
         $request->setSession($session);
 
-        $listener = new CompanyEventSubscriber(date('Y'), $router, $companySelector, $security);
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, date('Y'));
 
         $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);

--- a/src/InvoiceBundle/Action/View.php
+++ b/src/InvoiceBundle/Action/View.php
@@ -20,6 +20,7 @@ use SolidInvoice\CoreBundle\Templating\Template;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\PaymentBundle\Repository\PaymentRepository;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -40,7 +41,7 @@ final class View
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function __invoke(Request $request, Invoice $invoice): Template | PdfResponse
+    public function __invoke(Request $request, Invoice $invoice): Template | Response
     {
         if ('pdf' === $request->getRequestFormat() && $this->pdfGenerator->canPrintPdf()) {
             return new PdfResponse($this->pdfGenerator->generate($this->twig->render('@SolidInvoiceInvoice/Pdf/invoice.html.twig', ['invoice' => $invoice])), "invoice_{$invoice->getInvoiceId()}.pdf");

--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -39,7 +39,7 @@
 
 <htmlpageheader name="header">
     <h2 class="page-header">
-        {{ app_logo() }}
+        {{ app_logo(75) }}
         {{ setting('system/company/company_name') }}
     </h2>
 </htmlpageheader>

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -39,7 +39,7 @@
 
 <htmlpageheader name="header">
     <h2 class="page-header">
-        {{ app_logo() }}
+        {{ app_logo(75) }}
         {{ setting('system/company/company_name') }}
     </h2>
 </htmlpageheader>

--- a/src/SaasBundle/Resources/views/subscription/cancelled.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/cancelled.html.twig
@@ -1,7 +1,7 @@
 {% extends "@SolidInvoiceCore/Layout/default_no_nav.html.twig" %}
 
 {% block title %}
-    {{ app_logo() }}
+    {{ app_logo(75) }}
     {{ constant('SolidInvoice\\CoreBundle\\SolidInvoiceCoreBundle::APP_NAME') }}
     - {{ subscription.subscriber }}
 {% endblock title %}

--- a/src/SaasBundle/Resources/views/subscription/pending.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/pending.html.twig
@@ -1,7 +1,7 @@
 {% extends "@SolidInvoiceCore/Layout/default_no_nav.html.twig" %}
 
 {% block title %}
-    {{ app_logo() }}
+    {{ app_logo(75) }}
     {{ constant('SolidInvoice\\CoreBundle\\SolidInvoiceCoreBundle::APP_NAME') }}
     - {{ subscription.subscriber }}
 {% endblock title %}


### PR DESCRIPTION
Set a default logo size in most places to ensure the logo fits in the space provided.

Note: We can still physically resize the logo during upload to ensure we have a smaller image size and to have a default preferred size, but this can be implemented later.

Fixes #1636