### PR TITLE
Fix enum status handling in PDF templates

### DIFF
--- a/src/ClientBundle/Test/Factory/ClientFactory.php
+++ b/src/ClientBundle/Test/Factory/ClientFactory.php
@@ -65,7 +65,7 @@ final class ClientFactory extends PersistentProxyObjectFactory
     protected function defaults(): array
     {
         return [
-            'name' => self::faker()->company(),
+            'name' => self::faker()->unique()->company(),
             'website' => 'https://' . self::faker()->domainName(),
             'status' => self::faker()->randomElement(ClientStatus::cases()),
             'currencyCode' => self::faker()->currencyCode(),

--- a/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
@@ -71,7 +71,7 @@
                             </li>
                         {% endif %}
 
-                        {% if invoice.status == 'active' %}
+                        {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\RecurringInvoiceStatus').Active %}
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="{{ path('_action_recurring_invoice', {'action' : 'pause', 'id' : invoice.id}) }}">
@@ -81,7 +81,7 @@
                             </li>
                         {% endif %}
 
-                        {% if invoice.status == 'paused' %}
+                        {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\RecurringInvoiceStatus').Paused %}
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="{{ path('_action_recurring_invoice', {'action' : 'resume', 'id' : invoice.id}) }}">
@@ -120,7 +120,7 @@
                     {{ ux_icon('tabler:check', {width: 18, height: 18}) }}
                     {{ "invoice.recurring.activate"|trans }}
                 </a>
-            {% elseif invoice.status == 'paused' %}
+            {% elseif invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\RecurringInvoiceStatus').Paused %}
                 <a href="{{ path('_action_recurring_invoice', {'action' : 'resume', 'id' : invoice.id}) }}" class="btn btn-success btn-hero">
                     {{ ux_icon('tabler:player-play', {width: 18, height: 18}) }}
                     {{ "invoice.recurring.resume"|trans }}
@@ -360,7 +360,7 @@
             {% endif %}
 
             {# Upcoming Occurrences Card - Only for Active Invoices #}
-            {% if invoice.status == 'active' and nextOccurrences is defined and nextOccurrences|length > 0 %}
+            {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\RecurringInvoiceStatus').Active and nextOccurrences is defined and nextOccurrences|length > 0 %}
                 <div class="doc-sidebar-card">
                     <div class="doc-sidebar-card-header">
                         <div class="doc-sidebar-card-icon">

--- a/src/InvoiceBundle/Resources/views/Email/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Email/invoice.html.twig
@@ -96,7 +96,7 @@
     {% endif %}
 
     {% if invoice.payments|length > 0 and not invoice.balance.zero %}
-        {% for payment in invoice.payments|filter((v) => v.status == 'captured') %}
+        {% for payment in invoice.payments|filter((v) => v.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured) %}
             {{ email.spacer('xs') }}
             {{ email.info_row('invoice.payment_method'|trans({'%method%': payment.method.name}, 'email'), (payment.total * -1)|formatCurrency(invoice.client.currency)) }}
         {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Email/notification_overdue.text.twig
+++ b/src/InvoiceBundle/Resources/views/Email/notification_overdue.text.twig
@@ -26,7 +26,7 @@
 {% if invoice.balance -%}
 {{ 'invoice.notification_overdue.outstanding_balance'|trans({}, 'email') }}: {{ invoice.balance|formatCurrency(invoice.client.currency) }}
 {% endif -%}
-{{ 'invoice.notification_overdue.status'|trans({}, 'email') }}: {{ invoice.status }}
+{{ 'invoice.notification_overdue.status'|trans({}, 'email') }}: {{ invoice.status.value }}
 
 {{ '-'|repeat(60) }}
 {{ 'invoice.notification_overdue.view_invoice'|trans({}, 'email') }}: {{ url('_invoices_view', {'id': invoice.id}) }}

--- a/src/InvoiceBundle/Resources/views/Email/notification_overdue.text.twig
+++ b/src/InvoiceBundle/Resources/views/Email/notification_overdue.text.twig
@@ -26,7 +26,7 @@
 {% if invoice.balance -%}
 {{ 'invoice.notification_overdue.outstanding_balance'|trans({}, 'email') }}: {{ invoice.balance|formatCurrency(invoice.client.currency) }}
 {% endif -%}
-{{ 'invoice.notification_overdue.status'|trans({}, 'email') }}: {{ invoice.status.value }}
+{{ 'invoice.notification_overdue.status'|trans({}, 'email') }}: {{ invoice.status.label }}
 
 {{ '-'|repeat(60) }}
 {{ 'invoice.notification_overdue.view_invoice'|trans({}, 'email') }}: {{ url('_invoices_view', {'id': invoice.id}) }}

--- a/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
+++ b/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
@@ -16,7 +16,7 @@
 {% if invoice.client -%}
 {{ 'invoice.status_change.client'|trans({}, 'email') }}: {{ invoice.client.name }}
 {% endif -%}
-{{ 'invoice.status_change.new_status'|trans({}, 'email') }}: {{ invoice.status }}
+{{ 'invoice.status_change.new_status'|trans({}, 'email') }}: {{ invoice.status.value }}
 
 {{ '-'|repeat(60) }}
 {{ 'invoice.status_change.view_invoice'|trans({}, 'email') }}: {{ url('_invoices_view', {'id': invoice.id}) }}

--- a/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
+++ b/src/InvoiceBundle/Resources/views/Email/status_change.text.twig
@@ -16,7 +16,7 @@
 {% if invoice.client -%}
 {{ 'invoice.status_change.client'|trans({}, 'email') }}: {{ invoice.client.name }}
 {% endif -%}
-{{ 'invoice.status_change.new_status'|trans({}, 'email') }}: {{ invoice.status.value }}
+{{ 'invoice.status_change.new_status'|trans({}, 'email') }}: {{ invoice.status.label }}
 
 {{ '-'|repeat(60) }}
 {{ 'invoice.status_change.view_invoice'|trans({}, 'email') }}: {{ url('_invoices_view', {'id': invoice.id}) }}

--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -31,7 +31,7 @@
    STATUS WATERMARK
 ============================================================================ #}
 {% if setting('invoice/watermark') %}
-    <watermarktext content="{{ invoice.status|upper }}" alpha="0.08"/>
+    <watermarktext content="{{ invoice.status.value|upper }}" alpha="0.08"/>
 {% endif %}
 
 {# ============================================================================
@@ -125,7 +125,7 @@
                         </td>
                     </tr>
                     {# Due date urgency indicator #}
-                    {% if invoice.status != 'paid' %}
+                    {% if invoice.status != enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Paid %}
                         <tr>
                             <td colspan="2" style="text-align: right; padding: 2px 0 4px 0;">
                                 {% if isOverdue %}
@@ -303,7 +303,7 @@
 
         {# Partial Payments #}
         {% if invoice.payments|length > 0 and not invoice.balance.zero %}
-            {% for payment in invoice.payments|filter((v) => v.status == 'captured') %}
+            {% for payment in invoice.payments|filter((v) => v.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured) %}
                 <tr class="payment-row">
                     <td class="label-cell" style="padding: 8px 20px 8px 12px; font-size: 9pt; text-align: right; color: #475569;">
                         {{ 'invoice.payment.label'|trans }}: {{ payment.method.name }}
@@ -346,7 +346,7 @@
 {# ============================================================================
    PAYMENT INSTRUCTIONS (only show if invoice not paid and payments configured)
 ============================================================================ #}
-{% if invoice.status != 'paid' and payments_configured(false) > 0 %}
+{% if invoice.status != enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Paid and payments_configured(false) > 0 %}
     {% set paymentUrl = url("_payments_create", {"uuid" : invoice.uuid}) %}
     <div class="payment-section" style="margin-top: 24px; padding: 20px; background-color: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 8px;">
         <table cellpadding="0" cellspacing="0" style="width: 100%;">

--- a/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
+++ b/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
@@ -49,7 +49,7 @@
                             {% endif %}
                         </div>
                         {% if not invoice.paid and payments_configured(false) > 0 %}
-                            <a href="{{ path('_payments_create', {'uuid': invoice.uuid}) }}" class="btn btn-primary {{ invoice.status == 'overdue' ? 'btn-danger' : '' }}">
+                            <a href="{{ path('_payments_create', {'uuid': invoice.uuid}) }}" class="btn btn-primary {{ invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Overdue ? 'btn-danger' : '' }}">
                                 {{ ux_icon('tabler:credit-card', {width: 18, height: 18}) }}
                                 {{ 'invoice.action.pay_now'|trans }}
                             </a>
@@ -93,9 +93,9 @@
                                 {% if invoice.due is not empty %}
                                     <div class="col-sm-4 mb-3 mb-sm-0">
                                         <div class="ext-doc-metadata-label text-uppercase small mb-1">{{ 'invoice.due_date'|trans }}</div>
-                                        <div class="ext-doc-metadata-value fw-medium {{ invoice.status == 'overdue' ? 'text-danger' : '' }}">
+                                        <div class="ext-doc-metadata-value fw-medium {{ invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Overdue ? 'text-danger' : '' }}">
                                             {{ invoice.due|date('M d, Y') }}
-                                            {% if invoice.status == 'overdue' %}
+                                            {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Overdue %}
                                                 <span class="badge bg-danger-lt ms-1">{{ 'invoice.invoice_status.overdue'|trans }}</span>
                                             {% endif %}
                                         </div>
@@ -210,7 +210,7 @@
                                         </div>
                                     {% endif %}
                                     {% if invoice.payments|length > 0 and not invoice.balance.isZero %}
-                                        {% for payment in invoice.payments|filter((v) => v.status == 'captured') %}
+                                        {% for payment in invoice.payments|filter((v) => v.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured) %}
                                             <div class="ext-doc-totals-row">
                                                 <div class="ext-doc-totals-label">
                                                     {{ 'invoice.payment.label'|trans }}

--- a/src/InvoiceBundle/Resources/views/invoice_template.html.twig
+++ b/src/InvoiceBundle/Resources/views/invoice_template.html.twig
@@ -187,7 +187,7 @@
                             {% endif %}
                             {% set paid = 0 %}
                             {% if (isRecurring is not defined or isRecurring is same as(false)) and invoice.payments|length > 0 and not invoice.balance.isZero %}
-                                {% for payment in invoice.payments|filter((v) => v.status == 'captured') %}
+                                {% for payment in invoice.payments|filter((v) => v.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured) %}
                                     <tr>
                                         <td colspan="{{ footerSpan }}" class="no-line text-right">
                                             <strong>

--- a/src/PaymentBundle/Resources/views/Email/payment.txt.twig
+++ b/src/PaymentBundle/Resources/views/Email/payment.txt.twig
@@ -24,7 +24,7 @@
 
 {{ 'payment.details.method'|trans({}, 'email') }}: {{ payment.method.name ?? payment.method }}
 {{ 'payment.details.date'|trans({}, 'email') }}: {{ payment.created|date }}
-{{ 'payment.details.status'|trans({}, 'email') }}: {{ payment.status.value }}
+{{ 'payment.details.status'|trans({}, 'email') }}: {{ payment.status.label }}
 
 {% if payment.invoice is not empty %}
 {{ '-'|repeat(60) }}

--- a/src/PaymentBundle/Resources/views/Email/payment.txt.twig
+++ b/src/PaymentBundle/Resources/views/Email/payment.txt.twig
@@ -24,7 +24,7 @@
 
 {{ 'payment.details.method'|trans({}, 'email') }}: {{ payment.method.name ?? payment.method }}
 {{ 'payment.details.date'|trans({}, 'email') }}: {{ payment.created|date }}
-{{ 'payment.details.status'|trans({}, 'email') }}: {{ payment.status }}
+{{ 'payment.details.status'|trans({}, 'email') }}: {{ payment.status.value }}
 
 {% if payment.invoice is not empty %}
 {{ '-'|repeat(60) }}

--- a/src/PaymentBundle/Resources/views/Payment/create.html.twig
+++ b/src/PaymentBundle/Resources/views/Payment/create.html.twig
@@ -131,7 +131,7 @@
                                     </div>
                                 {% endif %}
                                 {% if invoice.payments|length > 0 and not invoice.balance.isZero %}
-                                    {% for payment in invoice.payments|filter((v) => v.status == 'captured') %}
+                                    {% for payment in invoice.payments|filter((v) => v.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured) %}
                                         <div class="totals-row totals-row-payment">
                                             <span class="totals-label">
                                                 {{ 'Payment'|trans }}: {{ payment.method.name }}
@@ -173,7 +173,7 @@
                             <div class="payment-history-body">
                                 <div class="payments-list">
                                     {% for payment in invoice.payments %}
-                                        <div class="payment-card {{ payment.status == 'captured' ? 'payment-card-captured' : (payment.status == 'failed' ? 'payment-card-failed' : '') }}">
+                                        <div class="payment-card {{ payment.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Captured ? 'payment-card-captured' : (payment.status == enum('SolidInvoice\\PaymentBundle\\Enum\\PaymentStatus').Failed ? 'payment-card-failed' : '') }}">
                                             <div class="payment-card-header">
                                                 <div class="payment-amount">{{ payment.totalAmount|formatCurrency(invoice.client.currency) }}</div>
                                                 <div class="payment-status">{{ payment_label(payment.status) }}</div>

--- a/src/QuoteBundle/Resources/views/Email/status_change.text.twig
+++ b/src/QuoteBundle/Resources/views/Email/status_change.text.twig
@@ -16,7 +16,7 @@
 {% if quote.client -%}
 {{ 'quote.status_change.client'|trans({}, 'email') }}: {{ quote.client.name }}
 {% endif -%}
-{{ 'quote.status_change.new_status'|trans({}, 'email') }}: {{ quote.status.value }}
+{{ 'quote.status_change.new_status'|trans({}, 'email') }}: {{ quote.status.label }}
 
 {{ '-'|repeat(60) }}
 {{ 'quote.status_change.view_quote'|trans({}, 'email') }}: {{ url('_quotes_view', {'id': quote.id}) }}

--- a/src/QuoteBundle/Resources/views/Email/status_change.text.twig
+++ b/src/QuoteBundle/Resources/views/Email/status_change.text.twig
@@ -16,7 +16,7 @@
 {% if quote.client -%}
 {{ 'quote.status_change.client'|trans({}, 'email') }}: {{ quote.client.name }}
 {% endif -%}
-{{ 'quote.status_change.new_status'|trans({}, 'email') }}: {{ quote.status }}
+{{ 'quote.status_change.new_status'|trans({}, 'email') }}: {{ quote.status.value }}
 
 {{ '-'|repeat(60) }}
 {{ 'quote.status_change.view_quote'|trans({}, 'email') }}: {{ url('_quotes_view', {'id': quote.id}) }}

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -30,7 +30,7 @@
    STATUS WATERMARK
 ============================================================================ #}
 {% if setting('quote/watermark') %}
-    <watermarktext content="{{ quote.status|upper }}" alpha="0.08"/>
+    <watermarktext content="{{ quote.status.value|upper }}" alpha="0.08"/>
 {% endif %}
 
 {# ============================================================================
@@ -124,7 +124,7 @@
                         </td>
                     </tr>
                     {# Validity indicator #}
-                    {% if quote.status != 'accepted' and quote.status != 'declined' and quote.status != 'cancelled' %}
+                    {% if quote.status != enum('SolidInvoice\\QuoteBundle\\Enum\\QuoteStatus').Accepted and quote.status != enum('SolidInvoice\\QuoteBundle\\Enum\\QuoteStatus').Declined and quote.status != enum('SolidInvoice\\QuoteBundle\\Enum\\QuoteStatus').Cancelled %}
                         <tr>
                             <td colspan="2" style="text-align: right; padding: 2px 0 4px 0;">
                                 {% if isExpired %}


### PR DESCRIPTION
## Summary

- Fix `mb_strtoupper()` TypeError when rendering PDF watermarks by accessing `.value` on backed enum status properties before applying Twig's `|upper` filter
- Replace fragile string comparisons (`status != 'paid'`) with type-safe `enum()` function calls (`status != enum('...').Paid`) in both invoice and quote PDF templates
- Fix the same latent bug in the invoice PDF template that hadn't been reported yet

## Details

The `status` properties on `Quote`, `Invoice`, and `Payment` entities return PHP backed enums (`QuoteStatus`, `InvoiceStatus`, `PaymentStatus`), but the PDF Twig templates were treating them as plain strings. This caused:

1. **Runtime crash**: `mb_strtoupper()` (called by `|upper`) requires a string argument, not an enum object
2. **Silent logic bugs**: String comparisons like `status != 'paid'` always evaluate to `true` when comparing an enum object to a string, causing conditional sections to render incorrectly

Fixes #2341