### PR TITLE
Add multi-platform package distribution support

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -54,15 +54,15 @@ jobs:
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-          # Check if this is a pre-release
+          # Check if this is a pre-release (versions with a hyphen followed by
+          # a letter, e.g. 3.0.0-alpha1, 3.0.0-rc1)
           if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Version: ${VERSION} (pre-release)"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Version: ${VERSION}"
           fi
-
-          echo "Version: ${VERSION}"
-          echo "Pre-release: $(echo "$VERSION" | grep -q '-' && echo 'true' || echo 'false')"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -286,35 +286,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Download binaries and compute checksums
-        id: checksums
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          REPO="${{ github.repository }}"
-
-          # Download binaries for checksum calculation
-          for arch in amd64 arm64; do
-            gh release download "${VERSION}" \
-              --repo "${REPO}" \
-              --pattern "solidinvoice-linux-${arch}" \
-              --dir /tmp/binaries/
-          done
-
-          # Compute SHA256 checksums
-          AMD64_SHA=$(sha256sum /tmp/binaries/solidinvoice-linux-amd64 | cut -d' ' -f1)
-          ARM64_SHA=$(sha256sum /tmp/binaries/solidinvoice-linux-arm64 | cut -d' ' -f1)
-
-          # Compute checksums for service and env files
-          SERVICE_SHA=$(sha256sum packaging/systemd/solidinvoice.service | cut -d' ' -f1)
-          ENV_SHA=$(sha256sum packaging/systemd/solidinvoice.env | cut -d' ' -f1)
-
-          echo "amd64_sha=${AMD64_SHA}" >> "$GITHUB_OUTPUT"
-          echo "arm64_sha=${ARM64_SHA}" >> "$GITHUB_OUTPUT"
-          echo "service_sha=${SERVICE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "env_sha=${ENV_SHA}" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@a97c11653f4b8e39915a7e7067fb858e2d0ef1e2 # v4.1.1

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,353 @@
+name: "Publish Packages"
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches-ignore:
+      - "3.0.x"  # Exclude preview/nightly builds
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SolidInvoice version (e.g. 3.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NFPM_VERSION: "2.41.1"
+
+jobs:
+  # ============================================================================
+  # Determine version and validate release
+  # ============================================================================
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Get version from the release workflow that triggered us
+            VERSION=$(gh release view --repo "${{ github.repository }}" --json tagName --jq '.tagName' 2>/dev/null || echo "")
+            if [[ -z "$VERSION" ]]; then
+              echo "::error::Could not determine version from latest release"
+              exit 1
+            fi
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Check if this is a pre-release
+          if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Version: ${VERSION}"
+          echo "Pre-release: $(echo "$VERSION" | grep -q '-' && echo 'true' || echo 'false')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================================================
+  # Build native packages using nFPM
+  # ============================================================================
+  build-packages:
+    name: Build ${{ matrix.format }} (${{ matrix.arch }})
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        format: [deb, rpm, apk, archlinux]
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Download binary from release
+        run: |
+          mkdir -p frankenphp/dist
+          gh release download "${{ needs.prepare.outputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "solidinvoice-linux-${{ matrix.arch }}" \
+            --dir frankenphp/dist/
+          chmod +x "frankenphp/dist/solidinvoice-linux-${{ matrix.arch }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nFPM
+        run: |
+          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin nfpm
+          nfpm --version
+
+      - name: Build package
+        working-directory: packaging
+        run: |
+          mkdir -p ../dist
+          nfpm package \
+            -p "${{ matrix.format }}" \
+            -f nfpm.yaml \
+            -t ../dist/
+        env:
+          NFPM_ARCH: ${{ matrix.arch }}
+          SOLIDINVOICE_VERSION: ${{ needs.prepare.outputs.version }}
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: package-${{ matrix.format }}-${{ matrix.arch }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 5
+
+  # ============================================================================
+  # Upload packages to GitHub Release
+  # ============================================================================
+  upload-release:
+    name: Upload to GitHub Release
+    needs: [prepare, build-packages]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Download all package artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: package-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Upload packages to release
+        run: |
+          for pkg in dist/*; do
+            echo "Uploading: $(basename "$pkg")"
+            gh release upload "${{ needs.prepare.outputs.version }}" \
+              "$pkg" \
+              --repo "${{ github.repository }}" \
+              --clobber
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+  # ============================================================================
+  # Publish to Cloudsmith (APT, YUM/DNF, Alpine)
+  # ============================================================================
+  publish-cloudsmith:
+    name: Publish to Cloudsmith
+    needs: [prepare, build-packages]
+    runs-on: ubuntu-latest
+    if: vars.CLOUDSMITH_ENABLED == 'true'
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Install Cloudsmith CLI
+        run: pip install cloudsmith-cli
+
+      - name: Download all package artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: package-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Publish .deb packages
+        run: |
+          for deb in dist/*.deb; do
+            [ -f "$deb" ] || continue
+            echo "Publishing: $(basename "$deb")"
+            cloudsmith push deb \
+              solidinvoice/solidinvoice/any-distro/any-version \
+              "$deb" \
+              --republish
+          done
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+      - name: Publish .rpm packages
+        run: |
+          for rpm in dist/*.rpm; do
+            [ -f "$rpm" ] || continue
+            echo "Publishing: $(basename "$rpm")"
+            cloudsmith push rpm \
+              solidinvoice/solidinvoice/any-distro/any-version \
+              "$rpm" \
+              --republish
+          done
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+      - name: Publish .apk packages
+        run: |
+          for apk in dist/*.apk; do
+            [ -f "$apk" ] || continue
+            echo "Publishing: $(basename "$apk")"
+            cloudsmith push alpine \
+              solidinvoice/solidinvoice/alpine/any-version \
+              "$apk" \
+              --republish
+          done
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+  # ============================================================================
+  # Publish to Snap Store
+  # ============================================================================
+  publish-snap:
+    name: Publish to Snap Store
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    if: vars.SNAP_ENABLED == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Download binary from release
+        run: |
+          mkdir -p frankenphp/dist
+          gh release download "${{ needs.prepare.outputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "solidinvoice-linux-${{ matrix.arch }}" \
+            --dir frankenphp/dist/
+          chmod +x "frankenphp/dist/solidinvoice-linux-${{ matrix.arch }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build snap
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
+        id: snapcraft
+        with:
+          path: packaging/snap
+          snapcraft-channel: latest/stable
+
+      - name: Publish to Snap Store
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79571f2b14313e3cb10 # v1.2.0
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_TOKEN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: ${{ needs.prepare.outputs.prerelease == 'true' && 'edge' || 'stable' }}
+
+  # ============================================================================
+  # Update AUR package
+  # ============================================================================
+  publish-aur:
+    name: Publish to AUR
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    if: |
+      vars.AUR_ENABLED == 'true' &&
+      needs.prepare.outputs.prerelease == 'false'
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Download binaries and compute checksums
+        id: checksums
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          REPO="${{ github.repository }}"
+
+          # Download binaries for checksum calculation
+          for arch in amd64 arm64; do
+            gh release download "${VERSION}" \
+              --repo "${REPO}" \
+              --pattern "solidinvoice-linux-${arch}" \
+              --dir /tmp/binaries/
+          done
+
+          # Compute SHA256 checksums
+          AMD64_SHA=$(sha256sum /tmp/binaries/solidinvoice-linux-amd64 | cut -d' ' -f1)
+          ARM64_SHA=$(sha256sum /tmp/binaries/solidinvoice-linux-arm64 | cut -d' ' -f1)
+
+          # Compute checksums for service and env files
+          SERVICE_SHA=$(sha256sum packaging/systemd/solidinvoice.service | cut -d' ' -f1)
+          ENV_SHA=$(sha256sum packaging/systemd/solidinvoice.env | cut -d' ' -f1)
+
+          echo "amd64_sha=${AMD64_SHA}" >> "$GITHUB_OUTPUT"
+          echo "arm64_sha=${ARM64_SHA}" >> "$GITHUB_OUTPUT"
+          echo "service_sha=${SERVICE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "env_sha=${ENV_SHA}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@a97c11653f4b8e39915a7e7067fb858e2d0ef1e2 # v4.1.1
+        with:
+          pkgname: solidinvoice-bin
+          pkgbuild: packaging/aur/PKGBUILD
+          commit_username: "SolidInvoice Bot"
+          commit_email: "bot@solidinvoice.co"
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          commit_message: "Update to ${{ needs.prepare.outputs.version }}"
+          force_push: true
+          updpkgsums: true
+
+  # ============================================================================
+  # Notify Homebrew tap to update formula
+  # ============================================================================
+  update-homebrew:
+    name: Update Homebrew tap
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    if: |
+      vars.HOMEBREW_TAP_ENABLED == 'true' &&
+      needs.prepare.outputs.prerelease == 'false'
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Dispatch Homebrew tap update
+        run: |
+          gh api repos/${{ vars.HOMEBREW_TAP_REPO }}/dispatches \
+            -f event_type=update-formula \
+            -f "client_payload[version]=${{ needs.prepare.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: SolidInvoice <open-source@solidworx.co>
+# AUR package for SolidInvoice (pre-built binary)
+#
+# This PKGBUILD downloads the pre-built binary from GitHub Releases.
+# For the automated AUR publishing workflow, version and checksums
+# are updated by the publish-packages GitHub Actions workflow.
+
+pkgname=solidinvoice-bin
+pkgver=${SOLIDINVOICE_VERSION:-0.0.0}
+pkgrel=1
+pkgdesc="Simple and elegant invoicing solution"
+arch=('x86_64' 'aarch64')
+url="https://solidinvoice.co"
+license=('MIT')
+depends=()
+provides=('solidinvoice')
+conflicts=('solidinvoice')
+backup=('etc/solidinvoice/solidinvoice.env')
+install=solidinvoice.install
+
+source_x86_64=("solidinvoice-${pkgver}-x86_64::https://github.com/SolidInvoice/SolidInvoice/releases/download/${pkgver}/solidinvoice-linux-amd64")
+source_aarch64=("solidinvoice-${pkgver}-aarch64::https://github.com/SolidInvoice/SolidInvoice/releases/download/${pkgver}/solidinvoice-linux-arm64")
+source=("solidinvoice.service::https://raw.githubusercontent.com/SolidInvoice/SolidInvoice/${pkgver}/packaging/systemd/solidinvoice.service"
+        "solidinvoice.env::https://raw.githubusercontent.com/SolidInvoice/SolidInvoice/${pkgver}/packaging/systemd/solidinvoice.env")
+
+# Checksums are updated automatically by CI
+sha256sums=('SKIP'
+            'SKIP')
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+
+package() {
+    # Install binary
+    if [ "$CARCH" = "x86_64" ]; then
+        install -Dm755 "solidinvoice-${pkgver}-x86_64" "${pkgdir}/usr/bin/solidinvoice"
+    elif [ "$CARCH" = "aarch64" ]; then
+        install -Dm755 "solidinvoice-${pkgver}-aarch64" "${pkgdir}/usr/bin/solidinvoice"
+    fi
+
+    # Install systemd service
+    install -Dm644 solidinvoice.service "${pkgdir}/usr/lib/systemd/system/solidinvoice.service"
+
+    # Install default config
+    install -Dm640 solidinvoice.env "${pkgdir}/etc/solidinvoice/solidinvoice.env"
+
+    # Create data directory
+    install -dm750 "${pkgdir}/var/lib/solidinvoice"
+}

--- a/packaging/aur/solidinvoice.install
+++ b/packaging/aur/solidinvoice.install
@@ -37,10 +37,10 @@ post_upgrade() {
 }
 
 pre_remove() {
-    if systemctl is-active --quiet solidinvoice; then
+    if systemctl is-active --quiet solidinvoice 2>/dev/null; then
         systemctl stop solidinvoice
     fi
-    if systemctl is-enabled --quiet solidinvoice; then
+    if systemctl is-enabled --quiet solidinvoice 2>/dev/null; then
         systemctl disable solidinvoice
     fi
 }

--- a/packaging/aur/solidinvoice.install
+++ b/packaging/aur/solidinvoice.install
@@ -1,0 +1,50 @@
+post_install() {
+    # Create system user and group
+    if ! getent group solidinvoice >/dev/null 2>&1; then
+        groupadd --system solidinvoice
+    fi
+
+    if ! getent passwd solidinvoice >/dev/null 2>&1; then
+        useradd --system --gid solidinvoice \
+            --home-dir /var/lib/solidinvoice --no-create-home \
+            --shell /usr/sbin/nologin \
+            --comment "SolidInvoice service account" solidinvoice
+    fi
+
+    # Fix ownership
+    chown solidinvoice:solidinvoice /var/lib/solidinvoice
+    chown root:solidinvoice /etc/solidinvoice
+    chown root:solidinvoice /etc/solidinvoice/solidinvoice.env
+
+    systemctl daemon-reload
+
+    echo ""
+    echo "SolidInvoice has been installed."
+    echo ""
+    echo "  Start:   sudo systemctl start solidinvoice"
+    echo "  Enable:  sudo systemctl enable solidinvoice"
+    echo "  Config:  /etc/solidinvoice/solidinvoice.env"
+    echo ""
+}
+
+post_upgrade() {
+    systemctl daemon-reload
+
+    if systemctl is-active --quiet solidinvoice; then
+        echo "Restarting SolidInvoice..."
+        systemctl restart solidinvoice
+    fi
+}
+
+pre_remove() {
+    if systemctl is-active --quiet solidinvoice; then
+        systemctl stop solidinvoice
+    fi
+    if systemctl is-enabled --quiet solidinvoice; then
+        systemctl disable solidinvoice
+    fi
+}
+
+post_remove() {
+    systemctl daemon-reload
+}

--- a/packaging/chocolatey/solidinvoice.nuspec
+++ b/packaging/chocolatey/solidinvoice.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  PLACEHOLDER: This package requires Windows binary support.
+  See https://github.com/SolidInvoice/SolidInvoice/issues for tracking.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>solidinvoice</id>
+    <version>${SOLIDINVOICE_VERSION}</version>
+    <title>SolidInvoice</title>
+    <authors>Pierre du Plessis</authors>
+    <owners>SolidWorx</owners>
+    <projectUrl>https://solidinvoice.co</projectUrl>
+    <projectSourceUrl>https://github.com/SolidInvoice/SolidInvoice</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/SolidInvoice/SolidInvoice/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/SolidInvoice/SolidInvoice/blob/3.0.x/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>invoice invoicing billing freelancer business</tags>
+    <summary>Simple and elegant invoicing solution</summary>
+    <description>SolidInvoice is an open-source invoicing application for small businesses and freelancers. Features include client management, quotes, invoices (including recurring), payments, tax and discount management, a REST API, and notifications.</description>
+  </metadata>
+  <files>
+    <file src="tools/**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,20 @@
+# PLACEHOLDER: This install script requires Windows binary support.
+# See https://github.com/SolidInvoice/SolidInvoice/issues for tracking.
+
+$ErrorActionPreference = 'Stop'
+
+$packageArgs = @{
+    packageName    = 'solidinvoice'
+    url64          = "https://github.com/SolidInvoice/SolidInvoice/releases/download/${env:chocolateyPackageVersion}/solidinvoice-windows-amd64.exe"
+    fileFullPath   = "$(Get-ToolsLocation)\solidinvoice.exe"
+    checksum64     = '' # Updated by CI
+    checksumType64 = 'sha256'
+}
+
+Get-ChocolateyWebFile @packageArgs
+
+# Add to PATH
+$toolsDir = Get-ToolsLocation
+Install-ChocolateyPath -PathToInstall $toolsDir -PathType 'Machine'
+
+Write-Host "SolidInvoice installed. Run 'solidinvoice run' to start."

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -17,4 +17,4 @@ Get-ChocolateyWebFile @packageArgs
 $toolsDir = Get-ToolsLocation
 Install-ChocolateyPath -PathToInstall $toolsDir -PathType 'Machine'
 
-Write-Host "SolidInvoice installed. Run 'solidinvoice run' to start."
+Write-Output "SolidInvoice installed. Run 'solidinvoice run' to start."

--- a/packaging/cloudsmith-setup.sh
+++ b/packaging/cloudsmith-setup.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Cloudsmith Repository Setup Guide for SolidInvoice
+#
+# This script documents the steps needed to set up Cloudsmith repositories
+# for hosting APT, YUM/DNF, and Alpine packages.
+#
+# Cloudsmith is free for open-source projects and provides:
+# - APT repositories (Debian, Ubuntu)
+# - RPM repositories (RHEL, CentOS, Fedora, openSUSE)
+# - Alpine APK repositories
+# - Automatic GPG signing
+# - CDN-backed distribution
+# - Package version management
+#
+# Prerequisites:
+# 1. Create a Cloudsmith account: https://cloudsmith.io
+# 2. Install the Cloudsmith CLI: pip install cloudsmith-cli
+# 3. Authenticate: cloudsmith login
+#
+# ============================================================================
+# STEP 1: Create Organization and Repository
+# ============================================================================
+#
+# Via the Cloudsmith web UI:
+# 1. Create organization "solidinvoice" (or use existing)
+# 2. Create repository "solidinvoice"
+# 3. Set repository type to "Open-Source" (free tier)
+# 4. Enable formats: Debian/Ubuntu, RedHat, Alpine
+#
+# ============================================================================
+# STEP 2: Generate API Key
+# ============================================================================
+#
+# 1. Go to Account Settings > API Keys
+# 2. Create a new API key with write access to the repository
+# 3. Add to GitHub repository secrets as: CLOUDSMITH_API_KEY
+#
+# ============================================================================
+# STEP 3: Upload Packages (manual test)
+# ============================================================================
+#
+# Debian/Ubuntu (.deb):
+#   cloudsmith push deb solidinvoice/solidinvoice/any-distro/any-version \
+#     dist/solidinvoice_VERSION_amd64.deb
+#
+# RPM (.rpm):
+#   cloudsmith push rpm solidinvoice/solidinvoice/any-distro/any-version \
+#     dist/solidinvoice-VERSION.x86_64.rpm
+#
+# Alpine (.apk):
+#   cloudsmith push alpine solidinvoice/solidinvoice/alpine/any-version \
+#     dist/solidinvoice-VERSION.apk
+#
+# ============================================================================
+# STEP 4: User Installation Instructions
+# ============================================================================
+#
+# Debian/Ubuntu (APT):
+#   curl -1sLf 'https://dl.cloudsmith.io/public/solidinvoice/solidinvoice/setup.deb.sh' | sudo -E bash
+#   sudo apt install solidinvoice
+#
+# RHEL/CentOS/Fedora (YUM/DNF):
+#   curl -1sLf 'https://dl.cloudsmith.io/public/solidinvoice/solidinvoice/setup.rpm.sh' | sudo -E bash
+#   sudo dnf install solidinvoice
+#
+# Alpine (APK):
+#   curl -1sLf 'https://dl.cloudsmith.io/public/solidinvoice/solidinvoice/setup.alpine.sh' | sudo -E sh
+#   sudo apk add solidinvoice
+#
+# ============================================================================
+# STEP 5: GPG Signing (Cloudsmith handles this automatically)
+# ============================================================================
+#
+# Cloudsmith automatically signs packages with a GPG key.
+# The public key is included in the setup scripts above.
+# No additional GPG configuration is needed.
+#
+# ============================================================================
+
+echo "This is a documentation script. Please read the comments for setup instructions."
+echo ""
+echo "Quick start:"
+echo "  1. Create Cloudsmith account at https://cloudsmith.io"
+echo "  2. Create org 'solidinvoice' and repo 'solidinvoice'"
+echo "  3. Generate API key and add as CLOUDSMITH_API_KEY GitHub secret"
+echo "  4. The publish-packages workflow will handle the rest"

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -58,7 +58,7 @@ detect_os() {
     case "$OS" in
         linux)   OS="linux" ;;
         darwin)  OS="mac" ;;
-        freebsd) OS="freebsd" ;;
+        freebsd) error "FreeBSD is not currently supported. See https://github.com/SolidInvoice/SolidInvoice/issues for tracking." ;;
         *)       error "Unsupported operating system: $OS" ;;
     esac
 }
@@ -194,6 +194,7 @@ install_systemd_service() {
     ENV_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${VERSION}/packaging/systemd/solidinvoice.env"
 
     tmpdir_svc=$(mktemp -d)
+    trap 'rm -rf "$tmpdir_svc"' EXIT
 
     download "$SERVICE_URL" "${tmpdir_svc}/solidinvoice.service"
     download "$ENV_URL" "${tmpdir_svc}/solidinvoice.env"
@@ -208,16 +209,26 @@ install_systemd_service() {
     fi
 
     rm -rf "$tmpdir_svc"
+    trap - EXIT
 
-    # Create service user
+    # Create service user (compatible with both glibc and BusyBox/Alpine)
     if ! getent group solidinvoice >/dev/null 2>&1; then
-        $SUDO groupadd --system solidinvoice
+        if command -v groupadd >/dev/null 2>&1; then
+            $SUDO groupadd --system solidinvoice
+        else
+            $SUDO addgroup -S solidinvoice
+        fi
     fi
     if ! getent passwd solidinvoice >/dev/null 2>&1; then
-        $SUDO useradd --system --gid solidinvoice \
-            --home-dir /var/lib/solidinvoice --no-create-home \
-            --shell /usr/sbin/nologin \
-            --comment "SolidInvoice service account" solidinvoice
+        if command -v useradd >/dev/null 2>&1; then
+            $SUDO useradd --system --gid solidinvoice \
+                --home-dir /var/lib/solidinvoice --no-create-home \
+                --shell /usr/sbin/nologin \
+                --comment "SolidInvoice service account" solidinvoice
+        else
+            $SUDO adduser -S -G solidinvoice -h /var/lib/solidinvoice \
+                -s /usr/sbin/nologin -D solidinvoice
+        fi
     fi
 
     $SUDO mkdir -p /var/lib/solidinvoice

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,281 @@
+#!/bin/sh
+# SolidInvoice Universal Installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/SolidInvoice/SolidInvoice/3.0.x/packaging/install.sh | sh
+#
+# Options (via environment variables):
+#   VERSION          - Specific version to install (default: latest)
+#   INSTALL_DIR      - Installation directory (default: /usr/local/bin)
+#   INSTALL_SERVICE  - Install systemd service (default: auto-detect)
+#
+# Examples:
+#   curl -fsSL ... | sh                                    # Install latest
+#   curl -fsSL ... | VERSION=3.0.0 sh                     # Install specific version
+#   curl -fsSL ... | INSTALL_DIR=$HOME/.local/bin sh       # Install to custom dir
+#   curl -fsSL ... | INSTALL_SERVICE=1 sh                  # Also install systemd service
+
+set -e
+
+GITHUB_REPO="SolidInvoice/SolidInvoice"
+BINARY_NAME="solidinvoice"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Colors (only if stdout is a terminal)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+info() {
+    printf "${BLUE}==>${NC} %s\n" "$1"
+}
+
+success() {
+    printf "${GREEN}==>${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}WARNING:${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}ERROR:${NC} %s\n" "$1" >&2
+    exit 1
+}
+
+detect_os() {
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case "$OS" in
+        linux)   OS="linux" ;;
+        darwin)  OS="mac" ;;
+        freebsd) OS="freebsd" ;;
+        *)       error "Unsupported operating system: $OS" ;;
+    esac
+}
+
+detect_arch() {
+    ARCH="$(uname -m)"
+    case "$ARCH" in
+        x86_64|amd64)   ARCH="amd64" ;;
+        aarch64|arm64)  ARCH="arm64" ;;
+        *)              error "Unsupported architecture: $ARCH" ;;
+    esac
+}
+
+detect_downloader() {
+    if command -v curl >/dev/null 2>&1; then
+        DOWNLOADER="curl"
+    elif command -v wget >/dev/null 2>&1; then
+        DOWNLOADER="wget"
+    else
+        error "Either 'curl' or 'wget' is required for installation."
+    fi
+}
+
+download() {
+    url="$1"
+    output="$2"
+
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl -fsSL -o "$output" "$url"
+    else
+        wget -q -O "$output" "$url"
+    fi
+}
+
+download_to_stdout() {
+    url="$1"
+
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl -fsSL "$url"
+    else
+        wget -q -O - "$url"
+    fi
+}
+
+get_latest_version() {
+    info "Fetching latest version..."
+    VERSION=$(download_to_stdout "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
+        | grep '"tag_name"' \
+        | head -1 \
+        | sed 's/.*"tag_name": *"//;s/".*//')
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to determine latest version. Please specify VERSION manually."
+    fi
+}
+
+check_existing() {
+    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        existing_version=$("$BINARY_NAME" version 2>/dev/null || echo "unknown")
+        warn "SolidInvoice is already installed (version: ${existing_version})"
+        info "Upgrading to version ${VERSION}..."
+    fi
+}
+
+needs_sudo() {
+    # Check if we need sudo to write to the install directory
+    if [ -w "$INSTALL_DIR" ]; then
+        SUDO=""
+    elif command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+    elif command -v doas >/dev/null 2>&1; then
+        SUDO="doas"
+    else
+        error "Cannot write to ${INSTALL_DIR} and neither 'sudo' nor 'doas' is available."
+    fi
+}
+
+install_binary() {
+    BINARY_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${BINARY_NAME}-${OS}-${ARCH}"
+
+    info "Downloading SolidInvoice ${VERSION} for ${OS}/${ARCH}..."
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    download "$BINARY_URL" "${tmpdir}/${BINARY_NAME}"
+
+    if [ ! -f "${tmpdir}/${BINARY_NAME}" ] || [ ! -s "${tmpdir}/${BINARY_NAME}" ]; then
+        error "Download failed. Binary not found for ${OS}/${ARCH}."
+    fi
+
+    chmod +x "${tmpdir}/${BINARY_NAME}"
+
+    # Verify the binary runs
+    if ! "${tmpdir}/${BINARY_NAME}" version >/dev/null 2>&1; then
+        error "Downloaded binary failed verification. It may be incompatible with your system."
+    fi
+
+    info "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
+
+    # Ensure install directory exists
+    if [ ! -d "$INSTALL_DIR" ]; then
+        $SUDO mkdir -p "$INSTALL_DIR"
+    fi
+
+    $SUDO mv "${tmpdir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+
+    success "SolidInvoice ${VERSION} installed to ${INSTALL_DIR}/${BINARY_NAME}"
+}
+
+install_systemd_service() {
+    if [ "$OS" != "linux" ]; then
+        return
+    fi
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return
+    fi
+
+    # Auto-detect or respect INSTALL_SERVICE
+    if [ "${INSTALL_SERVICE:-}" = "0" ]; then
+        return
+    fi
+
+    if [ "${INSTALL_SERVICE:-}" != "1" ]; then
+        info "Skipping systemd service installation (set INSTALL_SERVICE=1 to install)"
+        return
+    fi
+
+    info "Installing systemd service..."
+
+    SERVICE_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${VERSION}/packaging/systemd/solidinvoice.service"
+    ENV_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${VERSION}/packaging/systemd/solidinvoice.env"
+
+    tmpdir_svc=$(mktemp -d)
+
+    download "$SERVICE_URL" "${tmpdir_svc}/solidinvoice.service"
+    download "$ENV_URL" "${tmpdir_svc}/solidinvoice.env"
+
+    $SUDO cp "${tmpdir_svc}/solidinvoice.service" /usr/lib/systemd/system/solidinvoice.service
+    $SUDO chmod 0644 /usr/lib/systemd/system/solidinvoice.service
+
+    $SUDO mkdir -p /etc/solidinvoice
+    if [ ! -f /etc/solidinvoice/solidinvoice.env ]; then
+        $SUDO cp "${tmpdir_svc}/solidinvoice.env" /etc/solidinvoice/solidinvoice.env
+        $SUDO chmod 0640 /etc/solidinvoice/solidinvoice.env
+    fi
+
+    rm -rf "$tmpdir_svc"
+
+    # Create service user
+    if ! getent group solidinvoice >/dev/null 2>&1; then
+        $SUDO groupadd --system solidinvoice
+    fi
+    if ! getent passwd solidinvoice >/dev/null 2>&1; then
+        $SUDO useradd --system --gid solidinvoice \
+            --home-dir /var/lib/solidinvoice --no-create-home \
+            --shell /usr/sbin/nologin \
+            --comment "SolidInvoice service account" solidinvoice
+    fi
+
+    $SUDO mkdir -p /var/lib/solidinvoice
+    $SUDO chown solidinvoice:solidinvoice /var/lib/solidinvoice
+    $SUDO chown root:solidinvoice /etc/solidinvoice
+    $SUDO chmod 0750 /etc/solidinvoice /var/lib/solidinvoice
+
+    $SUDO systemctl daemon-reload
+
+    success "systemd service installed"
+    echo ""
+    echo "  Start:   sudo systemctl start solidinvoice"
+    echo "  Enable:  sudo systemctl enable solidinvoice"
+    echo "  Status:  sudo systemctl status solidinvoice"
+    echo "  Config:  /etc/solidinvoice/solidinvoice.env"
+    echo ""
+}
+
+print_next_steps() {
+    echo ""
+    success "Installation complete!"
+    echo ""
+    echo "  Run SolidInvoice:"
+    echo "    ${BINARY_NAME} run"
+    echo ""
+    echo "  Then open your browser to the URL shown in the terminal."
+    echo ""
+    echo "  For more options:"
+    echo "    ${BINARY_NAME} run --help"
+    echo ""
+
+    # Check if binary is on PATH
+    if ! echo "$PATH" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
+        warn "${INSTALL_DIR} is not in your PATH."
+        echo "  Add it with:"
+        echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+        echo ""
+    fi
+}
+
+main() {
+    echo ""
+    info "SolidInvoice Installer"
+    echo ""
+
+    detect_os
+    detect_arch
+    detect_downloader
+
+    if [ -z "${VERSION:-}" ]; then
+        get_latest_version
+    fi
+
+    check_existing
+    needs_sudo
+    install_binary
+    install_systemd_service
+    print_next_steps
+}
+
+main

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -74,13 +74,14 @@ scripts:
 overrides:
   deb:
     recommends:
-      - mysql-server
+      - mysql-server | mariadb-server
     suggests:
       - postgresql
       - nginx
   rpm:
     recommends:
       - mysql-server
+      - mariadb-server
     suggests:
       - postgresql-server
       - nginx

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,86 @@
+# nFPM configuration for SolidInvoice
+# https://nfpm.goreleaser.com/configuration/
+#
+# Build packages with:
+#   nfpm package -p deb -f packaging/nfpm.yaml -t dist/
+#   nfpm package -p rpm -f packaging/nfpm.yaml -t dist/
+#   nfpm package -p apk -f packaging/nfpm.yaml -t dist/
+#   nfpm package -p archlinux -f packaging/nfpm.yaml -t dist/
+#
+# Override architecture with:
+#   nfpm package -p deb -f packaging/nfpm.yaml --target dist/ --arch arm64
+
+name: solidinvoice
+arch: ${NFPM_ARCH:-amd64}
+version: ${SOLIDINVOICE_VERSION}
+release: 1
+epoch: 0
+section: web
+priority: optional
+
+maintainer: Pierre du Plessis <open-source@solidworx.co>
+vendor: SolidWorx
+homepage: https://solidinvoice.co
+license: MIT
+description: |
+  Simple and elegant invoicing solution.
+  SolidInvoice is an open-source invoicing application for small businesses
+  and freelancers. Features include client management, quotes, invoices
+  (including recurring), payments, tax and discount management, a REST API,
+  and notifications.
+
+contents:
+  # Binary
+  - src: ../frankenphp/dist/solidinvoice-linux-${NFPM_ARCH:-amd64}
+    dst: /usr/bin/solidinvoice
+    file_info:
+      mode: 0755
+
+  # systemd service
+  - src: systemd/solidinvoice.service
+    dst: /usr/lib/systemd/system/solidinvoice.service
+    file_info:
+      mode: 0644
+
+  # Default environment file
+  - src: systemd/solidinvoice.env
+    dst: /etc/solidinvoice/solidinvoice.env
+    type: config|noreplace
+    file_info:
+      mode: 0640
+      owner: root
+      group: solidinvoice
+
+  # Create required directories
+  - dst: /var/lib/solidinvoice
+    type: dir
+    file_info:
+      mode: 0750
+      owner: solidinvoice
+      group: solidinvoice
+
+  - dst: /etc/solidinvoice
+    type: dir
+    file_info:
+      mode: 0750
+      owner: root
+      group: solidinvoice
+
+scripts:
+  postinstall: scripts/postinstall.sh
+  preremove: scripts/preremove.sh
+  postremove: scripts/postremove.sh
+
+overrides:
+  deb:
+    recommends:
+      - mysql-server
+    suggests:
+      - postgresql
+      - nginx
+  rpm:
+    recommends:
+      - mysql-server
+    suggests:
+      - postgresql-server
+      - nginx

--- a/packaging/scoop/solidinvoice.json
+++ b/packaging/scoop/solidinvoice.json
@@ -1,0 +1,31 @@
+{
+    "_comment": "PLACEHOLDER: This manifest requires Windows binary support. See https://github.com/SolidInvoice/SolidInvoice/issues for tracking.",
+    "version": "${SOLIDINVOICE_VERSION}",
+    "description": "Simple and elegant invoicing solution",
+    "homepage": "https://solidinvoice.co",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-amd64.exe",
+            "hash": ""
+        },
+        "arm64": {
+            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-arm64.exe",
+            "hash": ""
+        }
+    },
+    "bin": "solidinvoice.exe",
+    "checkver": {
+        "github": "https://github.com/SolidInvoice/SolidInvoice"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-amd64.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-arm64.exe"
+            }
+        }
+    }
+}

--- a/packaging/scoop/solidinvoice.json
+++ b/packaging/scoop/solidinvoice.json
@@ -6,11 +6,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-amd64.exe",
+            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-amd64.exe#/solidinvoice.exe",
             "hash": ""
         },
         "arm64": {
-            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-arm64.exe",
+            "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-arm64.exe#/solidinvoice.exe",
             "hash": ""
         }
     },
@@ -21,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-amd64.exe"
+                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-amd64.exe#/solidinvoice.exe"
             },
             "arm64": {
-                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-arm64.exe"
+                "url": "https://github.com/SolidInvoice/SolidInvoice/releases/download/$version/solidinvoice-windows-arm64.exe#/solidinvoice.exe"
             }
         }
     }

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -2,18 +2,28 @@
 set -e
 
 # Create solidinvoice system user and group if they don't exist
+# Supports both glibc-based distros (groupadd/useradd) and Alpine/BusyBox (addgroup/adduser)
 if ! getent group solidinvoice >/dev/null 2>&1; then
-    groupadd --system solidinvoice
+    if command -v groupadd >/dev/null 2>&1; then
+        groupadd --system solidinvoice
+    else
+        addgroup -S solidinvoice
+    fi
 fi
 
 if ! getent passwd solidinvoice >/dev/null 2>&1; then
-    useradd --system \
-        --gid solidinvoice \
-        --home-dir /var/lib/solidinvoice \
-        --no-create-home \
-        --shell /usr/sbin/nologin \
-        --comment "SolidInvoice service account" \
-        solidinvoice
+    if command -v useradd >/dev/null 2>&1; then
+        useradd --system \
+            --gid solidinvoice \
+            --home-dir /var/lib/solidinvoice \
+            --no-create-home \
+            --shell /usr/sbin/nologin \
+            --comment "SolidInvoice service account" \
+            solidinvoice
+    else
+        adduser -S -G solidinvoice -h /var/lib/solidinvoice \
+            -s /usr/sbin/nologin -D solidinvoice
+    fi
 fi
 
 # Ensure directories exist with correct ownership

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+# Create solidinvoice system user and group if they don't exist
+if ! getent group solidinvoice >/dev/null 2>&1; then
+    groupadd --system solidinvoice
+fi
+
+if ! getent passwd solidinvoice >/dev/null 2>&1; then
+    useradd --system \
+        --gid solidinvoice \
+        --home-dir /var/lib/solidinvoice \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        --comment "SolidInvoice service account" \
+        solidinvoice
+fi
+
+# Ensure directories exist with correct ownership
+install -d -m 0750 -o solidinvoice -g solidinvoice /var/lib/solidinvoice
+install -d -m 0750 -o root -g solidinvoice /etc/solidinvoice
+
+# Fix ownership on config files
+if [ -f /etc/solidinvoice/solidinvoice.env ]; then
+    chown root:solidinvoice /etc/solidinvoice/solidinvoice.env
+    chmod 0640 /etc/solidinvoice/solidinvoice.env
+fi
+
+# Reload systemd to pick up the new service file
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    echo ""
+    echo "SolidInvoice has been installed successfully."
+    echo ""
+    echo "To start the service:"
+    echo "  sudo systemctl start solidinvoice"
+    echo ""
+    echo "To enable the service on boot:"
+    echo "  sudo systemctl enable solidinvoice"
+    echo ""
+    echo "Configuration: /etc/solidinvoice/solidinvoice.env"
+    echo ""
+fi

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Reload systemd after service file removal
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+fi
+
+# Note: We intentionally do NOT remove the solidinvoice user, group,
+# /etc/solidinvoice, or /var/lib/solidinvoice on uninstall.
+# This preserves configuration and data for reinstallation.
+# Users can manually remove these if desired:
+#   sudo userdel solidinvoice
+#   sudo groupdel solidinvoice
+#   sudo rm -rf /etc/solidinvoice /var/lib/solidinvoice

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Stop and disable the service before removal
+if command -v systemctl >/dev/null 2>&1; then
+    if systemctl is-active --quiet solidinvoice 2>/dev/null; then
+        systemctl stop solidinvoice
+    fi
+    if systemctl is-enabled --quiet solidinvoice 2>/dev/null; then
+        systemctl disable solidinvoice
+    fi
+fi

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,0 +1,60 @@
+name: solidinvoice
+title: SolidInvoice
+version: ${SOLIDINVOICE_VERSION}
+summary: Simple and elegant invoicing solution
+description: |
+  SolidInvoice is an open-source invoicing application for small businesses
+  and freelancers. Features include client management, quotes, invoices
+  (including recurring), payments, tax and discount management, a REST API,
+  and notifications.
+
+  SolidInvoice ships as a self-contained binary with an embedded web server.
+  No PHP, Apache, or Nginx installation required.
+
+  After installation, start the application with:
+    sudo snap start solidinvoice
+
+  Then open your browser to http://localhost:8765 to complete setup.
+
+  Configuration can be set via snap configuration:
+    sudo snap set solidinvoice port=8080
+
+license: MIT
+base: core24
+confinement: strict
+grade: stable
+
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
+
+apps:
+  solidinvoice:
+    command: bin/solidinvoice run --disable-https --skip-intro --log-format json
+    daemon: simple
+    restart-condition: on-failure
+    restart-delay: 5s
+    plugs:
+      - network
+      - network-bind
+    environment:
+      SOLIDINVOICE_CONFIG_DIR: $SNAP_COMMON/config
+      HOME: $SNAP_COMMON
+
+  cli:
+    command: bin/solidinvoice
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  solidinvoice:
+    plugin: dump
+    source: ../frankenphp/dist/
+    source-type: local
+    organize:
+      solidinvoice-linux-*: bin/solidinvoice
+    stage:
+      - bin/solidinvoice

--- a/packaging/systemd/solidinvoice.env
+++ b/packaging/systemd/solidinvoice.env
@@ -1,0 +1,64 @@
+# SolidInvoice environment configuration
+# This file is sourced by the systemd service unit.
+# Uncomment and modify options as needed.
+
+# ------------------------------------------------------------------
+# Network
+# ------------------------------------------------------------------
+
+# Port to listen on (default: 8765)
+#SOLIDINVOICE_PORT=8765
+
+# IP address to bind to (default: 0.0.0.0)
+#SOLIDINVOICE_SERVER_IP=0.0.0.0
+
+# Domain name (enables automatic SSL certificate generation)
+#SOLIDINVOICE_DOMAIN=
+
+# ------------------------------------------------------------------
+# HTTPS / TLS
+# ------------------------------------------------------------------
+
+# Set to "true" to enable Let's Encrypt (requires SOLIDINVOICE_DOMAIN)
+#SOLIDINVOICE_LETS_ENCRYPT=false
+
+# Custom SSL certificate paths (requires SOLIDINVOICE_DOMAIN)
+#SOLIDINVOICE_SSL_CERT=
+#SOLIDINVOICE_SSL_KEY=
+
+# ------------------------------------------------------------------
+# Performance
+# ------------------------------------------------------------------
+
+# Enable FrankenPHP worker mode for high-traffic deployments
+#FRANKENPHP_WORKER_MODE=0
+
+# Number of worker threads (only applies when worker mode is enabled)
+#SOLIDINVOICE_WORKER_THREADS=2
+
+# Number of background messenger worker processes
+#SOLIDINVOICE_MESSENGER_WORKERS=1
+
+# ------------------------------------------------------------------
+# Application
+# ------------------------------------------------------------------
+
+# Application environment (prod or dev)
+#SOLIDINVOICE_ENV=prod
+
+# Debug mode (0 or 1)
+#SOLIDINVOICE_DEBUG=0
+
+# Configuration directory
+SOLIDINVOICE_CONFIG_DIR=/etc/solidinvoice
+
+# Log format: "json" for structured logs, "console" for human-readable
+#LOG_FORMAT=json
+
+# Log level: DEBUG, INFO, WARN, ERROR
+#LOG_LEVEL=INFO
+
+# ------------------------------------------------------------------
+# Database (configure during initial setup or here)
+# ------------------------------------------------------------------
+#DATABASE_URL=mysql://user:password@localhost:3306/solidinvoice

--- a/packaging/systemd/solidinvoice.service
+++ b/packaging/systemd/solidinvoice.service
@@ -1,0 +1,50 @@
+[Unit]
+Description=SolidInvoice - Simple and elegant invoicing solution
+Documentation=https://docs.solidinvoice.co
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=solidinvoice
+Group=solidinvoice
+
+ExecStart=/usr/bin/solidinvoice run --disable-https --skip-intro --log-format json
+ExecReload=/bin/kill -USR1 $MAINPID
+
+EnvironmentFile=-/etc/solidinvoice/solidinvoice.env
+
+WorkingDirectory=/var/lib/solidinvoice
+
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=30
+TimeoutStopSec=30
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true
+RemoveIPC=true
+
+ReadWritePaths=/etc/solidinvoice /var/lib/solidinvoice
+
+# Allow binding to privileged ports if needed
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=solidinvoice
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/solidinvoice.service
+++ b/packaging/systemd/solidinvoice.service
@@ -10,7 +10,6 @@ User=solidinvoice
 Group=solidinvoice
 
 ExecStart=/usr/bin/solidinvoice run --disable-https --skip-intro --log-format json
-ExecReload=/bin/kill -USR1 $MAINPID
 
 EnvironmentFile=-/etc/solidinvoice/solidinvoice.env
 

--- a/packaging/winget/SolidInvoice.SolidInvoice.yaml
+++ b/packaging/winget/SolidInvoice.SolidInvoice.yaml
@@ -1,0 +1,35 @@
+# PLACEHOLDER: This manifest requires Windows binary support.
+# See https://github.com/SolidInvoice/SolidInvoice/issues for tracking.
+#
+# When Windows binaries are available, submit this manifest as a PR to:
+# https://github.com/microsoft/winget-pkgs
+#
+# Filename convention: manifests/s/SolidInvoice/SolidInvoice/<version>/SolidInvoice.SolidInvoice.yaml
+
+PackageIdentifier: SolidInvoice.SolidInvoice
+PackageVersion: "${SOLIDINVOICE_VERSION}"
+PackageName: SolidInvoice
+Publisher: SolidWorx
+PublisherUrl: https://solidinvoice.co
+License: MIT
+LicenseUrl: https://github.com/SolidInvoice/SolidInvoice/blob/3.0.x/LICENSE
+ShortDescription: Simple and elegant invoicing solution
+Description: SolidInvoice is an open-source invoicing application for small businesses and freelancers.
+Tags:
+  - invoice
+  - invoicing
+  - billing
+  - freelancer
+  - business
+PackageUrl: https://github.com/SolidInvoice/SolidInvoice
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-amd64.exe
+    InstallerSha256: ""
+  - Architecture: arm64
+    InstallerType: portable
+    InstallerUrl: https://github.com/SolidInvoice/SolidInvoice/releases/download/${SOLIDINVOICE_VERSION}/solidinvoice-windows-arm64.exe
+    InstallerSha256: ""
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add packaging configurations for distributing SolidInvoice across multiple package managers, distributions, and environments. Since the application ships as a self-contained static binary, each package simply installs the binary, creates a service user, and sets up a systemd service.

New files:
- nFPM config for building .deb, .rpm, .apk, and Arch Linux packages
- systemd service unit with security hardening and environment file
- Snap package configuration (snapcraft.yaml)
- Universal install script (curl | sh) with OS/arch auto-detection
- AUR PKGBUILD for Arch Linux
- Cloudsmith setup documentation for APT/YUM/Alpine repositories
- Windows placeholders (Scoop, Chocolatey, WinGet) pending binary support
- GitHub Actions workflow for automated package publishing

https://claude.ai/code/session_01Kw6dKW6cEsqhTxxztmRtUg