### PR TITLE
fix: validate ULID before querying invitation repository (fixes #2346)

### DIFF
--- a/src/UserBundle/Action/AcceptInvitation.php
+++ b/src/UserBundle/Action/AcceptInvitation.php
@@ -22,6 +22,7 @@ use SolidInvoice\UserBundle\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Uid\Ulid;
 
 final class AcceptInvitation
 {
@@ -34,6 +35,10 @@ final class AcceptInvitation
 
     public function __invoke(string $id): RedirectResponse
     {
+        if (! Ulid::isValid($id)) {
+            throw new NotFoundHttpException('Invitation is not valid');
+        }
+
         $invitation = $this->repository->find($id);
 
         if (! $invitation instanceof UserInvitation) {

--- a/src/UserBundle/Action/Register.php
+++ b/src/UserBundle/Action/Register.php
@@ -44,7 +44,13 @@ final class Register extends AbstractController
         $invitation = null;
 
         if ($request->query->has('invitation')) {
-            $invitation = $this->invitationRepository->find(Ulid::fromString($request->query->get('invitation')));
+            $invitationId = $request->query->getString('invitation');
+
+            if (! Ulid::isValid($invitationId)) {
+                throw $this->createNotFoundException('Invitation is not valid');
+            }
+
+            $invitation = $this->invitationRepository->find(Ulid::fromString($invitationId));
 
             if (! $invitation instanceof UserInvitation) {
                 throw $this->createNotFoundException('Invitation is not valid');

--- a/src/UserBundle/Tests/Action/AcceptInvitationTest.php
+++ b/src/UserBundle/Tests/Action/AcceptInvitationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Action;
+
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @group functional
+ */
+final class AcceptInvitationTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+
+    /**
+     * A 26-character string that passes the security access control regex
+     * (/invite/accept/[a-zA-Z0-9-]{26}) but is NOT a valid ULID because it
+     * contains characters excluded from ULID's Crockford base32 alphabet
+     * (e.g. 'O', 'L', 'I' are not valid ULID characters).
+     *
+     * Before the fix, this caused an unhandled InvalidArgumentException / 500.
+     * After the fix, it returns a clean 404.
+     */
+    public function testReturns404ForInvalidUlidFormat(): void
+    {
+        // 26 chars (correct length), but uses 'O' and 'L' which are excluded from ULID's
+        // Crockford base32 alphabet, so this passes the security regex but fails Ulid::isValid()
+        $invalidUlid = '01JXKZ1ABLOOOO1LOOO1LOOOO1';
+
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->request('GET', '/invite/accept/' . $invalidUlid);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testReturns404WhenInvitationNotFound(): void
+    {
+        $validUlid = (string) new Ulid();
+
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->request('GET', '/invite/accept/' . $validUlid);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
## Summary

When accepting an invitation via \`/invite/accept/{id}\`, the raw URL parameter was passed directly to Doctrine's \`find()\` without validation. A 26-character string that passes the security access control regex (\`[a-zA-Z0-9-]{26}\`) but contains characters excluded from ULID's Crockford base32 alphabet (e.g. \`O\`, \`L\`, \`I\`) caused an unhandled \`InvalidArgumentException\` / 500 error in Sentry (SOLIDINVOICE-7B).

A second instance of the same bug exists in the public \`Register\` action, where the \`?invitation=\` query parameter was also passed to \`Ulid::fromString()\` without pre-validation.

## Root cause

The invalid ULID in the Sentry report was **not** caused by a broken email — the invitation URL generation is correct: the entity is persisted first (generating a valid ULID via \`UlidGenerator\`), and *then* the email is sent with \`url('_user_accept_invite', {'id': invitation.id})\`. The crash was caused by someone externally crafting/corrupting the URL (security scan, bad copy-paste, or deliberate probing).

Both affected actions trusted the URL/query parameter to always be a valid ULID and called \`find()\` / \`Ulid::fromString()\` without guard. The security firewall regex only enforces length and alphanumeric characters — not strict ULID alphabet compliance — so invalid strings can reach the controller and crash.

## Changes

- \`src/UserBundle/Action/AcceptInvitation.php\` — add \`Ulid::isValid($id)\` guard before \`repository->find()\`; invalid IDs return 404 instead of crashing
- \`src/UserBundle/Action/Register.php\` — same guard before \`Ulid::fromString()\` on the \`?invitation\` query parameter (also a public route)
- \`src/UserBundle/Tests/Action/AcceptInvitationTest.php\` — functional tests covering the invalid-ULID scenario and a valid-ULID-but-no-invitation scenario

## Testing

- [x] Existing test suite passes (\`php bin/phpunit src/UserBundle/Tests/\`)
- [x] New test \`testReturns404ForInvalidUlidFormat\` reproduces the original bug (returns 404, not 500)
- [x] New test \`testReturns404WhenInvitationNotFound\` covers valid ULID with no matching record
- [x] ECS and PHPStan both pass

Closes #2346