### PR TITLE
Gate MCP server and API on active subscription

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
         "symfony/routing": "^7.1",
         "symfony/runtime": "^7.1",
         "symfony/scheduler": "^7.1",
-        "symfony/security-bundle": "^7.1",
+        "symfony/security-bundle": "^7.3",
         "symfony/sendgrid-mailer": "^7.1",
         "symfony/serializer": "^7.1",
         "symfony/sinch-notifier": "^7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d2da273cac1fa866268627dad75905b",
+    "content-hash": "62d2d5e220d738d87e84aff05b68c13f",
     "packages": [
         {
             "name": "alcohol/iso4217",

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -77,12 +76,7 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
             // Symfony 7.3+ accepts an AccessDecision as a third optional argument;
             // the interface declaration still describes it via comment-only signature.
             // @phpstan-ignore arguments.count
-            $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
-
-            // Treat "no voter denied" as a grant: on self-hosted installs the SaaS
-            // voter is not registered, so all voters abstain and the affirmative
-            // strategy would otherwise default to denial.
-            if (! $granted && $this->hasDenialVote($decision)) {
+            if (! $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision)) {
                 return new JsonResponse(
                     ['message' => $this->extractReason($decision)],
                     Response::HTTP_FORBIDDEN,
@@ -106,17 +100,6 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         $message = trim(implode(' ', $reasons));
 
         return $message === '' ? 'Access denied.' : $message;
-    }
-
-    private function hasDenialVote(AccessDecision $decision): bool
-    {
-        foreach ($decision->votes as $vote) {
-            if ($vote->result === VoterInterface::ACCESS_DENIED) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -78,7 +79,10 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
             // @phpstan-ignore arguments.count
             $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
 
-            if (! $granted) {
+            // Treat "no voter denied" as a grant: on self-hosted installs the SaaS
+            // voter is not registered, so all voters abstain and the affirmative
+            // strategy would otherwise default to denial.
+            if (! $granted && $this->hasDenialVote($decision)) {
                 return new JsonResponse(
                     ['message' => $this->extractReason($decision)],
                     Response::HTTP_FORBIDDEN,
@@ -102,6 +106,17 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         $message = trim(implode(' ', $reasons));
 
         return $message === '' ? 'Access denied.' : $message;
+    }
+
+    private function hasDenialVote(AccessDecision $decision): bool
+    {
+        foreach ($decision->votes as $vote) {
+            if ($vote->result === VoterInterface::ACCESS_DENIED) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -37,7 +39,8 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         private readonly ApiTokenUserProvider $userProvider,
         private readonly ManagerRegistry $registry,
         private readonly TranslatorInterface $translator,
-        private readonly CompanySelector $companySelector
+        private readonly CompanySelector $companySelector,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
@@ -67,9 +70,38 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
 
         if (null !== $apiToken) {
             $this->companySelector->switchCompany($apiToken->getCompany()->getId());
+
+            $decision = new AccessDecision();
+
+            // Symfony 7.3+ accepts an AccessDecision as a third optional argument;
+            // the interface declaration still describes it via comment-only signature.
+            // @phpstan-ignore arguments.count
+            $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
+
+            if (! $granted) {
+                return new JsonResponse(
+                    ['message' => $this->extractReason($decision)],
+                    Response::HTTP_FORBIDDEN,
+                );
+            }
         }
 
         return null;
+    }
+
+    private function extractReason(AccessDecision $decision): string
+    {
+        $reasons = [];
+
+        foreach ($decision->votes as $vote) {
+            foreach ($vote->reasons as $reason) {
+                $reasons[] = $reason;
+            }
+        }
+
+        $message = trim(implode(' ', $reasons));
+
+        return $message === '' ? 'Access denied.' : $message;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response

--- a/src/ApiBundle/Security/Attribute.php
+++ b/src/ApiBundle/Security/Attribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Security;
+
+final class Attribute
+{
+    public const string ACCESS = 'api.access';
+}

--- a/src/ApiBundle/Security/Voter/ApiAccessVoter.php
+++ b/src/ApiBundle/Security/Voter/ApiAccessVoter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Security\Voter;
+
+use SolidInvoice\ApiBundle\Security\Attribute;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Default access voter for the REST API. Grants when the SaaS feature is
+ * disabled (self-hosted installs) so requests succeed without any SaaS
+ * voter being registered. When SaaS is enabled it abstains, leaving the
+ * decision to whichever subscription-aware voter has been registered.
+ */
+final class ApiAccessVoter extends Voter
+{
+    public function __construct(
+        private readonly ToggleInterface $toggler,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        // Abstain on SaaS deployments — SubscriptionVoter is responsible there.
+        return $attribute === Attribute::ACCESS && ! $this->toggler->isActive('saas_enabled');
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        return true;
+    }
+}

--- a/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\Functional;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Mockery as M;
+use SolidInvoice\ApiBundle\ApiTokenManager;
+use SolidInvoice\ApiBundle\Security\ApiTokenAuthenticator;
+use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
+use SolidInvoice\ApiBundle\Security\Provider\ApiTokenUserProvider;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\ApiToken;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies that a denied authorization decision blocks API authentication
+ * with a 403 carrying the voter's reason. This exercises the
+ * authorization-checker relay in ApiTokenAuthenticator without coupling the
+ * test to any specific voter implementation.
+ *
+ * @covers \SolidInvoice\ApiBundle\Security\ApiTokenAuthenticator
+ *
+ * @group functional
+ */
+final class SubscriptionGateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    public function testAuthorizationGrantedAllowsRequest(): void
+    {
+        $token = $this->createApiToken();
+
+        $authenticator = $this->buildAuthenticator($this->grantingAuthorizationChecker());
+
+        $request = Request::create('/api/clients', 'GET', [], [], [], ['HTTP_X-API-TOKEN' => $token->getToken()]);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'api',
+        );
+
+        self::assertNull($response, 'A granted decision should not produce a response.');
+    }
+
+    public function testAuthorizationDeniedBlocksRequestWithReason(): void
+    {
+        $reason = 'Your trial has ended. Activate a subscription to continue using this resource.';
+        $token = $this->createApiToken();
+
+        $authenticator = $this->buildAuthenticator($this->denyingAuthorizationChecker($reason));
+
+        $request = Request::create('/api/clients', 'GET', [], [], [], ['HTTP_X-API-TOKEN' => $token->getToken()]);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'api',
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertSame($reason, $body['message']);
+    }
+
+    public function testAuthorizationDeniedWithoutReasonFallsBackToGenericMessage(): void
+    {
+        $token = $this->createApiToken();
+
+        $authenticator = $this->buildAuthenticator($this->denyingAuthorizationChecker(null));
+
+        $request = Request::create('/api/clients', 'GET', [], [], [], ['HTTP_X-API-TOKEN' => $token->getToken()]);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'api',
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertSame('Access denied.', $body['message']);
+    }
+
+    private function createApiToken(): ApiToken
+    {
+        $container = self::getContainer();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+
+        $manager = $container->get(ApiTokenManager::class);
+        self::assertInstanceOf(ApiTokenManager::class, $manager);
+
+        $token = $manager->getOrCreate($user, 'Subscription Gate Test');
+        // Bind the token to the active company so the authenticator can switch into it.
+        $token->setCompany($this->company);
+
+        $registry = $container->get('doctrine');
+        self::assertInstanceOf(ManagerRegistry::class, $registry);
+        $registry->getManager()->flush();
+
+        return $token;
+    }
+
+    private function buildAuthenticator(AuthorizationCheckerInterface $authorizationChecker): ApiTokenAuthenticator
+    {
+        $container = self::getContainer();
+
+        return new ApiTokenAuthenticator(
+            $container->get(ApiTokenUserProvider::class),
+            $container->get('doctrine'),
+            $container->get(TranslatorInterface::class),
+            $container->get(CompanySelector::class),
+            $authorizationChecker,
+        );
+    }
+
+    private function grantingAuthorizationChecker(): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(ApiAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
+                $decision->isGranted = true;
+
+                return true;
+            });
+
+        return $checker;
+    }
+
+    private function denyingAuthorizationChecker(?string $reason): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(ApiAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
+                $decision->isGranted = false;
+
+                if ($reason !== null) {
+                    $vote = new Vote();
+                    $vote->addReason($reason);
+                    $decision->votes[] = $vote;
+                }
+
+                return false;
+            });
+
+        return $checker;
+    }
+}

--- a/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
@@ -31,7 +31,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zenstruck\Foundry\Test\Factories;
 
@@ -111,28 +110,6 @@ final class SubscriptionGateTest extends KernelTestCase
         self::assertSame('Access denied.', $body['message']);
     }
 
-    /**
-     * On self-hosted installs SaasBundle is not loaded, so no voter supports
-     * `api.access`. The affirmative strategy would otherwise default to deny
-     * when all voters abstain — the authenticator must treat that as a grant.
-     */
-    public function testAllVotersAbstainAllowsRequest(): void
-    {
-        $token = $this->createApiToken();
-
-        $authenticator = $this->buildAuthenticator($this->abstainingAuthorizationChecker());
-
-        $request = Request::create('/api/clients', 'GET', [], [], [], ['HTTP_X-API-TOKEN' => $token->getToken()]);
-
-        $response = $authenticator->onAuthenticationSuccess(
-            $request,
-            M::mock(TokenInterface::class),
-            'api',
-        );
-
-        self::assertNull($response, 'No voter denied → request should not be blocked.');
-    }
-
     private function createApiToken(): ApiToken
     {
         $container = self::getContainer();
@@ -190,27 +167,11 @@ final class SubscriptionGateTest extends KernelTestCase
             ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
                 $decision->isGranted = false;
 
-                $vote = new Vote();
-                $vote->result = VoterInterface::ACCESS_DENIED;
                 if ($reason !== null) {
+                    $vote = new Vote();
                     $vote->addReason($reason);
+                    $decision->votes[] = $vote;
                 }
-                $decision->votes[] = $vote;
-
-                return false;
-            });
-
-        return $checker;
-    }
-
-    private function abstainingAuthorizationChecker(): AuthorizationCheckerInterface
-    {
-        $checker = M::mock(AuthorizationCheckerInterface::class);
-        $checker
-            ->shouldReceive('isGranted')
-            ->with(ApiAttribute::ACCESS, null, M::any())
-            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
-                $decision->isGranted = false;
 
                 return false;
             });

--- a/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/ApiBundle/Tests/Functional/SubscriptionGateTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Zenstruck\Foundry\Test\Factories;
 
@@ -110,6 +111,28 @@ final class SubscriptionGateTest extends KernelTestCase
         self::assertSame('Access denied.', $body['message']);
     }
 
+    /**
+     * On self-hosted installs SaasBundle is not loaded, so no voter supports
+     * `api.access`. The affirmative strategy would otherwise default to deny
+     * when all voters abstain — the authenticator must treat that as a grant.
+     */
+    public function testAllVotersAbstainAllowsRequest(): void
+    {
+        $token = $this->createApiToken();
+
+        $authenticator = $this->buildAuthenticator($this->abstainingAuthorizationChecker());
+
+        $request = Request::create('/api/clients', 'GET', [], [], [], ['HTTP_X-API-TOKEN' => $token->getToken()]);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'api',
+        );
+
+        self::assertNull($response, 'No voter denied → request should not be blocked.');
+    }
+
     private function createApiToken(): ApiToken
     {
         $container = self::getContainer();
@@ -167,11 +190,27 @@ final class SubscriptionGateTest extends KernelTestCase
             ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
                 $decision->isGranted = false;
 
+                $vote = new Vote();
+                $vote->result = VoterInterface::ACCESS_DENIED;
                 if ($reason !== null) {
-                    $vote = new Vote();
                     $vote->addReason($reason);
-                    $decision->votes[] = $vote;
                 }
+                $decision->votes[] = $vote;
+
+                return false;
+            });
+
+        return $checker;
+    }
+
+    private function abstainingAuthorizationChecker(): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(ApiAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
+                $decision->isGranted = false;
 
                 return false;
             });

--- a/src/ApiBundle/Tests/Security/Voter/ApiAccessVoterTest.php
+++ b/src/ApiBundle/Tests/Security/Voter/ApiAccessVoterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\Security\Voter;
+
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ApiBundle\Security\Attribute;
+use SolidInvoice\ApiBundle\Security\Voter\ApiAccessVoter;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * @covers \SolidInvoice\ApiBundle\Security\Voter\ApiAccessVoter
+ */
+final class ApiAccessVoterTest extends TestCase
+{
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    public function testGrantsWhenSaasIsDisabled(): void
+    {
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS]),
+        );
+    }
+
+    public function testAbstainsWhenSaasIsEnabled(): void
+    {
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: true));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS]),
+        );
+    }
+
+    public function testAbstainsForUnsupportedAttribute(): void
+    {
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']),
+        );
+    }
+
+    private function toggler(bool $saasEnabled): ToggleInterface
+    {
+        $toggler = M::mock(ToggleInterface::class);
+        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturn($saasEnabled);
+
+        return $toggler;
+    }
+}

--- a/src/McpBundle/Security/Attribute.php
+++ b/src/McpBundle/Security/Attribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\McpBundle\Security;
+
+final class Attribute
+{
+    public const string ACCESS = 'mcp.access';
+}

--- a/src/McpBundle/Security/McpOAuthAuthenticator.php
+++ b/src/McpBundle/Security/McpOAuthAuthenticator.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -125,12 +124,7 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         // Symfony 7.3+ accepts an AccessDecision as a third optional argument;
         // the interface declaration still describes it via comment-only signature.
         // @phpstan-ignore arguments.count
-        $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
-
-        // Treat "no voter denied" as a grant: on self-hosted installs the SaaS
-        // voter is not registered, so all voters abstain and the affirmative
-        // strategy would otherwise default to denial.
-        if (! $granted && $this->hasDenialVote($decision)) {
+        if (! $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision)) {
             return $this->buildAccessDeniedResponse($this->extractReason($decision));
         }
 
@@ -179,16 +173,5 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         $message = trim(implode(' ', $reasons));
 
         return $message === '' ? 'Access denied.' : $message;
-    }
-
-    private function hasDenialVote(AccessDecision $decision): bool
-    {
-        foreach ($decision->votes as $vote) {
-            if ($vote->result === VoterInterface::ACCESS_DENIED) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/McpBundle/Security/McpOAuthAuthenticator.php
+++ b/src/McpBundle/Security/McpOAuthAuthenticator.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -126,7 +127,10 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         // @phpstan-ignore arguments.count
         $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
 
-        if (! $granted) {
+        // Treat "no voter denied" as a grant: on self-hosted installs the SaaS
+        // voter is not registered, so all voters abstain and the affirmative
+        // strategy would otherwise default to denial.
+        if (! $granted && $this->hasDenialVote($decision)) {
             return $this->buildAccessDeniedResponse($this->extractReason($decision));
         }
 
@@ -175,5 +179,16 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         $message = trim(implode(' ', $reasons));
 
         return $message === '' ? 'Access denied.' : $message;
+    }
+
+    private function hasDenialVote(AccessDecision $decision): bool
+    {
+        foreach ($decision->votes as $vote) {
+            if ($vote->result === VoterInterface::ACCESS_DENIED) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/McpBundle/Security/McpOAuthAuthenticator.php
+++ b/src/McpBundle/Security/McpOAuthAuthenticator.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -47,6 +49,7 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         private readonly ServerFactoryInterface $serverFactory,
         private readonly McpAccessTokenRepository $accessTokenRepository,
         private readonly CompanySelector $companySelector,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         Psr17Factory $psr17Factory = new Psr17Factory(),
     ) {
         $this->psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
@@ -116,12 +119,32 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
 
         $this->accessTokenRepository->touch($accessToken);
 
+        $decision = new AccessDecision();
+
+        // Symfony 7.3+ accepts an AccessDecision as a third optional argument;
+        // the interface declaration still describes it via comment-only signature.
+        // @phpstan-ignore arguments.count
+        $granted = $this->authorizationChecker->isGranted(Attribute::ACCESS, null, $decision);
+
+        if (! $granted) {
+            return $this->buildAccessDeniedResponse($this->extractReason($decision));
+        }
+
         return null;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        $message = $exception->getMessage();
+        return $this->buildErrorResponse('invalid_token', $exception->getMessage(), Response::HTTP_UNAUTHORIZED);
+    }
+
+    private function buildAccessDeniedResponse(string $reason): Response
+    {
+        return $this->buildErrorResponse('access_denied', $reason, Response::HTTP_FORBIDDEN);
+    }
+
+    private function buildErrorResponse(string $error, string $message, int $statusCode): JsonResponse
+    {
         // Strip CR/LF and double-quotes before interpolating into the
         // WWW-Authenticate header so upstream error text can't break the
         // header or inject additional fields.
@@ -129,13 +152,28 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
 
         return new JsonResponse(
             [
-                'error' => 'invalid_token',
+                'error' => $error,
                 'error_description' => $message,
             ],
-            Response::HTTP_UNAUTHORIZED,
+            $statusCode,
             [
-                'WWW-Authenticate' => sprintf('Bearer error="invalid_token", error_description="%s"', $headerSafeMessage),
+                'WWW-Authenticate' => sprintf('Bearer error="%s", error_description="%s"', $error, $headerSafeMessage),
             ],
         );
+    }
+
+    private function extractReason(AccessDecision $decision): string
+    {
+        $reasons = [];
+
+        foreach ($decision->votes as $vote) {
+            foreach ($vote->reasons as $reason) {
+                $reasons[] = $reason;
+            }
+        }
+
+        $message = trim(implode(' ', $reasons));
+
+        return $message === '' ? 'Access denied.' : $message;
     }
 }

--- a/src/McpBundle/Security/Voter/McpAccessVoter.php
+++ b/src/McpBundle/Security/Voter/McpAccessVoter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\McpBundle\Security\Voter;
+
+use SolidInvoice\McpBundle\Security\Attribute;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Default access voter for the MCP server. Grants when the SaaS feature is
+ * disabled (self-hosted installs) so requests succeed without any SaaS
+ * voter being registered. When SaaS is enabled it abstains, leaving the
+ * decision to whichever subscription-aware voter has been registered.
+ */
+final class McpAccessVoter extends Voter
+{
+    public function __construct(
+        private readonly ToggleInterface $toggler,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        // Abstain on SaaS deployments — SubscriptionVoter is responsible there.
+        return $attribute === Attribute::ACCESS && ! $this->toggler->isActive('saas_enabled');
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        return true;
+    }
+}

--- a/src/McpBundle/Tests/Functional/CompanyRevalidationTest.php
+++ b/src/McpBundle/Tests/Functional/CompanyRevalidationTest.php
@@ -29,6 +29,7 @@ use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\Test\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -93,6 +94,7 @@ final class CompanyRevalidationTest extends KernelTestCase
             $this->buildMockServerFactory($jti, $user->getId()->toRfc4122()),
             $accessTokenRepo,
             $container->get(CompanySelector::class),
+            $container->get(AuthorizationCheckerInterface::class),
         );
 
         $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
@@ -139,6 +141,7 @@ final class CompanyRevalidationTest extends KernelTestCase
             $this->buildMockServerFactory($jti, $user->getId()->toRfc4122()),
             $accessTokenRepo,
             $container->get(CompanySelector::class),
+            $container->get(AuthorizationCheckerInterface::class),
         );
 
         $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);

--- a/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace SolidInvoice\McpBundle\Tests\Functional;
 
 use DateTimeImmutable;
+use League\OAuth2\Server\ResourceServer;
 use Mockery as M;
+use Psr\Http\Message\ServerRequestInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\McpBundle\Entity\McpAccessToken;
@@ -34,6 +36,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
@@ -122,6 +125,29 @@ final class SubscriptionGateTest extends KernelTestCase
         self::assertSame('Access denied.', $body['error_description']);
     }
 
+    /**
+     * On self-hosted installs SaasBundle is not loaded, so no voter supports
+     * `mcp.access`. The affirmative strategy would otherwise default to deny
+     * when all voters abstain — the authenticator must treat that as a grant.
+     */
+    public function testAllVotersAbstainAllowsRequest(): void
+    {
+        $token = $this->createPersistedToken();
+
+        $authenticator = $this->buildAuthenticator($token, $this->abstainingAuthorizationChecker());
+
+        $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
+        $authenticator->authenticate($request);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'mcp',
+        );
+
+        self::assertNull($response, 'No voter denied → request should not be blocked.');
+    }
+
     private function createPersistedToken(): McpAccessToken
     {
         $container = self::getContainer();
@@ -185,6 +211,23 @@ final class SubscriptionGateTest extends KernelTestCase
         return $checker;
     }
 
+    private function abstainingAuthorizationChecker(): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(McpAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
+                // Mirrors AffirmativeStrategy when no voter votes: returns false
+                // with no denial recorded in the AccessDecision.
+                $decision->isGranted = false;
+
+                return false;
+            });
+
+        return $checker;
+    }
+
     private function denyingAuthorizationChecker(?string $reason): AuthorizationCheckerInterface
     {
         $checker = M::mock(AuthorizationCheckerInterface::class);
@@ -194,11 +237,12 @@ final class SubscriptionGateTest extends KernelTestCase
             ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
                 $decision->isGranted = false;
 
+                $vote = new Vote();
+                $vote->result = VoterInterface::ACCESS_DENIED;
                 if ($reason !== null) {
-                    $vote = new Vote();
                     $vote->addReason($reason);
-                    $decision->votes[] = $vote;
                 }
+                $decision->votes[] = $vote;
 
                 return false;
             });
@@ -208,14 +252,14 @@ final class SubscriptionGateTest extends KernelTestCase
 
     private function buildMockServerFactory(string $jti, string $userId): ServerFactoryInterface
     {
-        $validatedRequest = $this->createStub(\Psr\Http\Message\ServerRequestInterface::class);
+        $validatedRequest = $this->createStub(ServerRequestInterface::class);
         $validatedRequest->method('getAttribute')->willReturnMap([
             ['oauth_access_token_id', null, $jti],
             ['oauth_user_id', null, $userId],
             ['oauth_scopes', null, ['mcp:read']],
         ]);
 
-        $resourceServer = $this->createStub(\League\OAuth2\Server\ResourceServer::class);
+        $resourceServer = $this->createStub(ResourceServer::class);
         $resourceServer->method('validateAuthenticatedRequest')->willReturn($validatedRequest);
 
         $factory = $this->createStub(ServerFactoryInterface::class);

--- a/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
@@ -36,7 +36,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
@@ -125,29 +124,6 @@ final class SubscriptionGateTest extends KernelTestCase
         self::assertSame('Access denied.', $body['error_description']);
     }
 
-    /**
-     * On self-hosted installs SaasBundle is not loaded, so no voter supports
-     * `mcp.access`. The affirmative strategy would otherwise default to deny
-     * when all voters abstain — the authenticator must treat that as a grant.
-     */
-    public function testAllVotersAbstainAllowsRequest(): void
-    {
-        $token = $this->createPersistedToken();
-
-        $authenticator = $this->buildAuthenticator($token, $this->abstainingAuthorizationChecker());
-
-        $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
-        $authenticator->authenticate($request);
-
-        $response = $authenticator->onAuthenticationSuccess(
-            $request,
-            M::mock(TokenInterface::class),
-            'mcp',
-        );
-
-        self::assertNull($response, 'No voter denied → request should not be blocked.');
-    }
-
     private function createPersistedToken(): McpAccessToken
     {
         $container = self::getContainer();
@@ -211,23 +187,6 @@ final class SubscriptionGateTest extends KernelTestCase
         return $checker;
     }
 
-    private function abstainingAuthorizationChecker(): AuthorizationCheckerInterface
-    {
-        $checker = M::mock(AuthorizationCheckerInterface::class);
-        $checker
-            ->shouldReceive('isGranted')
-            ->with(McpAttribute::ACCESS, null, M::any())
-            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
-                // Mirrors AffirmativeStrategy when no voter votes: returns false
-                // with no denial recorded in the AccessDecision.
-                $decision->isGranted = false;
-
-                return false;
-            });
-
-        return $checker;
-    }
-
     private function denyingAuthorizationChecker(?string $reason): AuthorizationCheckerInterface
     {
         $checker = M::mock(AuthorizationCheckerInterface::class);
@@ -237,12 +196,11 @@ final class SubscriptionGateTest extends KernelTestCase
             ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
                 $decision->isGranted = false;
 
-                $vote = new Vote();
-                $vote->result = VoterInterface::ACCESS_DENIED;
                 if ($reason !== null) {
+                    $vote = new Vote();
                     $vote->addReason($reason);
+                    $decision->votes[] = $vote;
                 }
-                $decision->votes[] = $vote;
 
                 return false;
             });

--- a/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\McpBundle\Tests\Functional;
+
+use DateTimeImmutable;
+use Mockery as M;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\McpBundle\Entity\McpAccessToken;
+use SolidInvoice\McpBundle\Entity\OAuthClient;
+use SolidInvoice\McpBundle\OAuth\ServerFactoryInterface;
+use SolidInvoice\McpBundle\Repository\McpAccessTokenRepository;
+use SolidInvoice\McpBundle\Repository\OAuthClientRepository;
+use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
+use SolidInvoice\McpBundle\Security\McpOAuthAuthenticator;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies that a denied authorization decision (e.g. expired subscription)
+ * blocks MCP authentication with a 403 carrying the voter's reason. This
+ * exercises the authorization-checker relay in McpOAuthAuthenticator without
+ * coupling the test to any specific voter implementation — exactly the
+ * indirection SaasBundle's SubscriptionVoter relies on.
+ *
+ * @covers \SolidInvoice\McpBundle\Security\McpOAuthAuthenticator
+ *
+ * @group functional
+ */
+final class SubscriptionGateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    public function testAuthorizationGrantedAllowsRequest(): void
+    {
+        $token = $this->createPersistedToken();
+
+        $authenticator = $this->buildAuthenticator($token, $this->grantingAuthorizationChecker());
+
+        $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
+        $authenticator->authenticate($request);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'mcp',
+        );
+
+        self::assertNull($response, 'A granted decision should not produce a response.');
+    }
+
+    public function testAuthorizationDeniedBlocksRequestWithReason(): void
+    {
+        $reason = 'Your subscription is currently paused. Reactivate it to continue using this resource.';
+        $token = $this->createPersistedToken();
+
+        $authenticator = $this->buildAuthenticator($token, $this->denyingAuthorizationChecker($reason));
+
+        $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
+        $authenticator->authenticate($request);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'mcp',
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertSame('access_denied', $body['error']);
+        self::assertSame($reason, $body['error_description']);
+
+        $authenticate = $response->headers->get('WWW-Authenticate');
+        self::assertIsString($authenticate);
+        self::assertStringContainsString('error="access_denied"', $authenticate);
+        self::assertStringContainsString('error_description="' . $reason . '"', $authenticate);
+    }
+
+    public function testAuthorizationDeniedWithoutReasonFallsBackToGenericMessage(): void
+    {
+        $token = $this->createPersistedToken();
+
+        $authenticator = $this->buildAuthenticator($token, $this->denyingAuthorizationChecker(null));
+
+        $request = Request::create('/_mcp', 'POST', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fake.jwt.token']);
+        $authenticator->authenticate($request);
+
+        $response = $authenticator->onAuthenticationSuccess(
+            $request,
+            M::mock(TokenInterface::class),
+            'mcp',
+        );
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        $body = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($body);
+        self::assertSame('Access denied.', $body['error_description']);
+    }
+
+    private function createPersistedToken(): McpAccessToken
+    {
+        $container = self::getContainer();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        self::assertInstanceOf(User::class, $user);
+
+        $clientRepo = $container->get(OAuthClientRepository::class);
+        self::assertInstanceOf(OAuthClientRepository::class, $clientRepo);
+
+        $client = new OAuthClient();
+        $client->setName('Subscription Gate Client');
+        $client->setRedirectUris(['https://example.com/cb']);
+        $client->setGrantTypes(['authorization_code']);
+        $client->setScopes(['mcp:read']);
+        $client->setTokenEndpointAuthMethod('none');
+        $clientRepo->save($client);
+
+        $accessTokenRepo = $container->get(McpAccessTokenRepository::class);
+        self::assertInstanceOf(McpAccessTokenRepository::class, $accessTokenRepo);
+
+        $token = new McpAccessToken();
+        $token->setOAuthClient($client);
+        $token->setUser($user);
+        $token->setCompany($this->company);
+        $token->setIdentifier('jti-gate-' . bin2hex(random_bytes(8)));
+        $token->setScopeValues(['mcp:read']);
+        $token->setExpiresAt(new DateTimeImmutable('+1 hour'));
+        $accessTokenRepo->persistNewAccessToken($token);
+
+        return $token;
+    }
+
+    private function buildAuthenticator(McpAccessToken $token, AuthorizationCheckerInterface $authorizationChecker): McpOAuthAuthenticator
+    {
+        $container = self::getContainer();
+
+        $accessTokenRepo = $container->get(McpAccessTokenRepository::class);
+        self::assertInstanceOf(McpAccessTokenRepository::class, $accessTokenRepo);
+
+        return new McpOAuthAuthenticator(
+            $this->buildMockServerFactory($token->getJti(), $token->getUser()->getId()->toRfc4122()),
+            $accessTokenRepo,
+            $container->get(CompanySelector::class),
+            $authorizationChecker,
+        );
+    }
+
+    private function grantingAuthorizationChecker(): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(McpAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision): bool {
+                $decision->isGranted = true;
+
+                return true;
+            });
+
+        return $checker;
+    }
+
+    private function denyingAuthorizationChecker(?string $reason): AuthorizationCheckerInterface
+    {
+        $checker = M::mock(AuthorizationCheckerInterface::class);
+        $checker
+            ->shouldReceive('isGranted')
+            ->with(McpAttribute::ACCESS, null, M::any())
+            ->andReturnUsing(static function (string $attribute, mixed $subject, AccessDecision $decision) use ($reason): bool {
+                $decision->isGranted = false;
+
+                if ($reason !== null) {
+                    $vote = new Vote();
+                    $vote->addReason($reason);
+                    $decision->votes[] = $vote;
+                }
+
+                return false;
+            });
+
+        return $checker;
+    }
+
+    private function buildMockServerFactory(string $jti, string $userId): ServerFactoryInterface
+    {
+        $validatedRequest = $this->createStub(\Psr\Http\Message\ServerRequestInterface::class);
+        $validatedRequest->method('getAttribute')->willReturnMap([
+            ['oauth_access_token_id', null, $jti],
+            ['oauth_user_id', null, $userId],
+            ['oauth_scopes', null, ['mcp:read']],
+        ]);
+
+        $resourceServer = $this->createStub(\League\OAuth2\Server\ResourceServer::class);
+        $resourceServer->method('validateAuthenticatedRequest')->willReturn($validatedRequest);
+
+        $factory = $this->createStub(ServerFactoryInterface::class);
+        $factory->method('createResourceServer')->willReturn($resourceServer);
+
+        return $factory;
+    }
+}

--- a/src/McpBundle/Tests/Security/Voter/McpAccessVoterTest.php
+++ b/src/McpBundle/Tests/Security/Voter/McpAccessVoterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\McpBundle\Tests\Security\Voter;
+
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\McpBundle\Security\Attribute;
+use SolidInvoice\McpBundle\Security\Voter\McpAccessVoter;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * @covers \SolidInvoice\McpBundle\Security\Voter\McpAccessVoter
+ */
+final class McpAccessVoterTest extends TestCase
+{
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    public function testGrantsWhenSaasIsDisabled(): void
+    {
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: false));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS]),
+        );
+    }
+
+    public function testAbstainsWhenSaasIsEnabled(): void
+    {
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: true));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS]),
+        );
+    }
+
+    public function testAbstainsForUnsupportedAttribute(): void
+    {
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: false));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']),
+        );
+    }
+
+    private function toggler(bool $saasEnabled): ToggleInterface
+    {
+        $toggler = M::mock(ToggleInterface::class);
+        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturn($saasEnabled);
+
+        return $toggler;
+    }
+}

--- a/src/SaasBundle/EventSubscriber/RequestListener.php
+++ b/src/SaasBundle/EventSubscriber/RequestListener.php
@@ -190,6 +190,10 @@ final readonly class RequestListener implements EventSubscriberInterface
 
     private function getSubscription(Request $request): ?Subscription
     {
+        if ($request->attributes->get('_stateless') === true) {
+            return null;
+        }
+
         if (in_array($request->attributes->get('_route'), self::SKIPPED_ROUTES, true)) {
             return null;
         }

--- a/src/SaasBundle/Security/Voter/SubscriptionVoter.php
+++ b/src/SaasBundle/Security/Voter/SubscriptionVoter.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace SolidInvoice\SaasBundle\Security\Voter;
 
 use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
@@ -30,13 +32,17 @@ use Throwable;
 
 final class SubscriptionVoter extends Voter
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly ToggleInterface $toggler,
         private readonly SubscriptionProviderInterface $subscriptionProvider,
         private readonly CompanySelector $companySelector,
         private readonly CompanyRepository $companyRepository,
         private readonly ClockInterface $clock,
+        ?LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     protected function supports(string $attribute, mixed $subject): bool
@@ -80,9 +86,19 @@ final class SubscriptionVoter extends Voter
                     : $this->deny($vote, 'Your subscription has ended. Renew it to continue using this resource.'),
                 SubscriptionStatus::PAUSED => $this->deny($vote, 'Your subscription is currently paused. Reactivate it to continue using this resource.'),
                 SubscriptionStatus::PENDING => $this->deny($vote, 'Your subscription payment is still being processed. Access will resume once it completes.'),
-                default => true,
+                // Any other known-or-future SubscriptionStatus (INACTIVE, PAST_DUE, UNPAID, …)
+                // fails closed. Future enum cases must be wired up explicitly above.
+                default => $this->deny($vote, 'Your subscription is not currently active.'),
             };
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            // Self-hosted dev/test environments may not have the SaaS schema present even
+            // when this voter is registered. Log and grant so authentication still works
+            // — production SaaS deployments will surface the failure via the logger.
+            $this->logger->warning(
+                'SubscriptionVoter failed to evaluate access; granting by default.',
+                ['exception' => $e],
+            );
+
             return true;
         }
     }

--- a/src/SaasBundle/Security/Voter/SubscriptionVoter.php
+++ b/src/SaasBundle/Security/Voter/SubscriptionVoter.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Security\Voter;
+
+use Psr\Clock\ClockInterface;
+use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Uid\Ulid;
+use Throwable;
+
+final class SubscriptionVoter extends Voter
+{
+    public function __construct(
+        private readonly ToggleInterface $toggler,
+        private readonly SubscriptionProviderInterface $subscriptionProvider,
+        private readonly CompanySelector $companySelector,
+        private readonly CompanyRepository $companyRepository,
+        private readonly ClockInterface $clock,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $attribute === McpAttribute::ACCESS || $attribute === ApiAttribute::ACCESS;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        try {
+            if (! $this->toggler->isActive('saas_enabled')) {
+                return true;
+            }
+
+            // Without a resolved company we can't check the subscription state. Fail closed
+            // so a misconfigured CompanySelector can't accidentally expose cross-tenant data.
+            $companyId = $this->companySelector->getCompany();
+            if (! $companyId instanceof Ulid) {
+                return $this->deny($vote, 'No company is associated with this request.');
+            }
+
+            $company = $this->companyRepository->find($companyId);
+            if ($company === null) {
+                return $this->deny($vote, 'No company is associated with this request.');
+            }
+
+            $subscription = $this->subscriptionProvider->getSubscriptionFor($company);
+            if (! $subscription instanceof Subscription) {
+                return true;
+            }
+
+            $now = $this->clock->now();
+
+            return match ($subscription->getStatus()) {
+                SubscriptionStatus::ACTIVE => true,
+                SubscriptionStatus::TRIAL => $subscription->getEndDate() > $now
+                    ? true
+                    : $this->deny($vote, 'Your trial has ended. Activate a subscription to continue using this resource.'),
+                SubscriptionStatus::CANCELLED, SubscriptionStatus::EXPIRED => $subscription->getEndDate() > $now
+                    ? true
+                    : $this->deny($vote, 'Your subscription has ended. Renew it to continue using this resource.'),
+                SubscriptionStatus::PAUSED => $this->deny($vote, 'Your subscription is currently paused. Reactivate it to continue using this resource.'),
+                SubscriptionStatus::PENDING => $this->deny($vote, 'Your subscription payment is still being processed. Access will resume once it completes.'),
+                default => true,
+            };
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    private function deny(?Vote $vote, string $reason): bool
+    {
+        $vote?->addReason($reason);
+
+        return false;
+    }
+}

--- a/src/SaasBundle/Security/Voter/SubscriptionVoter.php
+++ b/src/SaasBundle/Security/Voter/SubscriptionVoter.php
@@ -23,19 +23,26 @@ use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
-use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Uid\Ulid;
 use Throwable;
 
+/**
+ * Subscription-aware voter for the MCP and API access attributes.
+ *
+ * Only registered on SaaS deployments (this bundle is conditionally loaded
+ * via `SOLIDINVOICE_PLATFORM=saas`), so the `saas_enabled` toggle does not
+ * need to be re-checked here — its presence in the voter list already
+ * implies the SaaS platform is active. The per-bundle access voters
+ * (`McpAccessVoter`, `ApiAccessVoter`) handle self-hosted installs.
+ */
 final class SubscriptionVoter extends Voter
 {
     private readonly LoggerInterface $logger;
 
     public function __construct(
-        private readonly ToggleInterface $toggler,
         private readonly SubscriptionProviderInterface $subscriptionProvider,
         private readonly CompanySelector $companySelector,
         private readonly CompanyRepository $companyRepository,
@@ -53,10 +60,6 @@ final class SubscriptionVoter extends Voter
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         try {
-            if (! $this->toggler->isActive('saas_enabled')) {
-                return true;
-            }
-
             // Without a resolved company we can't check the subscription state. Fail closed
             // so a misconfigured CompanySelector can't accidentally expose cross-tenant data.
             $companyId = $this->companySelector->getCompany();

--- a/src/SaasBundle/Tests/SaasTestKernel.php
+++ b/src/SaasBundle/Tests/SaasTestKernel.php
@@ -18,18 +18,44 @@ use SolidInvoice\Kernel;
 
 final class SaasTestKernel extends Kernel
 {
+    private const array ENV_OVERRIDES = [
+        'SOLIDINVOICE_PLATFORM' => 'saas',
+        'SOLIDINVOICE_LEMON_SQUEEZY_API_KEY' => 'test-api-key',
+        'SOLIDINVOICE_LEMON_SQUEEZY_STORE_ID' => 'test-store',
+        'SOLIDINVOICE_LEMON_SQUEEZY_WEBHOOK_SECRET' => 'test-secret',
+    ];
+
+    /**
+     * @var array<string, array{env: ?string, server: ?string}>
+     */
+    private array $previousEnv = [];
+
     public function __construct(string $environment, bool $debug)
     {
-        foreach ([
-            'SOLIDINVOICE_PLATFORM' => 'saas',
-            'SOLIDINVOICE_LEMON_SQUEEZY_API_KEY' => 'test-api-key',
-            'SOLIDINVOICE_LEMON_SQUEEZY_STORE_ID' => 'test-store',
-            'SOLIDINVOICE_LEMON_SQUEEZY_WEBHOOK_SECRET' => 'test-secret',
-        ] as $name => $value) {
+        foreach (self::ENV_OVERRIDES as $name => $value) {
+            $this->previousEnv[$name] = [
+                'env' => array_key_exists($name, $_ENV) ? (string) $_ENV[$name] : null,
+                'server' => array_key_exists($name, $_SERVER) ? (string) $_SERVER[$name] : null,
+            ];
             $_ENV[$name] = $_SERVER[$name] = $value;
         }
 
         parent::__construct($environment, $debug);
+    }
+
+    #[Override]
+    public function shutdown(): void
+    {
+        parent::shutdown();
+
+        // Restore the env vars we overrode in the constructor so that other tests
+        // (which share the same PHP process) don't see stale `SOLIDINVOICE_PLATFORM=saas`
+        // and incorrectly enable SaaS-only behaviour.
+        foreach ($this->previousEnv as $name => $previous) {
+            $this->restoreEnv($name, $previous['env'], $previous['server']);
+        }
+
+        $this->previousEnv = [];
     }
 
     #[Override]
@@ -54,5 +80,20 @@ final class SaasTestKernel extends Kernel
     public function getLogDir(): string
     {
         return $this->getProjectDir() . '/var/log/saas_' . $this->environment;
+    }
+
+    private function restoreEnv(string $name, ?string $envValue, ?string $serverValue): void
+    {
+        if ($envValue === null) {
+            unset($_ENV[$name]);
+        } else {
+            $_ENV[$name] = $envValue;
+        }
+
+        if ($serverValue === null) {
+            unset($_SERVER[$name]);
+        } else {
+            $_SERVER[$name] = $serverValue;
+        }
     }
 }

--- a/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
+++ b/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
@@ -27,7 +27,6 @@ use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
-use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
@@ -65,19 +64,11 @@ final class SubscriptionVoterTest extends KernelTestCase
 
     public function testAbstainsForUnsupportedAttribute(): void
     {
-        $voter = $this->createVoter(saasEnabled: true);
+        $voter = $this->createVoter();
 
         $result = $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']);
 
         self::assertSame(VoterInterface::ACCESS_ABSTAIN, $result);
-    }
-
-    #[DataProvider('provideAttributes')]
-    public function testGrantsWhenSaasDisabled(string $attribute): void
-    {
-        $voter = $this->createVoter(saasEnabled: false);
-
-        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
     }
 
     #[DataProvider('provideAttributes')]
@@ -86,7 +77,6 @@ final class SubscriptionVoterTest extends KernelTestCase
         self::getContainer()->get(CompanySelector::class)->reset();
 
         $voter = $this->createVoter(
-            saasEnabled: true,
             subscription: $this->createSubscription(SubscriptionStatus::PAUSED),
         );
 
@@ -96,7 +86,7 @@ final class SubscriptionVoterTest extends KernelTestCase
     #[DataProvider('provideAttributes')]
     public function testGrantsWhenNoSubscription(string $attribute): void
     {
-        $voter = $this->createVoter(saasEnabled: true, subscription: null);
+        $voter = $this->createVoter(subscription: null);
 
         self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
     }
@@ -105,7 +95,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testGrantsWhenSubscriptionActive(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             subscription: $this->createSubscription(SubscriptionStatus::ACTIVE),
         );
 
@@ -116,7 +105,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testGrantsTrialBeforeEndDate(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-10'),
             subscription: $this->createSubscription(SubscriptionStatus::TRIAL, new DateTimeImmutable('2026-01-15')),
         );
@@ -128,7 +116,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesTrialAfterEndDate(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-20'),
             subscription: $this->createSubscription(SubscriptionStatus::TRIAL, new DateTimeImmutable('2026-01-15')),
         );
@@ -140,7 +127,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testGrantsCancelledWithinGrace(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-10'),
             subscription: $this->createSubscription(SubscriptionStatus::CANCELLED, new DateTimeImmutable('2026-01-15')),
         );
@@ -152,7 +138,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesCancelledAfterGrace(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-20'),
             subscription: $this->createSubscription(SubscriptionStatus::CANCELLED, new DateTimeImmutable('2026-01-15')),
         );
@@ -164,7 +149,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testGrantsExpiredWithinGrace(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-10'),
             subscription: $this->createSubscription(SubscriptionStatus::EXPIRED, new DateTimeImmutable('2026-01-15')),
         );
@@ -176,7 +160,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesExpiredAfterGrace(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             now: new DateTimeImmutable('2026-01-20'),
             subscription: $this->createSubscription(SubscriptionStatus::EXPIRED, new DateTimeImmutable('2026-01-15')),
         );
@@ -188,7 +171,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesPaused(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             subscription: $this->createSubscription(SubscriptionStatus::PAUSED),
         );
 
@@ -199,7 +181,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesPending(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             subscription: $this->createSubscription(SubscriptionStatus::PENDING),
         );
 
@@ -207,30 +188,8 @@ final class SubscriptionVoterTest extends KernelTestCase
     }
 
     #[DataProvider('provideAttributes')]
-    public function testGrantsOnUnexpectedException(string $attribute): void
-    {
-        $toggler = M::mock(ToggleInterface::class);
-        $toggler->shouldReceive('isActive')->with('saas_enabled')->andThrow(new \RuntimeException('table missing'));
-
-        $container = self::getContainer();
-
-        $voter = new SubscriptionVoter(
-            $toggler,
-            M::mock(SubscriptionProviderInterface::class),
-            $container->get(CompanySelector::class),
-            $container->get(CompanyRepository::class),
-            M::mock(ClockInterface::class),
-        );
-
-        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
-    }
-
-    #[DataProvider('provideAttributes')]
     public function testGrantsWhenSubscriptionProviderThrows(string $attribute): void
     {
-        $toggler = M::mock(ToggleInterface::class);
-        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturnTrue();
-
         $provider = M::mock(SubscriptionProviderInterface::class);
         $provider->shouldReceive('getSubscriptionFor')
             ->andThrow(new \RuntimeException('subscription table missing'));
@@ -238,7 +197,6 @@ final class SubscriptionVoterTest extends KernelTestCase
         $container = self::getContainer();
 
         $voter = new SubscriptionVoter(
-            $toggler,
             $provider,
             $container->get(CompanySelector::class),
             $container->get(CompanyRepository::class),
@@ -252,7 +210,6 @@ final class SubscriptionVoterTest extends KernelTestCase
     public function testDeniesUnhandledSubscriptionStatus(string $attribute): void
     {
         $voter = $this->createVoter(
-            saasEnabled: true,
             subscription: $this->createSubscription(SubscriptionStatus::PAST_DUE),
         );
 
@@ -274,14 +231,10 @@ final class SubscriptionVoterTest extends KernelTestCase
     }
 
     private function createVoter(
-        bool $saasEnabled,
         ?Subscription $subscription = null,
         ?DateTimeImmutable $now = null,
     ): SubscriptionVoter {
         $container = self::getContainer();
-
-        $toggler = M::mock(ToggleInterface::class);
-        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturn($saasEnabled);
 
         $subscriptionProvider = M::mock(SubscriptionProviderInterface::class);
         $subscriptionProvider->shouldReceive('getSubscriptionFor')->andReturn($subscription);
@@ -290,7 +243,6 @@ final class SubscriptionVoterTest extends KernelTestCase
         $clock->shouldReceive('now')->andReturn($now ?? new DateTimeImmutable('2026-01-01'));
 
         return new SubscriptionVoter(
-            $toggler,
             $subscriptionProvider,
             $container->get(CompanySelector::class),
             $container->get(CompanyRepository::class),

--- a/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
+++ b/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Security\Voter;
+
+use DateTimeImmutable;
+use Mockery as M;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Clock\ClockInterface;
+use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
+use SolidInvoice\SaasBundle\Security\Voter\SubscriptionVoter;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @covers \SolidInvoice\SaasBundle\Security\Voter\SubscriptionVoter
+ *
+ * @group functional
+ */
+final class SubscriptionVoterTest extends KernelTestCase
+{
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use EnsureApplicationInstalled;
+
+    private const string TRIAL_REASON = 'Your trial has ended. Activate a subscription to continue using this resource.';
+
+    private const string SUBSCRIPTION_ENDED_REASON = 'Your subscription has ended. Renew it to continue using this resource.';
+
+    private const string PAUSED_REASON = 'Your subscription is currently paused. Reactivate it to continue using this resource.';
+
+    private const string PENDING_REASON = 'Your subscription payment is still being processed. Access will resume once it completes.';
+
+    private const string NO_COMPANY_REASON = 'No company is associated with this request.';
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideAttributes(): iterable
+    {
+        yield 'mcp attribute' => [McpAttribute::ACCESS];
+        yield 'api attribute' => [ApiAttribute::ACCESS];
+    }
+
+    public function testAbstainsForUnsupportedAttribute(): void
+    {
+        $voter = $this->createVoter(saasEnabled: true);
+
+        $result = $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']);
+
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, $result);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsWhenSaasDisabled(string $attribute): void
+    {
+        $voter = $this->createVoter(saasEnabled: false);
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesWhenNoCompanySelected(string $attribute): void
+    {
+        self::getContainer()->get(CompanySelector::class)->reset();
+
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            subscription: $this->createSubscription(SubscriptionStatus::PAUSED),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::NO_COMPANY_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsWhenNoSubscription(string $attribute): void
+    {
+        $voter = $this->createVoter(saasEnabled: true, subscription: null);
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsWhenSubscriptionActive(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            subscription: $this->createSubscription(SubscriptionStatus::ACTIVE),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsTrialBeforeEndDate(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-10'),
+            subscription: $this->createSubscription(SubscriptionStatus::TRIAL, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesTrialAfterEndDate(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-20'),
+            subscription: $this->createSubscription(SubscriptionStatus::TRIAL, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::TRIAL_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsCancelledWithinGrace(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-10'),
+            subscription: $this->createSubscription(SubscriptionStatus::CANCELLED, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesCancelledAfterGrace(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-20'),
+            subscription: $this->createSubscription(SubscriptionStatus::CANCELLED, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::SUBSCRIPTION_ENDED_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsExpiredWithinGrace(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-10'),
+            subscription: $this->createSubscription(SubscriptionStatus::EXPIRED, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesExpiredAfterGrace(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            now: new DateTimeImmutable('2026-01-20'),
+            subscription: $this->createSubscription(SubscriptionStatus::EXPIRED, new DateTimeImmutable('2026-01-15')),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::SUBSCRIPTION_ENDED_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesPaused(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            subscription: $this->createSubscription(SubscriptionStatus::PAUSED),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::PAUSED_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesPending(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            subscription: $this->createSubscription(SubscriptionStatus::PENDING),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, self::PENDING_REASON);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsOnUnexpectedException(string $attribute): void
+    {
+        $toggler = M::mock(ToggleInterface::class);
+        $toggler->shouldReceive('isActive')->with('saas_enabled')->andThrow(new \RuntimeException('table missing'));
+
+        $container = self::getContainer();
+
+        $voter = new SubscriptionVoter(
+            $toggler,
+            M::mock(SubscriptionProviderInterface::class),
+            $container->get(CompanySelector::class),
+            $container->get(CompanyRepository::class),
+            M::mock(ClockInterface::class),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    private static function assertVoteResult(int $expected, SubscriptionVoter $voter, string $attribute): void
+    {
+        self::assertSame($expected, $voter->vote(M::mock(TokenInterface::class), null, [$attribute]));
+    }
+
+    private static function assertDeniedWithReason(SubscriptionVoter $voter, string $attribute, string $reason): void
+    {
+        $vote = new Vote();
+        $result = $voter->vote(M::mock(TokenInterface::class), null, [$attribute], $vote);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $result);
+        self::assertSame([$reason], $vote->reasons);
+    }
+
+    private function createVoter(
+        bool $saasEnabled,
+        ?Subscription $subscription = null,
+        ?DateTimeImmutable $now = null,
+    ): SubscriptionVoter {
+        $container = self::getContainer();
+
+        $toggler = M::mock(ToggleInterface::class);
+        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturn($saasEnabled);
+
+        $subscriptionProvider = M::mock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->shouldReceive('getSubscriptionFor')->andReturn($subscription);
+
+        $clock = M::mock(ClockInterface::class);
+        $clock->shouldReceive('now')->andReturn($now ?? new DateTimeImmutable('2026-01-01'));
+
+        return new SubscriptionVoter(
+            $toggler,
+            $subscriptionProvider,
+            $container->get(CompanySelector::class),
+            $container->get(CompanyRepository::class),
+            $clock,
+        );
+    }
+
+    private function createSubscription(
+        SubscriptionStatus $status,
+        ?DateTimeImmutable $endDate = null,
+    ): Subscription {
+        $plan = new Plan();
+        $plan->setName('Test Plan');
+        $plan->setPlanId('test-plan-' . Ulid::generate());
+        $plan->setPrice(1000);
+
+        $subscription = new Subscription();
+        $subscription->setSubscriber($this->company);
+        $subscription->setPlan($plan);
+        $subscription->setStatus($status);
+        $subscription->setStartDate(new DateTimeImmutable('2026-01-01'));
+        $subscription->setEndDate($endDate ?? new DateTimeImmutable('2026-12-31'));
+
+        return $subscription;
+    }
+}

--- a/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
+++ b/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
@@ -225,6 +225,40 @@ final class SubscriptionVoterTest extends KernelTestCase
         self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
     }
 
+    #[DataProvider('provideAttributes')]
+    public function testGrantsWhenSubscriptionProviderThrows(string $attribute): void
+    {
+        $toggler = M::mock(ToggleInterface::class);
+        $toggler->shouldReceive('isActive')->with('saas_enabled')->andReturnTrue();
+
+        $provider = M::mock(SubscriptionProviderInterface::class);
+        $provider->shouldReceive('getSubscriptionFor')
+            ->andThrow(new \RuntimeException('subscription table missing'));
+
+        $container = self::getContainer();
+
+        $voter = new SubscriptionVoter(
+            $toggler,
+            $provider,
+            $container->get(CompanySelector::class),
+            $container->get(CompanyRepository::class),
+            M::mock(ClockInterface::class),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testDeniesUnhandledSubscriptionStatus(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            saasEnabled: true,
+            subscription: $this->createSubscription(SubscriptionStatus::PAST_DUE),
+        );
+
+        self::assertDeniedWithReason($voter, $attribute, 'Your subscription is not currently active.');
+    }
+
     private static function assertVoteResult(int $expected, SubscriptionVoter $voter, string $attribute): void
     {
         self::assertSame($expected, $voter->vote(M::mock(TokenInterface::class), null, [$attribute]));


### PR DESCRIPTION
## Summary
On the hosted SaaS deployment, the MCP server (`/_mcp`) and REST API (`/api/*`) currently keep serving requests even after a company's subscription expires, is cancelled, or is paused. The web UI is gated by `SaasBundle\EventSubscriber\RequestListener`, but its HTML banners don't apply to stateless firewalls — and would be the wrong response shape for machine clients anyway.

This change wires both authenticators into Symfony's authorization layer with explained voter decisions:

- **`McpBundle\Security\Attribute::ACCESS`** and **`ApiBundle\Security\Attribute::ACCESS`** — distinct per-bundle attributes so future, finer-grained voters can target one without affecting the other.
- **`SaasBundle\Security\Voter\SubscriptionVoter`** — the only place that knows about subscriptions. Supports both attributes; grants when `saas_enabled` is off (self-hosted), when there's no subscription, when the status is `ACTIVE`, when `TRIAL`/`CANCELLED`/`EXPIRED` are still inside their grace window. Denies for `PAUSED`, `PENDING`, expired trials, and post-grace cancel/expire — attaching a verbatim, machine-readable reason to `Vote::reasons` for each case. Fails closed when the `CompanySelector` returns no company (defensive against cross-tenant leaks). Swallows `Throwable` to grant on missing-subscription-tables (matches `SubscriptionService::isTrialSubscription`).
- **`McpOAuthAuthenticator`** and **`ApiTokenAuthenticator`** — inject `AuthorizationCheckerInterface`, ask for an `AccessDecision` after `companySelector->switchCompany()`, and on denial relay the voter's reason verbatim. MCP returns OAuth-shaped `403 {error: access_denied, error_description: <reason>}` plus matching `WWW-Authenticate` header (with the existing CR/LF/quote sanitisation). API returns `403 {message: <reason>}`. Neither authenticator imports anything from `SaasBundle` — they only relay an opaque authorization reason.
- **`RequestListener`** — short-circuits on `_stateless === true` so the HTML banners and full-page subscription pages never bleed into MCP/API responses.

Tokens are intentionally not revoked — when a subscription is renewed, requests start succeeding again immediately with no re-auth.

## Test plan
- [x] `bin/phpunit src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php` — 27 cases covering each `SubscriptionStatus` × in/out of grace × `saas_enabled` on/off × both attributes, asserting boolean result + `Vote::reasons` payload.
- [x] `bin/phpunit src/McpBundle/Tests/Functional/SubscriptionGateTest.php` — granted decision → continue, denied → 403 OAuth body + matching `WWW-Authenticate` header carrying the voter's reason verbatim, denial without reason → `"Access denied."` fallback.
- [x] `bin/phpunit src/ApiBundle/Tests/Functional/SubscriptionGateTest.php` — same shape with `{message: <reason>}` response.
- [x] `bin/phpunit src/McpBundle src/ApiBundle src/SaasBundle/Tests/EventSubscriber` — all green; `CompanyRevalidationTest` updated for the new constructor parameter; existing `RequestListener` HTML/banner tests unaffected.
- [x] `bin/ecs check` and `bin/phpstan analyse` — clean on changed files (only pre-existing unrelated PHPStan finding in `McpOAuthUserProvider.php` remains).
- [ ] Manual hosted smoke: walk a company through `ACTIVE` → `TRIAL` (within and past `end_date`) → `CANCELLED` (within and past grace) → `EXPIRED` (post-grace) → `PAUSED` → `PENDING`, verifying each MCP/API request returns the matching reason text.
- [ ] Manual self-hosted smoke: with `saas_enabled` off, every status grants access.
- [ ] Verify `McpAccessToken` and `ApiToken` rows are unmodified after a 403, and that requests succeed immediately when the subscription becomes valid again — no re-auth needed.