### PR TITLE
Reduce size of logo on PDF files

### DIFF
--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -39,7 +39,7 @@
 
 <htmlpageheader name="header">
     <h2 class="page-header">
-        {{ app_logo(75) }}
+        {{ app_logo(55) }}
         {{ setting('system/company/company_name') }}
     </h2>
 </htmlpageheader>

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -39,7 +39,7 @@
 
 <htmlpageheader name="header">
     <h2 class="page-header">
-        {{ app_logo(75) }}
+        {{ app_logo(55) }}
         {{ setting('system/company/company_name') }}
     </h2>
 </htmlpageheader>


### PR DESCRIPTION
Reduce the size of the logo on PDF files to prevent larger logo's from displaying over invoice text

Fixes #1965