### PR TITLE
Remove automatically adding tax rates during installation

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10943,23 +10943,22 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.4",
+            "version": "v7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "c061c7c18918b1b64268771aad04b40be41dd2e6"
+                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/c061c7c18918b1b64268771aad04b40be41dd2e6",
-                "reference": "c061c7c18918b1b64268771aad04b40be41dd2e6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bd1af1e425811d6f077db240c3a588bdb405cd27",
+                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php83": "^1.27"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
                 "doctrine/dbal": "<3.6",
@@ -10968,13 +10967,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/mime": "^6.4|^7.0",
-                "symfony/rate-limiter": "^6.4|^7.0"
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -11002,7 +11001,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.4"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.1"
             },
             "funding": [
                 {
@@ -11022,7 +11021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-16T08:38:17+00:00"
+            "time": "2025-12-07T11:13:10+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -24234,5 +24233,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/InstallBundle/Action/Setup.php
+++ b/src/InstallBundle/Action/Setup.php
@@ -24,7 +24,6 @@ use SolidInvoice\CoreBundle\Repository\VersionRepository;
 use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
 use SolidInvoice\CoreBundle\Templating\Template;
 use SolidInvoice\InstallBundle\Form\Step\SystemInformationForm;
-use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -153,21 +152,6 @@ final class Setup
         ];
 
         $this->configWriter->save($config);
-
-        $countryCode = explode('_', $data['locale'])[1] ?? $data['locale'];
-
-        if ($this->vatCalculator->shouldCollectVAT($countryCode)) {
-            $rate = $this->vatCalculator->getTaxRateForCountry($countryCode);
-
-            $tax = new Tax();
-            $tax->setRate($rate * 100)
-                ->setType(Tax::TYPE_INCLUSIVE)
-                ->setName('VAT');
-
-            $em = $this->doctrine->getManager();
-            $em->persist($tax);
-            $em->flush();
-        }
     }
 
     private function render(FormInterface $form): Template

--- a/src/InstallBundle/Action/Setup.php
+++ b/src/InstallBundle/Action/Setup.php
@@ -17,7 +17,6 @@ use DateTime;
 use DateTimeInterface;
 use Defuse\Crypto\Exception\EnvironmentIsBrokenException;
 use Doctrine\Persistence\ManagerRegistry;
-use Mpociot\VatCalculator\VatCalculator;
 use SolidInvoice\CoreBundle\ConfigWriter;
 use SolidInvoice\CoreBundle\Entity\Version;
 use SolidInvoice\CoreBundle\Repository\VersionRepository;
@@ -33,15 +32,14 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Throwable;
 
-final class Setup
+final readonly class Setup
 {
     public function __construct(
-        private readonly PasswordHasherFactoryInterface $passwordHasherFactory,
-        private readonly FormFactoryInterface $formFactory,
-        private readonly ManagerRegistry $doctrine,
-        private readonly ConfigWriter $configWriter,
-        private readonly VatCalculator $vatCalculator,
-        private readonly RouterInterface $router
+        private PasswordHasherFactoryInterface $passwordHasherFactory,
+        private FormFactoryInterface $formFactory,
+        private ManagerRegistry $doctrine,
+        private ConfigWriter $configWriter,
+        private RouterInterface $router
     ) {
     }
 
@@ -76,7 +74,7 @@ final class Setup
     /**
      * @throws EnvironmentIsBrokenException|Throwable
      */
-    public function handleForm(Request $request): Template|RedirectResponse
+    public function handleForm(Request $request): Template | RedirectResponse
     {
         $form = $this->getForm();
 

--- a/src/MenuBundle/Builder/MenuBuilder.php
+++ b/src/MenuBundle/Builder/MenuBuilder.php
@@ -21,8 +21,8 @@ use SolidInvoice\MenuBundle\MenuItem;
 final class MenuBuilder
 {
     public function __construct(
-        protected BuilderInterface $class,
-        protected string $method
+        private BuilderInterface $class,
+        private string $method
     ) {
     }
 


### PR DESCRIPTION
During installation, a company is not created. Automatically adding a tax rate based on the locale breaks due to integrity constraints (the tax rate must be linked to a company). Remove this part since we can't reliable create a tax rate during installation

Fixes #2184