### PR TITLE
Remove HTML sanitization options from ContactDetailType

### DIFF
--- a/src/ClientBundle/Form/Type/ContactDetailType.php
+++ b/src/ClientBundle/Form/Type/ContactDetailType.php
@@ -55,8 +55,6 @@ final class ContactDetailType extends AbstractType
                     new NotBlank(['groups' => 'not_blank']),
                     new Email(['groups' => 'email']),
                 ],
-                'sanitize_html' => true,
-                'allow_single_quotes' => true,
             ]
         );
     }


### PR DESCRIPTION
## Summary
Removed HTML sanitization and single quote handling options from the email field configuration in the ContactDetailType form.

## Changes
- Removed `'sanitize_html' => true` option from the email field
- Removed `'allow_single_quotes' => true` option from the email field

## Details
These options were unnecessary for email field validation since:
1. Email fields have built-in validation constraints (NotBlank and Email validators)
2. HTML sanitization is not applicable to email input fields
3. Email format validation inherently restricts the allowed character set

This cleanup simplifies the form configuration and removes redundant settings that don't affect email field behavior.

Fixes #2270