### PR TITLE
Add UserSettings feature for storing user-specific settings

### DIFF
--- a/migrations/Version20000.php
+++ b/migrations/Version20000.php
@@ -27,7 +27,7 @@ final class Version20000 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20100.php
+++ b/migrations/Version20100.php
@@ -29,7 +29,7 @@ final class Version20100 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20200.php
+++ b/migrations/Version20200.php
@@ -75,7 +75,7 @@ final class Version20200 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -47,7 +47,7 @@ final class Version20201 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void

--- a/migrations/Version20202.php
+++ b/migrations/Version20202.php
@@ -22,7 +22,7 @@ final class Version20202 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20300.php
+++ b/migrations/Version20300.php
@@ -40,7 +40,7 @@ final class Version20300 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void

--- a/migrations/Version20305.php
+++ b/migrations/Version20305.php
@@ -26,7 +26,7 @@ final class Version20305 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20306.php
+++ b/migrations/Version20306.php
@@ -25,7 +25,7 @@ final class Version20306 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_1.php
+++ b/migrations/Version30000_1.php
@@ -29,7 +29,7 @@ final class Version30000_1 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_1.php
+++ b/migrations/Version30000_1.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+
+final class Version30000_1 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user_settings table for storing user-specific settings';
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof OraclePlatform;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $userSettingsTable = $schema->createTable('user_settings');
+
+        $userSettingsTable->addColumn('id', UlidType::NAME);
+        $userSettingsTable->addColumn('user_id', UlidType::NAME, ['notnull' => true]);
+        $userSettingsTable->addColumn('setting_key', Types::STRING, ['length' => 125, 'notnull' => true]);
+        $userSettingsTable->addColumn('setting_value', Types::TEXT, ['notnull' => false]);
+        $userSettingsTable->addColumn('created', Types::DATETIME_MUTABLE, ['notnull' => false]);
+        $userSettingsTable->addColumn('updated', Types::DATETIME_MUTABLE, ['notnull' => false]);
+
+        $userSettingsTable->setPrimaryKey(['id']);
+        $userSettingsTable->addUniqueIndex(['setting_key', 'user_id'], 'unique_user_setting');
+        $userSettingsTable->addForeignKeyConstraint('users', ['user_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('user_settings');
+    }
+}

--- a/src/InstallBundle/Tests/Functional/InstallationTest.php
+++ b/src/InstallBundle/Tests/Functional/InstallationTest.php
@@ -105,6 +105,7 @@ final class InstallationTest extends PantherTestCase
             )
             ->assertSee('Database Config')
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('button[name="installation[navigator][next]"]')
@@ -248,6 +249,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[database_config][driver]"][value="sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -275,6 +277,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[database_config][driver]"][value="sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -306,6 +309,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[database_config][driver]"][value="sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -349,6 +353,7 @@ final class InstallationTest extends PantherTestCase
             )
             ->assertSee('Database Config')
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -399,6 +404,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('label[data-testid="database-driver-sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -471,6 +477,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[database_config][driver]"][value="sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
@@ -514,6 +521,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[database_config][driver]"][value="sqlite"]')
             )
             ->click('label[data-testid="database-driver-sqlite"]')
+            ->wait(200)
             ->click('button[name="installation[navigator][next]"]')
             ->use(
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')

--- a/src/UserBundle/Config/UserConfig.php
+++ b/src/UserBundle/Config/UserConfig.php
@@ -29,7 +29,7 @@ readonly class UserConfig
     public function get(UserSettingType $key, ?User $user = null): ?string
     {
         $user ??= $this->security->getUser();
-        /** @var User $user */
+        /** @var User|null $user */
 
         if (null === $user) {
             return null;
@@ -41,7 +41,7 @@ readonly class UserConfig
     public function set(UserSettingType $key, ?string $value, ?User $user = null): void
     {
         $user ??= $this->security->getUser();
-        /** @var User $user */
+        /** @var User|null $user */
 
         if (null === $user) {
             return;
@@ -53,7 +53,7 @@ readonly class UserConfig
     public function has(UserSettingType $key, ?User $user = null): bool
     {
         $user ??= $this->security->getUser();
-        /** @var User $user */
+        /** @var User|null $user */
 
         if (null === $user) {
             return false;
@@ -65,7 +65,7 @@ readonly class UserConfig
     public function remove(UserSettingType $key, ?User $user = null): void
     {
         $user ??= $this->security->getUser();
-        /** @var User $user */
+        /** @var User|null $user */
 
         if (null === $user) {
             return;
@@ -80,7 +80,7 @@ readonly class UserConfig
     public function getAll(?User $user = null): array
     {
         $user ??= $this->security->getUser();
-        /** @var User $user */
+        /** @var User|null $user */
 
         if (null === $user) {
             return [];

--- a/src/UserBundle/Config/UserConfig.php
+++ b/src/UserBundle/Config/UserConfig.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Config;
+
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+use SolidInvoice\UserBundle\Repository\UserSettingRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+readonly class UserConfig
+{
+    public function __construct(
+        private UserSettingRepositoryInterface $repository,
+        private Security $security,
+    ) {
+    }
+
+    public function get(UserSettingType $key, ?User $user = null): ?string
+    {
+        $user ??= $this->security->getUser();
+        /** @var User $user */
+
+        if (null === $user) {
+            return null;
+        }
+
+        return $this->repository->getSetting($user, $key)?->getValue();
+    }
+
+    public function set(UserSettingType $key, ?string $value, ?User $user = null): void
+    {
+        $user ??= $this->security->getUser();
+        /** @var User $user */
+
+        if (null === $user) {
+            return;
+        }
+
+        $this->repository->saveSetting($user, $key, $value);
+    }
+
+    public function has(UserSettingType $key, ?User $user = null): bool
+    {
+        $user ??= $this->security->getUser();
+        /** @var User $user */
+
+        if (null === $user) {
+            return false;
+        }
+
+        return null !== $this->repository->getSetting($user, $key);
+    }
+
+    public function remove(UserSettingType $key, ?User $user = null): void
+    {
+        $user ??= $this->security->getUser();
+        /** @var User $user */
+
+        if (null === $user) {
+            return;
+        }
+
+        $this->repository->remove($user, $key);
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function getAll(?User $user = null): array
+    {
+        $user ??= $this->security->getUser();
+        /** @var User $user */
+
+        if (null === $user) {
+            return [];
+        }
+
+        return $this->repository->getAllForUser($user);
+    }
+}

--- a/src/UserBundle/Entity/UserSetting.php
+++ b/src/UserBundle/Entity/UserSetting.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+use SolidInvoice\UserBundle\Repository\UserSettingRepository;
+use Stringable;
+use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Table(name: UserSetting::TABLE_NAME)]
+#[ORM\UniqueConstraint(columns: ['setting_key', 'user_id'])]
+#[ORM\Entity(repositoryClass: UserSettingRepository::class)]
+#[UniqueEntity(fields: ['key', 'user'])]
+class UserSetting implements Stringable
+{
+    final public const string TABLE_NAME = 'user_settings';
+
+    use TimeStampable;
+
+    #[ORM\Column(name: 'id', type: UlidType::NAME)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
+    private ?Ulid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', nullable: false)]
+    private User $user;
+
+    #[ORM\Column(name: 'setting_key', type: Types::STRING, length: 125, enumType: UserSettingType::class)]
+    private UserSettingType $key;
+
+    #[ORM\Column(name: 'setting_value', type: Types::TEXT, nullable: true)]
+    private ?string $value = null;
+
+    public function getId(): ?Ulid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getKey(): UserSettingType
+    {
+        return $this->key;
+    }
+
+    public function setKey(UserSettingType $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    public function setValue(?string $value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/UserBundle/Enum/UserSettingType.php
+++ b/src/UserBundle/Enum/UserSettingType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Enum;
+
+enum UserSettingType: string
+{
+    case Timezone = 'timezone';
+    case Location = 'location';
+    case OnboardComplete = 'onboard_complete';
+}

--- a/src/UserBundle/Repository/UserSettingRepository.php
+++ b/src/UserBundle/Repository/UserSettingRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Entity\UserSetting;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
+
+/**
+ * @extends EntityRepository<UserSetting>
+ */
+final class UserSettingRepository extends EntityRepository implements UserSettingRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserSetting::class);
+    }
+
+    public function getSetting(User $user, UserSettingType $key): ?UserSetting
+    {
+        return $this->findOneBy([
+            'user' => $user,
+            'key' => $key,
+        ]);
+    }
+
+    public function saveSetting(User $user, UserSettingType $key, ?string $value): void
+    {
+        $setting = $this->getSetting($user, $key);
+
+        if (null === $setting) {
+            $setting = new UserSetting();
+            $setting->setUser($user);
+            $setting->setKey($key);
+        }
+
+        $setting->setValue($value);
+
+        $this->getEntityManager()->persist($setting);
+        $this->getEntityManager()->flush();
+    }
+
+    public function remove(User $user, UserSettingType $key): void
+    {
+        $setting = $this->getSetting($user, $key);
+
+        if (null !== $setting) {
+            $this->getEntityManager()->remove($setting);
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function getAllForUser(User $user): array
+    {
+        $settings = $this->findBy(['user' => $user]);
+
+        $result = [];
+        foreach ($settings as $setting) {
+            $result[$setting->getKey()->value] = $setting->getValue();
+        }
+
+        return $result;
+    }
+}

--- a/src/UserBundle/Repository/UserSettingRepositoryInterface.php
+++ b/src/UserBundle/Repository/UserSettingRepositoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Repository;
+
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Entity\UserSetting;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+
+interface UserSettingRepositoryInterface
+{
+    public function getSetting(User $user, UserSettingType $key): ?UserSetting;
+
+    public function saveSetting(User $user, UserSettingType $key, ?string $value): void;
+
+    public function remove(User $user, UserSettingType $key): void;
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function getAllForUser(User $user): array;
+}

--- a/src/UserBundle/Resources/config/services/services.php
+++ b/src/UserBundle/Resources/config/services/services.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 use SolidInvoice\UserBundle\Repository\UserRepository;
 use SolidInvoice\UserBundle\Repository\UserRepositoryInterface;
+use SolidInvoice\UserBundle\Repository\UserSettingRepository;
+use SolidInvoice\UserBundle\Repository\UserSettingRepositoryInterface;
 use SolidInvoice\UserBundle\SolidInvoiceUserBundle;
 use SolidWorx\Platform\PlatformBundle\Contracts\Doctrine\Repository\UserRepository as PlatformUserRepository;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -36,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->alias(UserRepositoryInterface::class, UserRepository::class);
     $services->alias(PlatformUserRepository::class, UserRepository::class);
+    $services->alias(UserSettingRepositoryInterface::class, UserSettingRepository::class);
 
     $services
         ->load(SolidInvoiceUserBundle::NAMESPACE . '\\DataFixtures\\ORM\\', dirname(__DIR__, 3) . '/DataFixtures/ORM/*')

--- a/src/UserBundle/Tests/Config/UserConfigTest.php
+++ b/src/UserBundle/Tests/Config/UserConfigTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Config;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\UserBundle\Config\UserConfig;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Entity\UserSetting;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+use SolidInvoice\UserBundle\Repository\UserSettingRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @covers \SolidInvoice\UserBundle\Config\UserConfig
+ */
+final class UserConfigTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private m\MockInterface&UserSettingRepositoryInterface $repository;
+
+    private m\MockInterface&Security $security;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = m::mock(UserSettingRepositoryInterface::class);
+        $this->security = m::mock(Security::class);
+        $this->user = new User();
+        $this->user->setEmail('test@example.com');
+    }
+
+    public function testGetWithCurrentUser(): void
+    {
+        $setting = $this->createSetting(UserSettingType::Timezone, 'Europe/London');
+
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('getSetting')
+            ->with($this->user, UserSettingType::Timezone)
+            ->andReturn($setting);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertSame('Europe/London', $config->get(UserSettingType::Timezone));
+    }
+
+    public function testGetWithSpecificUser(): void
+    {
+        $specificUser = new User();
+        $specificUser->setEmail('other@example.com');
+
+        $setting = $this->createSetting(UserSettingType::Timezone, 'America/New_York');
+
+        $this->repository->shouldReceive('getSetting')
+            ->with($specificUser, UserSettingType::Timezone)
+            ->andReturn($setting);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertSame('America/New_York', $config->get(UserSettingType::Timezone, $specificUser));
+    }
+
+    public function testGetReturnsNullWhenSettingDoesNotExist(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('getSetting')
+            ->with($this->user, UserSettingType::Timezone)
+            ->andReturn(null);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertNull($config->get(UserSettingType::Timezone));
+    }
+
+    public function testGetReturnsNullWhenNoUserLoggedIn(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn(null);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertNull($config->get(UserSettingType::Timezone));
+    }
+
+    public function testSetWithCurrentUser(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('saveSetting')
+            ->once()
+            ->with($this->user, UserSettingType::Timezone, 'UTC');
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->set(UserSettingType::Timezone, 'UTC');
+    }
+
+    public function testSetWithSpecificUser(): void
+    {
+        $specificUser = new User();
+        $specificUser->setEmail('other@example.com');
+
+        $this->repository->shouldReceive('saveSetting')
+            ->once()
+            ->with($specificUser, UserSettingType::Location, 'London');
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->set(UserSettingType::Location, 'London', $specificUser);
+    }
+
+    public function testSetDoesNothingWhenNoUserLoggedIn(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn(null);
+        $this->repository->shouldNotReceive('saveSetting');
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->set(UserSettingType::Timezone, 'UTC');
+    }
+
+    public function testHasReturnsTrueWhenSettingExists(): void
+    {
+        $setting = $this->createSetting(UserSettingType::OnboardComplete, '1');
+
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('getSetting')
+            ->with($this->user, UserSettingType::OnboardComplete)
+            ->andReturn($setting);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertTrue($config->has(UserSettingType::OnboardComplete));
+    }
+
+    public function testHasReturnsFalseWhenSettingDoesNotExist(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('getSetting')
+            ->with($this->user, UserSettingType::OnboardComplete)
+            ->andReturn(null);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertFalse($config->has(UserSettingType::OnboardComplete));
+    }
+
+    public function testHasReturnsFalseWhenNoUserLoggedIn(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn(null);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertFalse($config->has(UserSettingType::OnboardComplete));
+    }
+
+    public function testRemoveWithCurrentUser(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('remove')
+            ->once()
+            ->with($this->user, UserSettingType::Timezone);
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->remove(UserSettingType::Timezone);
+    }
+
+    public function testRemoveWithSpecificUser(): void
+    {
+        $specificUser = new User();
+        $specificUser->setEmail('other@example.com');
+
+        $this->repository->shouldReceive('remove')
+            ->once()
+            ->with($specificUser, UserSettingType::Timezone);
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->remove(UserSettingType::Timezone, $specificUser);
+    }
+
+    public function testRemoveDoesNothingWhenNoUserLoggedIn(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn(null);
+        $this->repository->shouldNotReceive('remove');
+
+        $config = new UserConfig($this->repository, $this->security);
+        $config->remove(UserSettingType::Timezone);
+    }
+
+    public function testGetAllWithCurrentUser(): void
+    {
+        $expectedSettings = [
+            'timezone' => 'Europe/London',
+            'location' => 'London',
+        ];
+
+        $this->security->shouldReceive('getUser')->andReturn($this->user);
+        $this->repository->shouldReceive('getAllForUser')
+            ->with($this->user)
+            ->andReturn($expectedSettings);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertSame($expectedSettings, $config->getAll());
+    }
+
+    public function testGetAllWithSpecificUser(): void
+    {
+        $specificUser = new User();
+        $specificUser->setEmail('other@example.com');
+
+        $expectedSettings = [
+            'timezone' => 'America/New_York',
+        ];
+
+        $this->repository->shouldReceive('getAllForUser')
+            ->with($specificUser)
+            ->andReturn($expectedSettings);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertSame($expectedSettings, $config->getAll($specificUser));
+    }
+
+    public function testGetAllReturnsEmptyArrayWhenNoUserLoggedIn(): void
+    {
+        $this->security->shouldReceive('getUser')->andReturn(null);
+
+        $config = new UserConfig($this->repository, $this->security);
+
+        self::assertSame([], $config->getAll());
+    }
+
+    private function createSetting(UserSettingType $key, ?string $value): UserSetting
+    {
+        $setting = new UserSetting();
+        $setting->setUser($this->user);
+        $setting->setKey($key);
+        $setting->setValue($value);
+
+        return $setting;
+    }
+}

--- a/src/UserBundle/Tests/Repository/UserSettingRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserSettingRepositoryTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SolidInvoice\CoreBundle\Test\Traits\FakerTestTrait;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Entity\UserSetting;
+use SolidInvoice\UserBundle\Enum\UserSettingType;
+use SolidInvoice\UserBundle\Repository\UserSettingRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \SolidInvoice\UserBundle\Repository\UserSettingRepository
+ */
+final class UserSettingRepositoryTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use FakerTestTrait;
+
+    private UserSettingRepository $repository;
+
+    private EntityManagerInterface $em;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $registry = self::getContainer()->get('doctrine');
+        $em = $registry->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $repository = self::getContainer()->get(UserSettingRepository::class);
+        assert($repository instanceof UserSettingRepository);
+        $this->repository = $repository;
+
+        // Create a test user
+        $this->user = new User();
+        $this->user->setEmail($this->getFaker()->email())
+            ->setPassword($this->getFaker()->password())
+            ->addCompany($this->company);
+
+        $this->em->persist($this->user);
+        $this->em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up user settings
+        foreach ($this->repository->findAll() as $setting) {
+            $this->em->remove($setting);
+        }
+
+        $this->em->flush();
+
+        parent::tearDown();
+    }
+
+    public function testGetSetting(): void
+    {
+        $setting = new UserSetting();
+        $setting->setUser($this->user);
+        $setting->setKey(UserSettingType::Timezone);
+        $setting->setValue('Europe/London');
+
+        $this->em->persist($setting);
+        $this->em->flush();
+
+        $result = $this->repository->getSetting($this->user, UserSettingType::Timezone);
+
+        self::assertNotNull($result);
+        self::assertSame('Europe/London', $result->getValue());
+        self::assertSame(UserSettingType::Timezone, $result->getKey());
+        self::assertSame($this->user->getId()->toRfc4122(), $result->getUser()->getId()->toRfc4122());
+    }
+
+    public function testGetSettingReturnsNullWhenNotFound(): void
+    {
+        $result = $this->repository->getSetting($this->user, UserSettingType::Timezone);
+
+        self::assertNull($result);
+    }
+
+    public function testSaveSettingCreatesNewSetting(): void
+    {
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'America/New_York');
+
+        $setting = $this->repository->getSetting($this->user, UserSettingType::Timezone);
+
+        self::assertNotNull($setting);
+        self::assertSame('America/New_York', $setting->getValue());
+        self::assertSame(UserSettingType::Timezone, $setting->getKey());
+    }
+
+    public function testSaveSettingUpdatesExistingSetting(): void
+    {
+        // Create initial setting
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'Europe/London');
+
+        // Update the setting
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'Asia/Tokyo');
+
+        $setting = $this->repository->getSetting($this->user, UserSettingType::Timezone);
+
+        self::assertNotNull($setting);
+        self::assertSame('Asia/Tokyo', $setting->getValue());
+
+        // Ensure only one setting exists
+        self::assertCount(1, $this->repository->findAll());
+    }
+
+    public function testSaveSettingWithNullValue(): void
+    {
+        $this->repository->saveSetting($this->user, UserSettingType::Location, null);
+
+        $setting = $this->repository->getSetting($this->user, UserSettingType::Location);
+
+        self::assertNotNull($setting);
+        self::assertNull($setting->getValue());
+    }
+
+    public function testRemove(): void
+    {
+        // Create a setting
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'Europe/London');
+
+        self::assertNotNull($this->repository->getSetting($this->user, UserSettingType::Timezone));
+
+        // Remove it
+        $this->repository->remove($this->user, UserSettingType::Timezone);
+
+        self::assertNull($this->repository->getSetting($this->user, UserSettingType::Timezone));
+    }
+
+    public function testRemoveDoesNothingWhenSettingDoesNotExist(): void
+    {
+        // This should not throw an exception
+        $this->repository->remove($this->user, UserSettingType::Timezone);
+
+        self::assertNull($this->repository->getSetting($this->user, UserSettingType::Timezone));
+    }
+
+    public function testGetAllForUser(): void
+    {
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'Europe/London');
+        $this->repository->saveSetting($this->user, UserSettingType::Location, 'London');
+        $this->repository->saveSetting($this->user, UserSettingType::OnboardComplete, '1');
+
+        $result = $this->repository->getAllForUser($this->user);
+
+        self::assertCount(3, $result);
+        self::assertSame('Europe/London', $result['timezone']);
+        self::assertSame('London', $result['location']);
+        self::assertSame('1', $result['onboard_complete']);
+    }
+
+    public function testGetAllForUserReturnsEmptyArrayWhenNoSettings(): void
+    {
+        $result = $this->repository->getAllForUser($this->user);
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetAllForUserOnlyReturnsSettingsForSpecificUser(): void
+    {
+        // Create another user
+        $otherUser = new User();
+        $otherUser->setEmail($this->getFaker()->email())
+            ->setPassword($this->getFaker()->password())
+            ->addCompany($this->company);
+
+        $this->em->persist($otherUser);
+        $this->em->flush();
+
+        // Create settings for both users
+        $this->repository->saveSetting($this->user, UserSettingType::Timezone, 'Europe/London');
+        $this->repository->saveSetting($otherUser, UserSettingType::Timezone, 'America/New_York');
+        $this->repository->saveSetting($otherUser, UserSettingType::Location, 'New York');
+
+        // Get settings for first user
+        $result = $this->repository->getAllForUser($this->user);
+
+        self::assertCount(1, $result);
+        self::assertSame('Europe/London', $result['timezone']);
+        self::assertArrayNotHasKey('location', $result);
+    }
+}


### PR DESCRIPTION
- Add UserSetting entity with key-value storage linked to User
- Add UserSettingType enum for type-safe setting keys (Timezone, Location, OnboardComplete)
- Add UserSettingRepository with methods for get, save, remove, and getAll
- Add UserSettingRepositoryInterface to enable proper dependency injection
- Add UserConfig service for clean API to manage user settings
- Add database migration (Version30000_1) creating user_settings table
- Add comprehensive unit tests for UserConfig service
- Add functional tests for UserSettingRepository
- Register repository as service in UserBundle