### PR TITLE
fix: display actual discount amount instead of raw percentage in grids

### DIFF
--- a/src/InvoiceBundle/DataGrid/BaseInvoiceGrid.php
+++ b/src/InvoiceBundle/DataGrid/BaseInvoiceGrid.php
@@ -28,9 +28,15 @@ use SolidInvoice\DataGridBundle\Source\ORMSource;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Model\Graph;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
+use SolidInvoice\MoneyBundle\Calculator;
 
 abstract class BaseInvoiceGrid extends Grid
 {
+    public function __construct(
+        protected readonly Calculator $calculator,
+    ) {
+    }
+
     public function entityFQCN(): string
     {
         return Invoice::class;
@@ -67,7 +73,7 @@ abstract class BaseInvoiceGrid extends Grid
                 ->label('Discount')
                 ->searchable(false)
                 ->formatValue(function (float | BigNumber $value, Invoice $invoice): Money {
-                    $discountAmount = $invoice->getBaseTotal()->toBigDecimal()->plus($invoice->getTax())->minus($invoice->getTotal());
+                    $discountAmount = $this->calculator->calculateDiscount($invoice);
 
                     return new Money((string) $discountAmount, $invoice->getClient()?->getCurrency());
                 }),

--- a/src/InvoiceBundle/DataGrid/BaseInvoiceGrid.php
+++ b/src/InvoiceBundle/DataGrid/BaseInvoiceGrid.php
@@ -66,7 +66,11 @@ abstract class BaseInvoiceGrid extends Grid
             MoneyColumn::new('discount.value')
                 ->label('Discount')
                 ->searchable(false)
-                ->formatValue(fn (float | BigNumber $value, Invoice $invoice) => new Money((string) $value, $invoice->getClient()?->getCurrency())),
+                ->formatValue(function (float | BigNumber $value, Invoice $invoice): Money {
+                    $discountAmount = $invoice->getBaseTotal()->toBigDecimal()->plus($invoice->getTax())->minus($invoice->getTotal());
+
+                    return new Money((string) $discountAmount, $invoice->getClient()?->getCurrency());
+                }),
         ];
     }
 

--- a/src/InvoiceBundle/DataGrid/RecurringInvoiceGrid.php
+++ b/src/InvoiceBundle/DataGrid/RecurringInvoiceGrid.php
@@ -73,7 +73,11 @@ final class RecurringInvoiceGrid extends Grid
             MoneyColumn::new('discount.value')
                 ->label('Discount')
                 ->searchable(false)
-                ->formatValue(fn (float|BigNumber $value, RecurringInvoice $invoice) => new Money((string) $value, $invoice->getClient()?->getCurrency())),
+                ->formatValue(function (float|BigNumber $value, RecurringInvoice $invoice): Money {
+                    $discountAmount = $invoice->getBaseTotal()->toBigDecimal()->plus($invoice->getTax())->minus($invoice->getTotal());
+
+                    return new Money((string) $discountAmount, $invoice->getClient()?->getCurrency());
+                }),
         ];
     }
 

--- a/src/InvoiceBundle/DataGrid/RecurringInvoiceGrid.php
+++ b/src/InvoiceBundle/DataGrid/RecurringInvoiceGrid.php
@@ -28,6 +28,7 @@ use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Model\Graph;
 use SolidInvoice\InvoiceBundle\Recurring\RecurringSchedule;
 use SolidInvoice\InvoiceBundle\Repository\RecurringInvoiceRepository;
+use SolidInvoice\MoneyBundle\Calculator;
 
 #[AsDataGrid(name: self::GRID_NAME, title: 'Recurring Invoices')]
 final class RecurringInvoiceGrid extends Grid
@@ -35,9 +36,9 @@ final class RecurringInvoiceGrid extends Grid
     final public const GRID_NAME = 'recurring_invoice_grid';
 
     public function __construct(
-        private readonly RecurringSchedule $schedule
+        private readonly RecurringSchedule $schedule,
+        private readonly Calculator $calculator,
     ) {
-
     }
 
     public function entityFQCN(): string
@@ -74,7 +75,7 @@ final class RecurringInvoiceGrid extends Grid
                 ->label('Discount')
                 ->searchable(false)
                 ->formatValue(function (float|BigNumber $value, RecurringInvoice $invoice): Money {
-                    $discountAmount = $invoice->getBaseTotal()->toBigDecimal()->plus($invoice->getTax())->minus($invoice->getTotal());
+                    $discountAmount = $this->calculator->calculateDiscount($invoice);
 
                     return new Money((string) $discountAmount, $invoice->getClient()?->getCurrency());
                 }),

--- a/src/QuoteBundle/DataGrid/BaseQuoteGrid.php
+++ b/src/QuoteBundle/DataGrid/BaseQuoteGrid.php
@@ -51,7 +51,11 @@ abstract class BaseQuoteGrid extends Grid
             MoneyColumn::new('discount.value')
                 ->label('Discount')
                 ->searchable(false)
-                ->formatValue(fn (float|BigNumber $value, Quote $quote) => new Money((string) $value, $quote->getClient()?->getCurrency())),
+                ->formatValue(function (float|BigNumber $value, Quote $quote): Money {
+                    $discountAmount = $quote->getBaseTotal()->toBigDecimal()->plus($quote->getTax())->minus($quote->getTotal());
+
+                    return new Money((string) $discountAmount, $quote->getClient()?->getCurrency());
+                }),
             DateTimeColumn::new('created')
                 ->format('d F Y')
                 ->filter(new DateRangeFilter('created'))

--- a/src/QuoteBundle/DataGrid/BaseQuoteGrid.php
+++ b/src/QuoteBundle/DataGrid/BaseQuoteGrid.php
@@ -22,12 +22,18 @@ use SolidInvoice\DataGridBundle\GridBuilder\Column\MoneyColumn;
 use SolidInvoice\DataGridBundle\GridBuilder\Column\StringColumn;
 use SolidInvoice\DataGridBundle\GridBuilder\Filter\ChoiceFilter;
 use SolidInvoice\DataGridBundle\GridBuilder\Filter\DateRangeFilter;
+use SolidInvoice\MoneyBundle\Calculator;
 use SolidInvoice\QuoteBundle\Entity\Quote;
 use SolidInvoice\QuoteBundle\Model\Graph;
 use SolidInvoice\QuoteBundle\Repository\QuoteRepository;
 
 abstract class BaseQuoteGrid extends Grid
 {
+    public function __construct(
+        protected readonly Calculator $calculator,
+    ) {
+    }
+
     public function entityFQCN(): string
     {
         return Quote::class;
@@ -52,7 +58,7 @@ abstract class BaseQuoteGrid extends Grid
                 ->label('Discount')
                 ->searchable(false)
                 ->formatValue(function (float|BigNumber $value, Quote $quote): Money {
-                    $discountAmount = $quote->getBaseTotal()->toBigDecimal()->plus($quote->getTax())->minus($quote->getTotal());
+                    $discountAmount = $this->calculator->calculateDiscount($quote);
 
                     return new Money((string) $discountAmount, $quote->getClient()?->getCurrency());
                 }),


### PR DESCRIPTION
The discount column in invoice, recurring invoice, and quote list views
was displaying the raw discount.value (the percentage number) as a
currency amount. For example, a 50% discount on a £200 invoice showed
£50 instead of the actual £100 discount. Now computes the real monetary
discount as baseTotal + tax - total.

Fixes #2276

https://claude.ai/code/session_012zQfEoCthSm6BWvEuRjZLs