### PR TITLE
feat(saas): show promo code on trial expired page

### DIFF
--- a/config/packages/saas/services.php
+++ b/config/packages/saas/services.php
@@ -19,4 +19,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_LEMON_SQUEEZY_API_KEY)', null);
     $parameters->set('env(SOLIDINVOICE_LEMON_SQUEEZY_STORE_ID)', null);
     $parameters->set('env(SOLIDINVOICE_LEMON_SQUEEZY_WEBHOOK_SECRET)', '');
+    $parameters->set('env(SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE)', '');
 };

--- a/src/SaasBundle/EventSubscriber/RequestListener.php
+++ b/src/SaasBundle/EventSubscriber/RequestListener.php
@@ -18,6 +18,7 @@ use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -56,6 +57,8 @@ final readonly class RequestListener implements EventSubscriberInterface
         private Security $security,
         private UrlGeneratorInterface $urlGenerator,
         private ClockInterface $clock,
+        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
+        private string $onboardingCouponCode = '',
     ) {
     }
 
@@ -114,6 +117,7 @@ final readonly class RequestListener implements EventSubscriberInterface
                         new Response(
                             $this->twig->render('@SolidInvoiceSaas/subscription/trial_expired.html.twig', [
                                 'subscription' => $subscription,
+                                'coupon_code' => $this->onboardingCouponCode,
                             ]),
                         )
                     );

--- a/src/SaasBundle/Onboarding/Step/TrialAboutToEndStep.php
+++ b/src/SaasBundle/Onboarding/Step/TrialAboutToEndStep.php
@@ -29,7 +29,7 @@ final class TrialAboutToEndStep extends AbstractOnboardingEmailStep
         private readonly ClockInterface $clock,
         private readonly ClientRepository $clientRepository,
         private readonly InvoiceRepository $invoiceRepository,
-        #[Autowire(env: 'SAAS_ONBOARDING_COUPON_CODE')]
+        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
         private readonly string $couponCode = '',
     ) {
         parent::__construct($translator);

--- a/src/SaasBundle/Onboarding/Step/UpgradeOfferStep.php
+++ b/src/SaasBundle/Onboarding/Step/UpgradeOfferStep.php
@@ -21,7 +21,7 @@ final class UpgradeOfferStep extends AbstractOnboardingEmailStep
 {
     public function __construct(
         TranslatorInterface $translator,
-        #[Autowire(env: 'SAAS_ONBOARDING_COUPON_CODE')]
+        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
         private readonly string $couponCode = '',
     ) {
         parent::__construct($translator);

--- a/src/SaasBundle/Resources/views/subscription/trial_expired.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/trial_expired.html.twig
@@ -58,10 +58,42 @@
                 </ul>
             </div>
 
+            {# Limited-time promo to entice activation #}
+            {% if coupon_code|default('') is not empty %}
+                <div class="subscription-promo card border-azure bg-azure-lt mb-4 text-start">
+                    <div class="card-body">
+                        <div class="d-flex align-items-center gap-3">
+                            <div class="subscription-promo-icon text-azure">
+                                {{ ux_icon('tabler:gift', {width: 32, height: 32}) }}
+                            </div>
+                            <div class="flex-grow-1">
+                                <div class="fw-bold fs-3 mb-1">
+                                    {{ 'Don\'t go just yet — here\'s 20% off'|trans }}
+                                </div>
+                                <div class="text-secondary">
+                                    {% trans with {'%code%': coupon_code} %}
+                                        Activate your subscription now and use code <strong>%code%</strong> at checkout to get <strong>20%% off your first 3 months</strong>. Keep your invoices flowing without missing a beat.
+                                    {% endtrans %}
+                                </div>
+                            </div>
+                            <div class="subscription-promo-code text-center">
+                                <div class="text-uppercase text-secondary small mb-1">{{ 'Promo code'|trans }}</div>
+                                <span class="badge bg-azure text-white fs-2 px-3 py-2 font-monospace">{{ coupon_code }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+
             {# Primary CTA #}
             <div class="subscription-actions">
                 <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
-                    {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }} {{ 'Activate Subscription'|trans }}
+                    {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }}
+                    {% if coupon_code|default('') is not empty %}
+                        {{ 'Activate & Save 20%'|trans }}
+                    {% else %}
+                        {{ 'Activate Subscription'|trans }}
+                    {% endif %}
                 </a>
                 <a href="https://solidinvoice.co/contact" class="btn btn-ghost" target="_blank" rel="external noreferrer noopener">
                     {{ ux_icon('tabler:help', {width: 18, height: 18}) }} {{ 'Contact Support'|trans }}

--- a/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
@@ -199,6 +199,38 @@ final class RequestListenerTest extends KernelTestCase
         self::assertStringContainsString('Trial Expired Page', $response->getContent());
     }
 
+    public function testOnRequestWithExpiredTrialPassesCouponCodeToTemplate(): void
+    {
+        $now = new DateTimeImmutable('2024-01-15');
+        $endDate = new DateTimeImmutable('2024-01-10');
+        $subscription = $this->createSubscription(SubscriptionStatus::TRIAL, $endDate);
+
+        $capturedContext = null;
+        $listener = $this->createListener(
+            new User(),
+            $now,
+            $subscription,
+            'WELCOME20',
+            static function (array $context) use (&$capturedContext): void {
+                $capturedContext = $context;
+            },
+        );
+
+        $request = new Request();
+        $request->attributes->set('_route', '_dashboard');
+
+        $event = new RequestEvent(
+            M::mock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener->onRequest($event);
+
+        self::assertIsArray($capturedContext);
+        self::assertSame('WELCOME20', $capturedContext['coupon_code']);
+    }
+
     public function testOnRequestWithTrialStatusBeforeEndDate(): void
     {
         $now = new DateTimeImmutable('2024-01-10');
@@ -255,7 +287,9 @@ final class RequestListenerTest extends KernelTestCase
     private function createListener(
         ?User $user = null,
         ?DateTimeImmutable $now = null,
-        ?Subscription $subscription = null
+        ?Subscription $subscription = null,
+        string $couponCode = '',
+        ?callable $onTrialExpiredRender = null,
     ): RequestListener {
         // Get real services from container
         $companySelector = self::getContainer()->get(CompanySelector::class);
@@ -282,7 +316,13 @@ final class RequestListenerTest extends KernelTestCase
             ->with(M::pattern('/@SolidInvoiceSaas\/subscription\/cancelled\.html\.twig/'), M::any())
             ->andReturn('<html>Cancelled Page</html>');
         $twig->shouldReceive('render')
-            ->with(M::pattern('/@SolidInvoiceSaas\/subscription\/trial_expired\.html\.twig/'), M::any())
+            ->with(M::pattern('/@SolidInvoiceSaas\/subscription\/trial_expired\.html\.twig/'), M::on(static function (array $context) use ($onTrialExpiredRender): bool {
+                if ($onTrialExpiredRender !== null) {
+                    $onTrialExpiredRender($context);
+                }
+
+                return true;
+            }))
             ->andReturn('<html>Trial Expired Page</html>');
         $twig->shouldReceive('render')
             ->with(M::pattern('/@SolidInvoiceSaas\/_alert_banner\.html\.twig/'), M::any())
@@ -303,7 +343,8 @@ final class RequestListenerTest extends KernelTestCase
             $twig,
             $security,
             $urlGenerator,
-            $clock
+            $clock,
+            $couponCode,
         );
     }
 


### PR DESCRIPTION
## Summary

- Render an attention-grabbing Tabler `bg-azure-lt` promo callout on the `trial_expired.html.twig` page when an onboarding coupon code is configured. Marketing copy entices the user to activate with **20% off their first 3 months**, and the primary CTA label switches to "Activate & Save 20%" when a coupon is present.
- Rename env var `SAAS_ONBOARDING_COUPON_CODE` → `SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE` (across `RequestListener`, `TrialAboutToEndStep`, `UpgradeOfferStep`) for consistency with the other `SOLIDINVOICE_*` env vars.
- Register the new env var with an empty string default in `config/packages/saas/services.php` so container compilation doesn't fail when the value is not defined.

The promo block is gated on `coupon_code` being non-empty — the trial-expired page is unchanged in environments where no code is set.

## Test plan

- [x] `bin/phpunit src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php` — 16 tests pass, including the new `testOnRequestWithExpiredTrialPassesCouponCodeToTemplate`
- [x] `bin/phpstan analyse` clean on touched files
- [x] `bin/ecs check --fix` clean on touched files
- [x] `bin/console lint:twig` clean on `trial_expired.html.twig`
- [ ] Manually verify the promo card renders correctly with `SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE` set, and that the page falls back to the original layout when unset