### PR TITLE
fix: make TransportSetting and UserNotification entity IDs nullable

### DIFF
--- a/src/NotificationBundle/Entity/TransportSetting.php
+++ b/src/NotificationBundle/Entity/TransportSetting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of SolidInvoice project.
  *
@@ -37,7 +39,7 @@ class TransportSetting implements Stringable
     #[ORM\Column(type: UlidType::NAME)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
-    private Ulid $id;
+    private ?Ulid $id = null;
 
     #[ORM\Column(type: Types::STRING, length: 255)]
     #[Assert\NotBlank()]
@@ -56,7 +58,7 @@ class TransportSetting implements Stringable
     #[ORM\ManyToOne(targetEntity: User::class)]
     private User $user;
 
-    public function getId(): Ulid
+    public function getId(): ?Ulid
     {
         return $this->id;
     }

--- a/src/NotificationBundle/Entity/UserNotification.php
+++ b/src/NotificationBundle/Entity/UserNotification.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of SolidInvoice project.
  *
@@ -34,7 +36,7 @@ class UserNotification
     #[ORM\Column(type: UlidType::NAME)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
-    private Ulid $id;
+    private ?Ulid $id = null;
 
     #[ORM\Column(type: Types::STRING, length: 255)]
     private string $event;
@@ -56,7 +58,7 @@ class UserNotification
         $this->transports = new ArrayCollection();
     }
 
-    public function getId(): Ulid
+    public function getId(): ?Ulid
     {
         return $this->id;
     }

--- a/src/NotificationBundle/Tests/Entity/TransportSettingTest.php
+++ b/src/NotificationBundle/Tests/Entity/TransportSettingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\NotificationBundle\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\NotificationBundle\Entity\TransportSetting;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @covers \SolidInvoice\NotificationBundle\Entity\TransportSetting
+ */
+final class TransportSettingTest extends TestCase
+{
+    public function testGetIdReturnsNullForNewEntity(): void
+    {
+        $setting = new TransportSetting();
+
+        self::assertNull($setting->getId());
+    }
+
+    public function testGetIdReturnNullBeforePersist(): void
+    {
+        $setting = new TransportSetting();
+        $setting->setName('Test');
+        $setting->setTransport('some_transport');
+
+        // Accessing getId() on a new entity must not throw an error about
+        // uninitialized typed property - it should return null instead.
+        self::assertNull($setting->getId());
+    }
+
+    public function testSetAndGetName(): void
+    {
+        $setting = new TransportSetting();
+        $setting->setName('My Transport');
+
+        self::assertSame('My Transport', $setting->getName());
+    }
+
+    public function testSetAndGetTransport(): void
+    {
+        $setting = new TransportSetting();
+        $setting->setTransport('slack');
+
+        self::assertSame('slack', $setting->getTransport());
+    }
+
+    public function testSetAndGetSettings(): void
+    {
+        $setting = new TransportSetting();
+        $config = ['token' => 'abc123', 'channel' => '#general'];
+        $setting->setSettings($config);
+
+        self::assertSame($config, $setting->getSettings());
+    }
+
+    public function testDefaultSettingsAreEmpty(): void
+    {
+        $setting = new TransportSetting();
+
+        self::assertSame([], $setting->getSettings());
+    }
+
+    public function testSetAndGetUser(): void
+    {
+        $user = new User();
+        $setting = new TransportSetting();
+        $setting->setUser($user);
+
+        self::assertSame($user, $setting->getUser());
+    }
+
+    public function testToString(): void
+    {
+        $setting = new TransportSetting();
+        $setting->setName('Slack Notifications');
+
+        self::assertSame('Slack Notifications', (string) $setting);
+    }
+
+    public function testIdIsNullableType(): void
+    {
+        $setting = new TransportSetting();
+
+        // Verify the return type is ?Ulid (nullable)
+        $id = $setting->getId();
+        self::assertNull($id);
+        self::assertNotInstanceOf(Ulid::class, $id);
+    }
+}

--- a/src/NotificationBundle/Tests/Entity/UserNotificationTest.php
+++ b/src/NotificationBundle/Tests/Entity/UserNotificationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\NotificationBundle\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\NotificationBundle\Entity\TransportSetting;
+use SolidInvoice\NotificationBundle\Entity\UserNotification;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @covers \SolidInvoice\NotificationBundle\Entity\UserNotification
+ */
+final class UserNotificationTest extends TestCase
+{
+    public function testGetIdReturnsNullForNewEntity(): void
+    {
+        $notification = new UserNotification();
+
+        self::assertNull($notification->getId());
+    }
+
+    public function testGetIdReturnNullBeforePersist(): void
+    {
+        $notification = new UserNotification();
+        $notification->setEvent('invoice.paid');
+        $notification->setEmail(true);
+
+        // Accessing getId() on a new entity must not throw an error about
+        // uninitialized typed property - it should return null instead.
+        self::assertNull($notification->getId());
+    }
+
+    public function testSetAndGetEvent(): void
+    {
+        $notification = new UserNotification();
+        $notification->setEvent('invoice.created');
+
+        self::assertSame('invoice.created', $notification->getEvent());
+    }
+
+    public function testSetAndGetEmail(): void
+    {
+        $notification = new UserNotification();
+        $notification->setEmail(true);
+
+        self::assertTrue($notification->isEmail());
+
+        $notification->setEmail(false);
+        self::assertFalse($notification->isEmail());
+    }
+
+    public function testSetAndGetUser(): void
+    {
+        $user = new User();
+        $notification = new UserNotification();
+        $notification->setUser($user);
+
+        self::assertSame($user, $notification->getUser());
+    }
+
+    public function testTransportsDefaultToEmptyCollection(): void
+    {
+        $notification = new UserNotification();
+
+        self::assertCount(0, $notification->getTransports());
+    }
+
+    public function testAddTransport(): void
+    {
+        $notification = new UserNotification();
+        $transport = new TransportSetting();
+        $transport->setName('Slack');
+        $transport->setTransport('slack');
+
+        $notification->addTransport($transport);
+
+        self::assertCount(1, $notification->getTransports());
+        self::assertTrue($notification->getTransports()->contains($transport));
+    }
+
+    public function testAddTransportDoesNotDuplicate(): void
+    {
+        $notification = new UserNotification();
+        $transport = new TransportSetting();
+        $transport->setName('Slack');
+        $transport->setTransport('slack');
+
+        $notification->addTransport($transport);
+        $notification->addTransport($transport);
+
+        self::assertCount(1, $notification->getTransports());
+    }
+
+    public function testRemoveTransport(): void
+    {
+        $notification = new UserNotification();
+        $transport = new TransportSetting();
+        $transport->setName('Slack');
+        $transport->setTransport('slack');
+
+        $notification->addTransport($transport);
+        $notification->removeTransport($transport);
+
+        self::assertCount(0, $notification->getTransports());
+    }
+
+    public function testToString(): void
+    {
+        $notification = new UserNotification();
+        $notification->setEvent('invoice.sent');
+
+        self::assertSame('invoice.sent', (string) $notification);
+    }
+
+    public function testIdIsNullableType(): void
+    {
+        $notification = new UserNotification();
+
+        // Verify the return type is ?Ulid (nullable)
+        $id = $notification->getId();
+        self::assertNull($id);
+        self::assertNotInstanceOf(Ulid::class, $id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2359

Both `TransportSetting::$id` and `UserNotification::$id` were declared as `private Ulid $id` (non-nullable with no default value). This caused PHP to throw:

> Typed property `SolidInvoice\NotificationBundle\Entity\TransportSetting::$id` must not be accessed before initialization

whenever `getId()` was called on a new (unpersisted) entity — for example, when rendering a form with a new `TransportSetting` object, or when checking `getId() === null` to determine if an entity is new.

## Root Cause

PHP requires that a typed (non-nullable) property be explicitly initialized before it can be read. Doctrine assigns the `$id` value only after `flush()`, so any code that calls `getId()` on a newly-created entity will crash.

## Fix

- Changed `private Ulid $id;` → `private ?Ulid $id = null;` in both entities
- Updated `getId()` return type from `Ulid` to `?Ulid`
- Added `declare(strict_types=1)` (was missing from both files)

This matches the established pattern used by every other entity in the codebase (`Client`, `Invoice`, `Quote`, `Tax`, `User`, `UserInvitation`, etc.).

## Tests

Added unit tests for both entities (`TransportSettingTest`, `UserNotificationTest`) that explicitly verify:
- `getId()` returns `null` on a new entity (the bug that was crashing)
- All getter/setter methods behave correctly

## Test plan

- [ ] Verify `TransportSettingTest` passes — `getId()` returns `null` without error
- [ ] Verify `UserNotificationTest` passes — `getId()` returns `null` without error
- [ ] Create a new notification transport integration in the UI — should no longer crash
- [ ] Confirm existing `NotificationManagerTest` tests still pass (entities are persisted before `getId()` is called there)

https://claude.ai/code/session_01G6gbTQvPv5CwVBFBG4zQDB