### PR TITLE
Fix HTML sanitizer encoding special characters in line item descriptions

### DIFF
--- a/src/InvoiceBundle/Form/Type/ItemType.php
+++ b/src/InvoiceBundle/Form/Type/ItemType.php
@@ -41,8 +41,6 @@ class ItemType extends AbstractType
             'description',
             TextareaType::class,
             [
-                'sanitize_html' => true,
-                'allow_single_quotes' => true,
                 'attr' => [
                     'class' => 'input-medium invoice-item-name',
                 ],

--- a/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
@@ -15,16 +15,11 @@ namespace SolidInvoice\InvoiceBundle\Tests\Form\Type;
 
 use Brick\Math\BigDecimal;
 use Money\Currency;
-use SolidInvoice\CoreBundle\Form\TypeExtension\UnsanitizeSingleQuotesTypeExtension;
 use SolidInvoice\CoreBundle\Tests\FormTestCase;
 use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\InvoiceBundle\Form\Type\ItemType;
-use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\Form\Extension\HtmlSanitizer\Type\TextTypeHtmlSanitizerExtension;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\PreloadedExtension;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
 class ItemTypeTest extends FormTestCase
 {
@@ -33,6 +28,28 @@ class ItemTypeTest extends FormTestCase
         $description = $this->faker->text;
         $price = $this->faker->randomNumber(3);
         $qty = $this->faker->randomFloat(2);
+
+        $formData = [
+            'description' => $description,
+            'price' => $price,
+            'qty' => $qty,
+        ];
+
+        $currency = new Currency('USD');
+
+        $object = new Line();
+        $object->setDescription($description);
+        $object->setQty($qty);
+        $object->setPrice(BigDecimal::of($price * 100));
+
+        $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    public function testSubmitPreservesSpecialCharacters(): void
+    {
+        $description = 'Item + discount & "special" chars: 100% off';
+        $price = 100;
+        $qty = 1.0;
 
         $formData = [
             'description' => $description,
@@ -60,15 +77,6 @@ class ItemTypeTest extends FormTestCase
         return [
             // register the type instances with the PreloadedExtension
             new PreloadedExtension([$itemType], []),
-        ];
-    }
-
-    protected function getTypeExtensions(): array
-    {
-        return [
-            new TextTypeHtmlSanitizerExtension(new ServiceLocator(['default' => fn () => new HtmlSanitizer(new HtmlSanitizerConfig())])),
-            new UnsanitizeSingleQuotesTypeExtension(),
-            ...parent::getTypeExtensions(),
         ];
     }
 }

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -38,8 +38,6 @@ class ItemType extends AbstractType
             'description',
             TextareaType::class,
             [
-                'sanitize_html' => true,
-                'allow_single_quotes' => true,
                 'attr' => [
                     'class' => 'input-medium quote-item-name',
                 ],

--- a/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
@@ -48,6 +48,31 @@ final class ItemTypeTest extends FormTestCase
     }
 
     /**
+     * @throws MathException
+     */
+    public function testSubmitPreservesSpecialCharacters(): void
+    {
+        $description = 'Item + discount & "special" chars: 100% off';
+        $price = 100;
+        $qty = 1.0;
+
+        $formData = [
+            'description' => $description,
+            'price' => $price,
+            'qty' => $qty,
+        ];
+
+        $currency = new Currency('USD');
+
+        $object = new Line();
+        $object->setDescription($description);
+        $object->setQty($qty);
+        $object->setPrice(BigDecimal::of($price)->multipliedBy(100));
+
+        $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    /**
      * @return array<FormExtensionInterface>
      */
     protected function getExtensions(): array


### PR DESCRIPTION
Remove sanitize_html from invoice and quote line item description fields. The HTML sanitizer was incorrectly encoding characters like '+' as '&#43;', causing them to display incorrectly in invoices and quotes. Plain text description fields do not require HTML sanitization; Twig's auto-escaping via the nl2br filter in the templates already prevents XSS.

Also removes the redundant getTypeExtensions() override in InvoiceBundle's ItemTypeTest, and adds testSubmitPreservesSpecialCharacters() to both ItemTypeTest classes to verify special characters are preserved as-is.

Fixes #2283