### PR TITLE
Improve CI build time and test suite performance

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -160,7 +160,6 @@ jobs:
         with:
           egress-policy: audit
           allowed-endpoints: >
-            bun.sh:443
             packagist.org:443
             download.oracle.com:443
             azure.archive.ubuntu.com:443
@@ -179,8 +178,6 @@ jobs:
             setup-php.com:443
             dl.cloudsmith.io:443
             getcomposer.org:443
-            registry.npmjs.org:443
-            registry.yarnpkg.com:443
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -194,13 +191,7 @@ jobs:
         env:
           fail-fast: true
 
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
-
       - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3
-
-      - run: bun install
-
-      - run: bun run build
 
       - name: Run test suite
         # Installation currently only runs with SQLite,

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.4' ]
+        php: [ '8.4', '8.5' ]
         coverage: [ false ]
         include:
           - php: '8.4'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,10 +30,6 @@ jobs:
     env:
       SOLIDINVOICE_ENV: test
       SOLIDINVOICE_DEBUG: 0
-      PANTHER_NO_HEADLESS: 0
-      PANTHER_APP_ENV: test
-      PANTHER_NO_SANDBOX: 1
-      PANTHER_CHROME_ARGUMENTS: --disable-dev-shm-usage
       COVERAGE: 0
 
     steps:
@@ -42,48 +38,18 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            accounts.google.com:443
-            android.clients.google.com:443
-            api.cloudinary.com:443
             api.codecov.io:443
             api.github.com:443
-            api.ipify.org:443
-            api.iconify.design:443
-            bun.sh:443
-            cdn.jsdelivr.net:443
-            chromedriver.storage.googleapis.com:443
             cli.codecov.io:443
-            clients2.google.com:443
-            clients2.google.com:80
             codecov.io:443
-            content-autofill.googleapis.com:443
-            content-autofill.googleapis.com:80
-            coveralls.io:443
-            dl.cloudsmith.io:443
-            dl.google.com:443
-            edgedl.me.gvt1.com:443
             github.com:443
             getcomposer.org:443
-            googlechromelabs.github.io:443
-            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
             ingest.codecov.io:443
-            keybase.io:443
-            o26192.ingest.us.sentry.io:443
             objects.githubusercontent.com:443
-            optimizationguide-pa.googleapis.com:443
-            optimizationguide-pa.googleapis.com:80
             packagist.org:443
-            passwordsleakcheck-pa.googleapis.com:443
-            redirector.gvt1.com:443
-            registry.npmjs.org:443
-            registry.yarnpkg.com:443
-            release-assets.githubusercontent.com:443
             repo.packagist.org:443
             setup-php.com:443
-            storage.googleapis.com:443
-            update.googleapis.com:80
             uploader.codecov.io:443
-            www.google.com:443
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -103,28 +69,19 @@ jobs:
           extensions: intl, gd, mysql, pdo_mysql, soap, zip, :xdebug
           coverage: ${{ steps.coverage_driver.outputs.value }}
 
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
-
       - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3
-
-      - name: Detect browser drivers
-        run: bin/bdi detect drivers
-
-      - run: bun install
-
-      - run: bun run build
 
       - name: Enable code coverage
         if: matrix.coverage
         run: echo "COVERAGE=1" >> $GITHUB_ENV
 
-      - name: Run test suite
+      - name: Run unit test suite
         run: |
           mkdir -p build/logs var/log && chmod 777 var/log
           if [ "$COVERAGE" = '1' ]; then
-            bin/phpunit --coverage-clover build/logs/clover.xml
+            bin/phpunit --testsuite unit --coverage-clover build/logs/clover.xml
           else
-            bin/phpunit
+            bin/phpunit --testsuite unit
           fi
 
       - name: Upload coverage results to Codecov
@@ -137,12 +94,95 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+  functional:
+    name: Functional Tests
+
+    runs-on: ubuntu-latest
+
+    env:
+      SOLIDINVOICE_ENV: test
+      SOLIDINVOICE_DEBUG: 0
+      PANTHER_NO_HEADLESS: 0
+      PANTHER_APP_ENV: test
+      PANTHER_NO_SANDBOX: 1
+      PANTHER_CHROME_ARGUMENTS: --disable-dev-shm-usage
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            accounts.google.com:443
+            android.clients.google.com:443
+            api.cloudinary.com:443
+            api.github.com:443
+            api.ipify.org:443
+            api.iconify.design:443
+            bun.sh:443
+            cdn.jsdelivr.net:443
+            chromedriver.storage.googleapis.com:443
+            clients2.google.com:443
+            clients2.google.com:80
+            content-autofill.googleapis.com:443
+            content-autofill.googleapis.com:80
+            dl.cloudsmith.io:443
+            dl.google.com:443
+            edgedl.me.gvt1.com:443
+            github.com:443
+            getcomposer.org:443
+            googlechromelabs.github.io:443
+            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            objects.githubusercontent.com:443
+            optimizationguide-pa.googleapis.com:443
+            optimizationguide-pa.googleapis.com:80
+            packagist.org:443
+            passwordsleakcheck-pa.googleapis.com:443
+            redirector.gvt1.com:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            release-assets.githubusercontent.com:443
+            repo.packagist.org:443
+            setup-php.com:443
+            storage.googleapis.com:443
+            update.googleapis.com:80
+            www.google.com:443
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f
+        with:
+          php-version: '8.4'
+          ini-values: date.timezone=Africa/Johannesburg, memory_limit=-1
+          extensions: intl, gd, mysql, pdo_mysql, soap, zip, :xdebug
+          coverage: none
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+
+      - uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3
+
+      - name: Detect browser drivers
+        run: bin/bdi detect drivers
+
+      - run: bun install
+
+      - run: bun run build
+
+      - name: Run functional test suite
+        run: |
+          mkdir -p build/logs var/log && chmod 777 var/log
+          bin/phpunit --testsuite functional
+
       - name: Add comment to PR with failure screenshots
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         if: ${{ failure() }}
         env:
-            CLOUDINARY_URL: cloudinary://${{ secrets.CLOUDINARY_API_KEY }}:${{ secrets.CLOUDINARY_API_SECRET }}@${{ secrets.CLOUDINARY_CLOUD_NAME }}
-            JOB_NAME: Unit ( PHP ${{ matrix.php }} )
+            CLOUDINARY_URL: "cloudinary://${{ secrets.CLOUDINARY_API_KEY }}:${{ secrets.CLOUDINARY_API_SECRET }}@${{ secrets.CLOUDINARY_CLOUD_NAME }}"
+            JOB_NAME: Functional Tests
         with:
           script: |
             const script = require('./scripts/e2e-failure.js')

--- a/composer.json
+++ b/composer.json
@@ -196,6 +196,7 @@
     },
     "require-dev": {
         "captainhook/captainhook-phar": "^5.23",
+        "dama/doctrine-test-bundle": "^8.4",
         "dbrekelmans/bdi": "^1.0",
         "doctrine/doctrine-fixtures-bundle": "^4.0",
         "ergebnis/composer-normalize": "^2.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4507c94a173b79bac673756110eff0b",
+    "content-hash": "e2709df3bc3ef2f6501d0d48e5e7191e",
     "packages": [
         {
             "name": "alcohol/iso4217",
@@ -20844,6 +20844,75 @@
                 }
             ],
             "time": "2025-04-08T07:07:48+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "d9f4fb01a43da2e279ca190fa25ab9e26f15a0c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/d9f4fb01a43da2e279ca190fa25ab9e26f15a0c8",
+                "reference": "d9f4fb01a43da2e279ca190fa25ab9e26f15a0c8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.1",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<10.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5.57 || ^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.4.1"
+            },
+            "time": "2025-12-07T21:48:15+00:00"
         },
         {
             "name": "dbrekelmans/bdi",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -59,6 +59,7 @@ $bundles = [
     SolidWorx\Platform\UiBundle\SolidWorxPlatformUiBundle::class => ['all' => true],
     Symfony\UX\Chartjs\ChartjsBundle::class => ['all' => true],
     Meilisearch\Bundle\MeilisearchBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];
 
 if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) === 'saas') {

--- a/config/packages/dama_doctrine_test_bundle.yaml
+++ b/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,27 +2,19 @@
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
         backupGlobals="false"
-        backupStaticAttributes="false"
         colors="true"
-        verbose="true"
         executionOrder="random"
         failOnWarning="true"
         failOnRisky="true"
-        beStrictAboutTestsThatDoNotTestAnything="true"
         beStrictAboutOutputDuringTests="true"
-        beStrictAboutTodoAnnotatedTests="true"
         beStrictAboutChangesToGlobalState="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertDeprecationsToExceptions="false"
         processIsolation="false"
         stopOnFailure="false"
         bootstrap="tests/bootstrap.php"
 >
-    <coverage>
+    <source>
         <include>
             <directory>src</directory>
         </include>
@@ -30,10 +22,14 @@
             <directory>src/*Bundle/Resources</directory>
             <directory>src/*Bundle/Tests</directory>
         </exclude>
-    </coverage>
+    </source>
     <testsuites>
-        <testsuite name="SolidInvoice Test Suite">
+        <testsuite name="unit">
             <directory>src/*Bundle/Tests</directory>
+            <exclude>src/InstallBundle/Tests/Functional</exclude>
+        </testsuite>
+        <testsuite name="functional">
+            <directory>src/InstallBundle/Tests/Functional</directory>
         </testsuite>
     </testsuites>
     <php>
@@ -49,11 +45,9 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="BROWSER_ALWAYS_START_WEBSERVER" value="1"/>
     </php>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener"/>
-    </listeners>
     <extensions>
-        <extension class="Symfony\Component\Panther\ServerExtension"/>
-        <extension class="Zenstruck\Browser\Test\BrowserExtension" />
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+        <bootstrap class="Symfony\Component\Panther\ServerExtension"/>
+        <bootstrap class="Zenstruck\Browser\Test\BrowserExtension" />
     </extensions>
 </phpunit>

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -20,6 +20,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as M;
 use Money\Currency;
+use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\CoreBundle\Entity\Company;
@@ -36,7 +37,6 @@ use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Entity\Quote;
 use SolidInvoice\SettingsBundle\SystemConfig;
 use SolidInvoice\TaxBundle\Entity\Tax;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Workflow\Definition;
@@ -44,7 +44,7 @@ use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Component\Workflow\Transition;
 
-class InvoiceManagerTest extends KernelTestCase
+class InvoiceManagerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 

--- a/src/UserBundle/Test/Factory/UserFactory.php
+++ b/src/UserBundle/Test/Factory/UserFactory.php
@@ -66,7 +66,7 @@ final class UserFactory extends PersistentProxyObjectFactory
     {
         parent::__construct();
 
-        $this->passwordHasher = new NativePasswordHasher();
+        $this->passwordHasher = new NativePasswordHasher(3, 10 * 1024, 4);
     }
 
     /**

--- a/symfony.lock
+++ b/symfony.lock
@@ -34,6 +34,18 @@
     "composer/package-versions-deprecated": {
         "version": "1.10.99"
     },
+    "dama/doctrine-test-bundle": {
+        "version": "8.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        },
+        "files": [
+            "config/packages/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "dbrekelmans/bdi": {
         "version": "1.0"
     },


### PR DESCRIPTION
## Summary

- **DAMA DoctrineTestBundle**: Wraps each test in a transaction and rolls back after, eliminating expensive schema resets between tests (expected 40-60% reduction in integration test time)
- **Parallel CI jobs**: Split `unit-tests.yml` into a fast `unit` job (no bun, no browser drivers) and a `functional` job (Panther/browser tests with bun build) — both run in parallel
- **Remove bun from db-tests**: The 14-variant DB matrix no longer runs `bun install && bun run build`, saving ~1-2 min per variant (~14-28 min total across the matrix)
- **PHPUnit 10 config**: Updated `phpunit.xml.dist` to PHPUnit 10.5 schema — removed deprecated attributes, replaced `<coverage>` with `<source>`, removed global Mockery listener, switched extensions to `<bootstrap>` tags
- **UserFactory hashing**: Low-cost password params (`opsLimit=3, memLimit=10KiB, cost=4`) matching the test security config — avoids full bcrypt cost on every test that creates a user
- **Test suite split**: Defined `unit` and `functional` suites in `phpunit.xml.dist` so CI jobs can target them independently
- **InvoiceManagerTest**: Converted from `KernelTestCase` to `TestCase` — it only uses mocks and never boots the kernel

## Test Plan

- [x] Full unit test suite passes locally: `bin/phpunit --testsuite unit` (1146 tests, 0 failures)
- [ ] Verify `unit` CI job completes without bun/browser setup
- [ ] Verify `functional` CI job runs the Panther installation test
- [ ] Verify db-tests matrix jobs complete without bun steps
- [ ] Confirm overall CI wall-clock time reduction