### PR TITLE
Add configurable application URL to installer

### DIFF
--- a/config/packages/routing.php
+++ b/config/packages/routing.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
  */
 
 use Symfony\Config\FrameworkConfig;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
 return static function (FrameworkConfig $config): void {
     $config
         ->router()
-        ->utf8(true);
+        ->utf8(true)
+        ->defaultUri(env('default::SOLIDINVOICE_APPLICATION_URL'));
 };

--- a/config/packages/routing.php
+++ b/config/packages/routing.php
@@ -18,5 +18,5 @@ return static function (FrameworkConfig $config): void {
     $config
         ->router()
         ->utf8(true)
-        ->defaultUri(env('default::SOLIDINVOICE_APPLICATION_URL'));
+        ->defaultUri(env('SOLIDINVOICE_APPLICATION_URL'));
 };

--- a/config/services.php
+++ b/config/services.php
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_LOCALE)', 'en');
     $parameters->set('env(SOLIDINVOICE_APP_SECRET)', null);
     $parameters->set('env(SOLIDINVOICE_INSTALLED)', null);
-    $parameters->set('env(SOLIDINVOICE_APPLICATION_URL)', null);
+    $parameters->set('env(SOLIDINVOICE_APPLICATION_URL)', '');
     $parameters->set('env(SOLIDINVOICE_RUNTIME)', null);
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID)', null);

--- a/config/services.php
+++ b/config/services.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_LOCALE)', 'en');
     $parameters->set('env(SOLIDINVOICE_APP_SECRET)', null);
     $parameters->set('env(SOLIDINVOICE_INSTALLED)', null);
+    $parameters->set('env(SOLIDINVOICE_APPLICATION_URL)', null);
     $parameters->set('env(SOLIDINVOICE_RUNTIME)', null);
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID)', null);

--- a/src/InstallBundle/Action/Install.php
+++ b/src/InstallBundle/Action/Install.php
@@ -78,6 +78,7 @@ final class Install extends AbstractController
                 'installed' => date(DateTimeInterface::ATOM),
                 'locale' => $formData->userAccount->locale,
                 'installation_id' => Uuid::v4()->toString(),
+                'application_url' => (string) $formData->applicationUrl,
             ]);
 
             $form->reset();

--- a/src/InstallBundle/Command/InstallCommand.php
+++ b/src/InstallBundle/Command/InstallCommand.php
@@ -92,7 +92,8 @@ class InstallCommand extends Command
             ->addOption('skip-user', null, InputOption::VALUE_NONE, 'Skip creating the admin user')
             ->addOption('admin-password', null, InputOption::VALUE_REQUIRED, 'The password of admin user')
             ->addOption('admin-email', null, InputOption::VALUE_REQUIRED, 'The email address of admin user')
-            ->addOption('locale', null, InputOption::VALUE_REQUIRED, 'The locale to use');
+            ->addOption('locale', null, InputOption::VALUE_REQUIRED, 'The locale to use')
+            ->addOption('application-url', null, InputOption::VALUE_REQUIRED, 'The URL where this SolidInvoice instance will be accessible (including protocol, e.g. https://invoices.example.com). Use `bin/console secrets:set SOLIDINVOICE_APPLICATION_URL` to update this after installation.');
     }
 
     /**
@@ -126,7 +127,7 @@ class InstallCommand extends Command
      */
     private function validate(InputInterface $input): self
     {
-        $values = ['database-host', 'database-user', 'locale'];
+        $values = ['database-host', 'database-user', 'locale', 'application-url'];
 
         if (! $input->getOption('skip-user')) {
             $values = [...$values, 'admin-password', 'admin-email'];
@@ -139,6 +140,13 @@ class InstallCommand extends Command
         }
         if (! array_key_exists($locale = $input->getOption('locale'), Locales::getNames())) {
             throw new InvalidArgumentException(sprintf('The locale "%s" is invalid', $locale));
+        }
+
+        $applicationUrl = $input->getOption('application-url');
+        $scheme = parse_url((string) $applicationUrl, PHP_URL_SCHEME);
+
+        if (! in_array($scheme, ['http', 'https'], true) || filter_var($applicationUrl, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException(sprintf('The application URL "%s" is not a valid URL. It must include a protocol (http:// or https://).', $applicationUrl));
         }
 
         return $this;
@@ -229,6 +237,7 @@ class InstallCommand extends Command
             'database_user' => $input->getOption('database-user'),
             'database_password' => $input->getOption('database-password'),
             'locale' => $input->getOption('locale'),
+            'application_url' => $input->getOption('application-url'),
             'app_secret' => Key::createNewRandomKey()->saveToAsciiSafeString(),
         ];
 
@@ -287,6 +296,7 @@ class InstallCommand extends Command
             'database-password' => new Question('<question>please enter your database password:</question> '),
             'locale' => (new Question('<question>Please enter a locale:</question> '))
                 ->setAutocompleterValues(array_keys(Locales::getNames())),
+            'application-url' => new Question('<question>Please enter the application URL (including protocol, e.g. https://invoices.example.com):</question> '),
         ];
 
         if (! $input->getOption('skip-user')) {

--- a/src/InstallBundle/DTO/Installation.php
+++ b/src/InstallBundle/DTO/Installation.php
@@ -20,6 +20,7 @@ final class Installation
         public DatabaseConfig $databaseConfig = new DatabaseConfig(),
         #[Valid(groups: ['user_account'])]
         public UserAccount $userAccount = new UserAccount(),
+        public ?string $applicationUrl = null,
         public string $currentStep = 'start',
         public ?string $token = '',
     ) {

--- a/src/InstallBundle/Form/Step/UserAccountStep.php
+++ b/src/InstallBundle/Form/Step/UserAccountStep.php
@@ -13,22 +13,79 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InstallBundle\Form\Step;
 
+use SolidInvoice\InstallBundle\DTO\Installation;
 use SolidInvoice\InstallBundle\DTO\UserAccount;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
 
 /**
  * @see \SolidInvoice\InstallBundle\Tests\Form\Step\SystemInformationFormTest
  */
 class UserAccountStep extends AbstractType
 {
+    public function __construct(
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder->add(
+            'applicationUrl',
+            UrlType::class,
+            [
+                'mapped' => false,
+                'required' => true,
+                'default_protocol' => null,
+                'label' => 'Application URL',
+                'help' => 'The URL where this SolidInvoice instance is accessible. Include the protocol (http:// or https://).',
+                'constraints' => [
+                    new NotBlank(),
+                    new Url(protocols: ['http', 'https']),
+                ],
+            ],
+        );
+
+        $builder->get('applicationUrl')->addEventListener(
+            FormEvents::PRE_SET_DATA,
+            function (FormEvent $event): void {
+                if ($event->getData() !== null && $event->getData() !== '') {
+                    return;
+                }
+
+                $root = $event->getForm()->getRoot()->getData();
+
+                if ($root instanceof Installation && $root->applicationUrl !== null && $root->applicationUrl !== '') {
+                    $event->setData($root->applicationUrl);
+                    return;
+                }
+
+                $event->setData($this->requestStack->getCurrentRequest()?->getSchemeAndHttpHost());
+            },
+        );
+
+        $builder->addEventListener(
+            FormEvents::POST_SUBMIT,
+            static function (FormEvent $event): void {
+                $root = $event->getForm()->getRoot()->getData();
+
+                if ($root instanceof Installation) {
+                    $root->applicationUrl = $event->getForm()->get('applicationUrl')->getData();
+                }
+            },
+        );
+
         if (extension_loaded('intl')) {
             $builder->add(
                 'locale',

--- a/src/InstallBundle/Tests/Form/Step/SystemInformationFormTest.php
+++ b/src/InstallBundle/Tests/Form/Step/SystemInformationFormTest.php
@@ -18,6 +18,8 @@ use SolidInvoice\InstallBundle\DTO\UserAccount;
 use SolidInvoice\InstallBundle\Form\Step\UserAccountStep;
 use SolidInvoice\MoneyBundle\Form\Type\CurrencyType;
 use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Intl\Locales;
 
 /**
@@ -25,6 +27,15 @@ use Symfony\Component\Intl\Locales;
  */
 final class SystemInformationFormTest extends FormTestCase
 {
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = new RequestStack();
+
+        parent::setUp();
+    }
+
     public function testSubmit(): void
     {
         $locale = $this->faker->randomKey(Locales::getNames());
@@ -33,6 +44,7 @@ final class SystemInformationFormTest extends FormTestCase
         $lastName = $this->faker->lastName;
 
         $formData = [
+            'applicationUrl' => 'https://invoices.example.com',
             'locale' => $locale,
             'emailAddress' => $email,
             'firstName' => $firstName,
@@ -62,6 +74,7 @@ final class SystemInformationFormTest extends FormTestCase
         $password = $this->faker->password(8, 20);
 
         $formData = [
+            'applicationUrl' => 'https://invoices.example.com',
             'locale' => $locale,
             'emailAddress' => $email,
             'firstName' => $firstName,
@@ -87,11 +100,22 @@ final class SystemInformationFormTest extends FormTestCase
         $form = $this->factory->create(UserAccountStep::class);
         $view = $form->createView();
 
+        self::assertArrayHasKey('applicationUrl', $view->children);
         self::assertArrayHasKey('locale', $view->children);
         self::assertArrayHasKey('firstName', $view->children);
         self::assertArrayHasKey('lastName', $view->children);
         self::assertArrayHasKey('emailAddress', $view->children);
         self::assertArrayHasKey('password', $view->children);
+    }
+
+    public function testApplicationUrlFieldDefaultsToCurrentRequestHost(): void
+    {
+        $this->requestStack->push(Request::create('https://invoices.example.com/install'));
+
+        $form = $this->factory->create(UserAccountStep::class);
+        $view = $form->createView();
+
+        self::assertSame('https://invoices.example.com', $view->children['applicationUrl']->vars['value']);
     }
 
     public function testConfigureOptions(): void
@@ -140,7 +164,7 @@ final class SystemInformationFormTest extends FormTestCase
     protected function getExtensions(): array
     {
         return [
-            new PreloadedExtension([new CurrencyType('en')], []),
+            new PreloadedExtension([new UserAccountStep($this->requestStack), new CurrencyType('en')], []),
         ];
     }
 }

--- a/src/InstallBundle/Tests/Functional/InstallationTest.php
+++ b/src/InstallBundle/Tests/Functional/InstallationTest.php
@@ -295,6 +295,7 @@ final class InstallationTest extends PantherTestCase
                 static fn (Client $client) => $client->waitFor('input[name="installation[user_account][firstName]"]')
             )
             ->assertSee('User Account')
+            ->assertSee('Application URL')
             ->assertSee('Locale')
             ->assertSee('First Name')
             ->assertSee('Last Name')


### PR DESCRIPTION
## Summary

Adds a configurable Application URL captured during installation and exposed as `SOLIDINVOICE_APPLICATION_URL` for use as Symfony's `framework.router.default_uri`. This lets installed instances generate correct absolute URLs (emails, webhooks, console-generated links) without relying on a live request context.

## What changed

- New `applicationUrl` field on the install system-setup step, defaulting to the current request's scheme+host but user-editable.
- Explicit scheme validation — `http://` or `https://` is required (via Symfony's `Url` constraint on the form, and `parse_url` + `FILTER_VALIDATE_URL` in the CLI).
- `app:install` command gained a `--application-url` option (and interactive prompt) so headless installs can set it.
- The value is written through `ConfigWriter` alongside `installed`, `locale`, and `installation_id`.
- `config/packages/routing.php` wires `default_uri` to `env('default::SOLIDINVOICE_APPLICATION_URL')` with a null fallback so the app still boots before install.
- Post-install, the URL can be updated using Symfony's built-in `bin/console secrets:set SOLIDINVOICE_APPLICATION_URL`.

## Test plan

- [ ] `bin/ecs check` passes
- [ ] `bin/phpstan analyse` shows no new errors in the touched files
- [ ] Web installer: field pre-fills from request host, accepts override, rejects missing scheme
- [ ] `app:install --application-url=...` validates and persists the URL
- [ ] After install, generated absolute URLs (e.g. in emails sent via console) use the configured URL