### PR TITLE
feat(export): grid export + full company data export

### DIFF
--- a/assets/scss/components/_datagrid.scss
+++ b/assets/scss/components/_datagrid.scss
@@ -477,6 +477,116 @@
 }
 
 // ============================================================================
+// EXPORT MENU (Dropdown)
+// ============================================================================
+
+.datagrid-export-dropdown {
+    position: relative;
+}
+
+.datagrid-export-menu {
+    width: 280px;
+    padding: 0 !important;
+    border: 1px solid var(--swp-border);
+    border-radius: var(--swp-radius-lg);
+    box-shadow: var(--swp-shadow-lg);
+    overflow: hidden;
+}
+
+.datagrid-export-menu-header {
+    padding: var(--swp-space-3) var(--swp-space-4);
+    background: var(--swp-gray-50);
+    border-bottom: 1px solid var(--swp-border-light);
+}
+
+.datagrid-export-menu-title {
+    display: flex;
+    align-items: center;
+    gap: var(--swp-space-2);
+    margin: 0;
+    font-size: var(--swp-text-sm);
+    font-weight: var(--swp-font-semibold);
+    color: var(--swp-text-primary);
+
+    svg {
+        width: 16px;
+        height: 16px;
+        color: var(--swp-text-muted);
+    }
+}
+
+.datagrid-export-menu-subtitle {
+    margin: var(--swp-space-1) 0 0;
+    font-size: var(--swp-text-xs);
+    color: var(--swp-text-muted);
+}
+
+.datagrid-export-menu-body {
+    display: flex;
+    flex-direction: column;
+    padding: var(--swp-space-2);
+    gap: var(--swp-space-1);
+}
+
+.datagrid-export-option {
+    display: flex;
+    align-items: center;
+    gap: var(--swp-space-3);
+    padding: var(--swp-space-2) var(--swp-space-3);
+    border-radius: var(--swp-radius-md);
+    color: var(--swp-text-primary);
+    text-decoration: none;
+    transition: background-color var(--swp-transition-fast),
+                color var(--swp-transition-fast);
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background: var(--swp-gray-50);
+        color: var(--swp-text-primary);
+        outline: none;
+    }
+}
+
+.datagrid-export-option-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    color: var(--swp-text-secondary);
+    background: var(--swp-surface);
+    border: 1px solid var(--swp-border-light);
+    border-radius: var(--swp-radius-md);
+
+    .datagrid-export-option:hover &,
+    .datagrid-export-option:focus-visible & {
+        color: var(--swp-primary);
+        border-color: var(--swp-primary-light);
+        background: var(--swp-primary-lighter);
+    }
+}
+
+.datagrid-export-option-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.datagrid-export-option-label {
+    font-size: var(--swp-text-sm);
+    font-weight: var(--swp-font-semibold);
+    color: var(--swp-text-primary);
+    letter-spacing: 0.02em;
+}
+
+.datagrid-export-option-hint {
+    font-size: var(--swp-text-xs);
+    color: var(--swp-text-muted);
+}
+
+// ============================================================================
 // COLUMN VISIBILITY
 // ============================================================================
 

--- a/config/packages/messenger.php
+++ b/config/packages/messenger.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use SolidInvoice\CoreBundle\Export\Message\RequestCompanyExport;
 use SolidInvoice\CronBundle\Messenger\SentrySchedulerMiddleware;
 use SolidInvoice\SaasBundle\Message\SendOnboardingEmailMessage;
 use Symfony\Config\FrameworkConfig;
@@ -39,6 +40,11 @@ return static function (FrameworkConfig $config): void {
     // scheduler returns quickly and Messenger's retry strategy handles
     // transient mailer failures.
     $messenger->routing(SendOnboardingEmailMessage::class)
+        ->senders(['async']);
+
+    // Full company data exports are long-running and email the user on completion,
+    // so they must run out-of-band from the HTTP request that triggered them.
+    $messenger->routing(RequestCompanyExport::class)
         ->senders(['async']);
 
     // Configure default bus

--- a/config/routes.php
+++ b/config/routes.php
@@ -50,4 +50,7 @@ return static function (RoutingConfigurator $routingConfigurator): void {
         ->prefix('/');
 
     $routingConfigurator->import('.', 'mcp');
+
+    $routingConfigurator->import('@SolidInvoiceDataGridBundle/Resources/config/routing.php')
+        ->prefix('/');
 };

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -22,7 +22,6 @@ use Symfony\Bridge\Doctrine\Types\UlidType;
 
 final class Version30000_8 extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Create export_jobs table for tracking full company data export requests';

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -43,7 +43,7 @@ final class Version30000_8 extends AbstractMigration
         $table->addColumn('format', Types::STRING, ['length' => 10, 'notnull' => true]);
         $table->addColumn('status', Types::STRING, ['length' => 20, 'notnull' => true]);
         $table->addColumn('archive_path', Types::STRING, ['length' => 512, 'notnull' => false]);
-        $table->addColumn('file_size', Types::BIGINT, ['notnull' => false]);
+        $table->addColumn('file_size', Types::INTEGER, ['notnull' => false]);
         $table->addColumn('created_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
         $table->addColumn('completed_at', Types::DATETIME_IMMUTABLE, ['notnull' => false]);
         $table->addColumn('failure_reason', Types::TEXT, ['notnull' => false]);

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -53,6 +53,7 @@ final class Version30000_8 extends AbstractMigration
         $table->addIndex(['requested_by']);
         $table->addIndex(['status']);
         $table->addForeignKeyConstraint('companies', ['company_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('users', ['requested_by'], ['id'], ['onDelete' => 'CASCADE']);
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -13,32 +13,19 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
+use Symfony\Bridge\Doctrine\Types\UlidType;
 
-/**
- * Renames the custom-domain setting key from `system/company/custom_domain` to
- * `system/domain/custom_domain` so the field can live under its own top-level
- * "Domain" section in the settings UI rather than nested under "Company".
- *
- * Safe by design: `Company::customDomain` is the source of truth for inbound
- * host resolution. `CompanyRepository::findOneByCustomDomain()` and
- * `HostRoutingListener` both read from the `companies.custom_domain` column,
- * not from this `app_config` row, so renaming the setting key does not affect
- * how inbound requests resolve to a tenant.
- */
 final class Version30000_8 extends AbstractMigration
 {
-    private const OLD_KEY = 'system/company/custom_domain';
-
-    private const NEW_KEY = 'system/domain/custom_domain';
 
     public function getDescription(): string
     {
-        return 'Rename custom_domain setting from system/company to system/domain section';
+        return 'Create export_jobs table for tracking full company data export requests';
     }
 
     public function isTransactional(): bool
@@ -48,33 +35,28 @@ final class Version30000_8 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-    }
+        $table = $schema->createTable('export_jobs');
 
-    /**
-     * @throws Exception
-     */
-    public function postUp(Schema $schema): void
-    {
-        $this->connection->update(
-            'app_config',
-            ['setting_key' => self::NEW_KEY],
-            ['setting_key' => self::OLD_KEY]
-        );
+        $table->addColumn('id', UlidType::NAME);
+        $table->addColumn('company_id', UlidType::NAME, ['notnull' => true]);
+        $table->addColumn('requested_by', UlidType::NAME, ['notnull' => true]);
+        $table->addColumn('format', Types::STRING, ['length' => 10, 'notnull' => true]);
+        $table->addColumn('status', Types::STRING, ['length' => 20, 'notnull' => true]);
+        $table->addColumn('archive_path', Types::STRING, ['length' => 512, 'notnull' => false]);
+        $table->addColumn('file_size', Types::BIGINT, ['notnull' => false]);
+        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
+        $table->addColumn('completed_at', Types::DATETIME_IMMUTABLE, ['notnull' => false]);
+        $table->addColumn('failure_reason', Types::TEXT, ['notnull' => false]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['company_id']);
+        $table->addIndex(['requested_by']);
+        $table->addIndex(['status']);
+        $table->addForeignKeyConstraint('companies', ['company_id'], ['id'], ['onDelete' => 'CASCADE']);
     }
 
     public function down(Schema $schema): void
     {
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function postDown(Schema $schema): void
-    {
-        $this->connection->update(
-            'app_config',
-            ['setting_key' => self::OLD_KEY],
-            ['setting_key' => self::NEW_KEY]
-        );
+        $schema->dropTable('export_jobs');
     }
 }

--- a/src/CoreBundle/Entity/ExportJob.php
+++ b/src/CoreBundle/Entity/ExportJob.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Entity;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Enum\ExportStatus;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
+use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Table(name: ExportJob::TABLE_NAME)]
+#[ORM\Entity(repositoryClass: ExportJobRepository::class)]
+#[ExportIgnore]
+class ExportJob
+{
+    use CompanyAware;
+
+    final public const TABLE_NAME = 'export_jobs';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
+    #[ORM\Column(type: UlidType::NAME, unique: true)]
+    private Ulid $id;
+
+    #[ORM\Column(type: UlidType::NAME)]
+    private Ulid $requestedBy;
+
+    #[ORM\Column(type: Types::STRING, length: 10, enumType: ExportFormat::class)]
+    private ExportFormat $format;
+
+    #[ORM\Column(type: Types::STRING, length: 20, enumType: ExportStatus::class)]
+    private ExportStatus $status;
+
+    /**
+     * Relative path from the project root, e.g. `var/exports/{companyId58}/{jobId58}.zip`.
+     */
+    #[ORM\Column(type: Types::STRING, length: 512, nullable: true)]
+    private ?string $archivePath = null;
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $fileSize = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $completedAt = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $failureReason = null;
+
+    public function __construct(Ulid $requestedBy, ExportFormat $format)
+    {
+        $this->id = new Ulid();
+        $this->requestedBy = $requestedBy;
+        $this->format = $format;
+        $this->status = ExportStatus::Pending;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Ulid
+    {
+        return $this->id;
+    }
+
+    public function getRequestedBy(): Ulid
+    {
+        return $this->requestedBy;
+    }
+
+    public function getFormat(): ExportFormat
+    {
+        return $this->format;
+    }
+
+    public function getStatus(): ExportStatus
+    {
+        return $this->status;
+    }
+
+    public function getArchivePath(): ?string
+    {
+        return $this->archivePath;
+    }
+
+    public function getFileSize(): ?int
+    {
+        return $this->fileSize;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getCompletedAt(): ?DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function getFailureReason(): ?string
+    {
+        return $this->failureReason;
+    }
+
+    public function markProcessing(): void
+    {
+        $this->status = ExportStatus::Processing;
+    }
+
+    public function markCompleted(string $archivePath, int $fileSize): void
+    {
+        $this->status = ExportStatus::Completed;
+        $this->archivePath = $archivePath;
+        $this->fileSize = $fileSize;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markFailed(string $reason): void
+    {
+        $this->status = ExportStatus::Failed;
+        $this->failureReason = $reason;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function resolveAbsolutePath(string $projectDir): ?string
+    {
+        if ($this->archivePath === null) {
+            return null;
+        }
+
+        return rtrim($projectDir, '/') . '/' . ltrim($this->archivePath, '/');
+    }
+}

--- a/src/CoreBundle/Entity/ExportJob.php
+++ b/src/CoreBundle/Entity/ExportJob.php
@@ -26,6 +26,9 @@ use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
 
 #[ORM\Table(name: ExportJob::TABLE_NAME)]
+#[ORM\Index(columns: ['company_id'])]
+#[ORM\Index(columns: ['requested_by'])]
+#[ORM\Index(columns: ['status'])]
 #[ORM\Entity(repositoryClass: ExportJobRepository::class)]
 #[ExportIgnore]
 class ExportJob
@@ -47,19 +50,19 @@ class ExportJob
      * `requested_by` FK constraint in the migration (`ON DELETE CASCADE`) still
      * guarantees orphan cleanup at the database level.
      */
-    #[ORM\Column(type: UlidType::NAME)]
+    #[ORM\Column(name: 'requested_by', type: UlidType::NAME)]
     private Ulid $requestedBy;
 
-    #[ORM\Column(type: Types::STRING, length: 10, enumType: ExportFormat::class)]
+    #[ORM\Column(name: 'format', type: Types::STRING, length: 10, enumType: ExportFormat::class)]
     private ExportFormat $format;
 
-    #[ORM\Column(type: Types::STRING, length: 20, enumType: ExportStatus::class)]
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 20, enumType: ExportStatus::class)]
     private ExportStatus $status;
 
     /**
      * Relative path from the project root, e.g. `var/exports/{companyId58}/{jobId58}.zip`.
      */
-    #[ORM\Column(type: Types::STRING, length: 512, nullable: true)]
+    #[ORM\Column(name: 'archive_path', type: Types::STRING, length: 512, nullable: true)]
     private ?string $archivePath = null;
 
     /**
@@ -69,16 +72,16 @@ class ExportJob
      * exporter are well under this cap; if/when that changes, widen both the
      * column type and the PHP property in tandem.
      */
-    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    #[ORM\Column(name: 'file_size', type: Types::INTEGER, nullable: true)]
     private ?int $fileSize = null;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
     private DateTimeImmutable $createdAt;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    #[ORM\Column(name: 'completed_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $completedAt = null;
 
-    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    #[ORM\Column(name: 'failure_reason', type: Types::TEXT, nullable: true)]
     private ?string $failureReason = null;
 
     public function __construct(Ulid $requestedBy, ExportFormat $format)

--- a/src/CoreBundle/Entity/ExportJob.php
+++ b/src/CoreBundle/Entity/ExportJob.php
@@ -40,6 +40,13 @@ class ExportJob
     #[ORM\Column(type: UlidType::NAME, unique: true)]
     private Ulid $id;
 
+    /**
+     * Stored as a bare ULID rather than an `#[ORM\ManyToOne]` to `User` on purpose.
+     * The export feature lives in CoreBundle, and depending on UserBundle from here
+     * would invert the dependency direction used elsewhere in the codebase. The
+     * `requested_by` FK constraint in the migration (`ON DELETE CASCADE`) still
+     * guarantees orphan cleanup at the database level.
+     */
     #[ORM\Column(type: UlidType::NAME)]
     private Ulid $requestedBy;
 
@@ -55,7 +62,14 @@ class ExportJob
     #[ORM\Column(type: Types::STRING, length: 512, nullable: true)]
     private ?string $archivePath = null;
 
-    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    /**
+     * Size of the generated archive in bytes. The column uses INTEGER (signed
+     * 32-bit, ~2.1 GB) because Doctrine's BIGINT type returns a string on MySQL
+     * and would break the `?int` PHP property. ZIP archives produced by the
+     * exporter are well under this cap; if/when that changes, widen both the
+     * column type and the PHP property in tandem.
+     */
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
     private ?int $fileSize = null;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]

--- a/src/CoreBundle/Export/Action/DownloadExport.php
+++ b/src/CoreBundle/Export/Action/DownloadExport.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Action;
+
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\Enum\ExportStatus;
+use SolidInvoice\CoreBundle\Export\Security\Voter\ExportJobVoter;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Ulid;
+
+#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
+final class DownloadExport
+{
+    public function __construct(
+        private readonly ExportJobRepository $exportJobRepository,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public function __invoke(string $id): BinaryFileResponse|RedirectResponse
+    {
+        $ulid = $this->parseUlid($id);
+
+        $job = $this->exportJobRepository->find($ulid);
+        if (! $job instanceof ExportJob) {
+            throw new NotFoundHttpException();
+        }
+
+        if (! $this->authorizationChecker->isGranted(ExportJobVoter::DOWNLOAD, $job)) {
+            throw new AccessDeniedException();
+        }
+
+        if ($job->getStatus() !== ExportStatus::Completed) {
+            return new RedirectResponse($this->urlGenerator->generate('_export_list'));
+        }
+
+        $absolutePath = $job->resolveAbsolutePath($this->projectDir);
+        if ($absolutePath === null || ! is_file($absolutePath)) {
+            throw new NotFoundHttpException('Export archive is missing on disk.');
+        }
+
+        // Defense in depth: reject any archive_path that resolves outside the project's
+        // var/exports directory. archive_path is always written by CompanyExporter from
+        // ULIDs, but we never want a malformed value to enable arbitrary file reads.
+        $exportRoot = realpath($this->projectDir . '/var/exports');
+        $resolved = realpath($absolutePath);
+        if ($exportRoot === false || $resolved === false || ! str_starts_with($resolved, $exportRoot . DIRECTORY_SEPARATOR)) {
+            throw new NotFoundHttpException();
+        }
+
+        $response = new BinaryFileResponse($absolutePath);
+        $response->setContentDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            sprintf('solidinvoice-export-%s.zip', $job->getCreatedAt()->format('Y-m-d')),
+        );
+        $response->headers->set('Content-Type', 'application/zip');
+
+        return $response;
+    }
+
+    private function parseUlid(string $id): Ulid
+    {
+        try {
+            return Ulid::fromString($id);
+        } catch (\InvalidArgumentException) {
+            throw new NotFoundHttpException();
+        }
+    }
+}

--- a/src/CoreBundle/Export/Action/DownloadExport.php
+++ b/src/CoreBundle/Export/Action/DownloadExport.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Ulid;
 
-#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
+#[IsGranted('IS_AUTHENTICATED_FULLY')]
 final class DownloadExport
 {
     public function __construct(

--- a/src/CoreBundle/Export/Action/ListExports.php
+++ b/src/CoreBundle/Export/Action/ListExports.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Action;
+
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Bridge\Twig\Attribute\Template;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
+final class ListExports
+{
+    public function __construct(
+        private readonly ExportJobRepository $exportJobRepository,
+    ) {
+    }
+
+    /**
+     * @return array{jobs: list<\SolidInvoice\CoreBundle\Entity\ExportJob>, formats: list<ExportFormat>}
+     */
+    #[Template('@SolidInvoiceCore/Export/list.html.twig')]
+    public function __invoke(?UserInterface $user): array
+    {
+        if (! $user instanceof User) {
+            throw new AccessDeniedException();
+        }
+
+        return [
+            'jobs' => $this->exportJobRepository->findForUser($user->getId()),
+            'formats' => ExportFormat::cases(),
+        ];
+    }
+}

--- a/src/CoreBundle/Export/Action/RequestExport.php
+++ b/src/CoreBundle/Export/Action/RequestExport.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Action;
+
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Message\RequestCompanyExport;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use ValueError;
+
+#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
+final class RequestExport
+{
+    public const CSRF_TOKEN_ID = 'export.request';
+
+    public function __construct(
+        private readonly ExportJobRepository $exportJobRepository,
+        private readonly CompanyRepository $companyRepository,
+        private readonly CompanySelector $companySelector,
+        private readonly MessageBusInterface $messageBus,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function __invoke(Request $request, ?UserInterface $user): RedirectResponse
+    {
+        if (! $user instanceof User) {
+            throw new AccessDeniedException();
+        }
+
+        $token = (string) $request->request->get('_token');
+        if (! $this->csrfTokenManager->isTokenValid(new CsrfToken(self::CSRF_TOKEN_ID, $token))) {
+            throw new BadRequestHttpException('Invalid CSRF token.');
+        }
+
+        $format = $this->resolveFormat((string) $request->request->get('format', ''));
+
+        $activeCompanyId = $this->companySelector->getCompany();
+        if ($activeCompanyId === null) {
+            throw new BadRequestHttpException('No active company context.');
+        }
+
+        $company = $this->companyRepository->find($activeCompanyId);
+        if ($company === null) {
+            throw new BadRequestHttpException('Active company not found.');
+        }
+
+        $job = (new ExportJob($user->getId(), $format))->setCompany($company);
+        $this->exportJobRepository->save($job);
+
+        $this->messageBus->dispatch(new RequestCompanyExport(
+            exportJobId: $job->getId(),
+            companyId: $activeCompanyId,
+            userId: $user->getId(),
+        ));
+
+        return new RedirectResponse($this->urlGenerator->generate('_export_list'));
+    }
+
+    private function resolveFormat(string $raw): ExportFormat
+    {
+        try {
+            return ExportFormat::from($raw);
+        } catch (ValueError) {
+            throw new BadRequestHttpException(sprintf('Unsupported export format "%s".', $raw));
+        }
+    }
+}

--- a/src/CoreBundle/Export/Attribute/ExportIgnore.php
+++ b/src/CoreBundle/Export/Attribute/ExportIgnore.php
@@ -16,11 +16,14 @@ namespace SolidInvoice\CoreBundle\Export\Attribute;
 use Attribute;
 
 /**
- * Opts an entity class or entity property out of data export.
+ * Opts an entity class or entity property out of the full company export.
  *
  * Applied at class level, the entity is skipped entirely by the full company
  * export. Applied at property level, the property is stripped from the
- * serialized output for both grid and full exports.
+ * serialized output for the full company export only.
+ *
+ * Grid exports are defined by the configured grid columns and do not consult
+ * this attribute.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 final class ExportIgnore

--- a/src/CoreBundle/Export/Attribute/ExportIgnore.php
+++ b/src/CoreBundle/Export/Attribute/ExportIgnore.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Attribute;
+
+use Attribute;
+
+/**
+ * Opts an entity class or entity property out of data export.
+ *
+ * Applied at class level, the entity is skipped entirely by the full company
+ * export. Applied at property level, the property is stripped from the
+ * serialized output for both grid and full exports.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+final class ExportIgnore
+{
+}

--- a/src/CoreBundle/Export/CompanyExporter.php
+++ b/src/CoreBundle/Export/CompanyExporter.php
@@ -19,13 +19,14 @@ use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\ExportJob;
 use SolidInvoice\CoreBundle\Export\Discovery\EntityDiscovery;
 use SolidInvoice\CoreBundle\Export\Discovery\EntityExportSpec;
 use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
 use SolidInvoice\CoreBundle\Export\Serializer\ExportSerializer;
+use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use ZipArchive;
 use function array_map;
 use function sys_get_temp_dir;
@@ -49,9 +50,11 @@ final class CompanyExporter
     public function __construct(
         private readonly ManagerRegistry $registry,
         private readonly EntityDiscovery $discovery,
+        private readonly EntityRowNormalizer $rowNormalizer,
         private readonly ExportSerializer $serializer,
         private readonly ManifestGenerator $manifestGenerator,
         private readonly Filesystem $filesystem,
+        private readonly CompanySelector $companySelector,
         private readonly string $projectDir,
     ) {
     }
@@ -104,19 +107,15 @@ final class CompanyExporter
         $counts = [];
 
         foreach ($specs as $spec) {
-            $repository = $manager->getRepository($spec->entityClass);
-            $entities = $repository->findAll();
+            $entities = $this->fetchEntities($manager, $spec);
+            $metadata = $manager->getClassMetadata($spec->entityClass);
 
-            $normalized = array_map(
-                fn (object $entity): mixed => $this->serializer->normalize(
-                    $entity,
-                    $format,
-                    $this->normalizationContext($spec),
-                ),
+            $rows = array_map(
+                fn (object $entity): array => $this->rowNormalizer->normalize($entity, $metadata, $spec),
                 $entities,
             );
 
-            $payload = $this->serializer->encode($normalized, $format, $format->encoderContext($spec->filename));
+            $payload = $this->serializer->encode($rows, $format, $format->encoderContext($spec->filename));
 
             $filename = $stagingDir . '/' . $spec->filename . '.' . $format->extension();
             $this->filesystem->dumpFile($filename, $payload);
@@ -128,16 +127,39 @@ final class CompanyExporter
     }
 
     /**
-     * @return array<string, mixed>
+     * Fetches the entity rows to export.
+     *
+     * For CompanyAware roots, we rely on the active CompanyFilter to scope rows.
+     * For child entities (no `company_id`), we explicitly join through the spec's
+     * `companyScopeAssociation` so a child's parent must belong to the active
+     * company — this prevents cross-tenant leakage.
+     *
+     * @return list<object>
      */
-    private function normalizationContext(EntityExportSpec $spec): array
+    private function fetchEntities(EntityManagerInterface $manager, EntityExportSpec $spec): array
     {
-        return [
-            AbstractObjectNormalizer::ATTRIBUTES => $spec->includedProperties,
-            AbstractObjectNormalizer::SKIP_NULL_VALUES => false,
-            AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
-            AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true,
-        ];
+        if ($spec->companyScopeAssociation === null) {
+            /** @var list<object> $result */
+            $result = $manager->getRepository($spec->entityClass)->findAll();
+
+            return $result;
+        }
+
+        $activeCompanyId = $this->companySelector->getCompany();
+        if ($activeCompanyId === null) {
+            return [];
+        }
+
+        /** @var list<object> $result */
+        $result = $manager->getRepository($spec->entityClass)
+            ->createQueryBuilder('e')
+            ->innerJoin('e.' . $spec->companyScopeAssociation, 'p')
+            ->andWhere('p.company = :company')
+            ->setParameter('company', $activeCompanyId, UlidType::NAME)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
     }
 
     private function archivePath(ExportJob $job): string

--- a/src/CoreBundle/Export/CompanyExporter.php
+++ b/src/CoreBundle/Export/CompanyExporter.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\Discovery\EntityDiscovery;
+use SolidInvoice\CoreBundle\Export\Discovery\EntityExportSpec;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Serializer\ExportSerializer;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use ZipArchive;
+use function array_map;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * Produces a ZIP archive containing one file per company-owned entity plus a manifest.
+ *
+ * Expected to run inside a company-scoped context (CompanySelector::switchCompany()
+ * has been called) so the CompanyFilter transparently limits queries to the export's
+ * company.
+ *
+ * TODO(streaming): the current implementation materializes each entity's full result
+ *   set before encoding. Switch to Doctrine's toIterable() + chunked writes and a
+ *   streaming JSON/XML writer (e.g. XMLWriter) when we start seeing large tenants.
+ * TODO(binary-attachments): include PDF invoices, uploaded receipts, and company
+ *   logos under a `files/` subdirectory in the archive.
+ */
+final class CompanyExporter
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly EntityDiscovery $discovery,
+        private readonly ExportSerializer $serializer,
+        private readonly ManifestGenerator $manifestGenerator,
+        private readonly Filesystem $filesystem,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    /**
+     * Returns the archive's path relative to the project root.
+     */
+    public function export(ExportJob $job): string
+    {
+        $manager = $this->registry->getManager();
+        assert($manager instanceof EntityManagerInterface);
+
+        $specs = $this->discovery->discover();
+        $format = $job->getFormat();
+
+        $stagingDir = sys_get_temp_dir() . '/solidinvoice_export_' . $job->getId()->toBase58() . '_' . uniqid();
+        $this->filesystem->mkdir($stagingDir, 0o755);
+
+        try {
+            $counts = $this->writeEntityFiles($manager, $specs, $format, $stagingDir);
+
+            $manifest = $this->manifestGenerator->generate($job, $counts);
+            $this->filesystem->dumpFile(
+                $stagingDir . '/manifest.json',
+                (string) json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            );
+
+            $relativePath = $this->archivePath($job);
+            $absolutePath = $this->projectDir . '/' . $relativePath;
+            $this->filesystem->mkdir(dirname($absolutePath), 0o755);
+
+            $this->zipDirectory($stagingDir, $absolutePath);
+
+            return $relativePath;
+        } finally {
+            $this->filesystem->remove($stagingDir);
+        }
+    }
+
+    /**
+     * @param list<EntityExportSpec> $specs
+     * @return array<string, int>
+     */
+    private function writeEntityFiles(
+        EntityManagerInterface $manager,
+        array $specs,
+        ExportFormat $format,
+        string $stagingDir,
+    ): array {
+        $counts = [];
+
+        foreach ($specs as $spec) {
+            $repository = $manager->getRepository($spec->entityClass);
+            $entities = $repository->findAll();
+
+            $normalized = array_map(
+                fn (object $entity): mixed => $this->serializer->normalize(
+                    $entity,
+                    $format,
+                    $this->normalizationContext($spec),
+                ),
+                $entities,
+            );
+
+            $payload = $this->serializer->encode($normalized, $format, $format->encoderContext($spec->filename));
+
+            $filename = $stagingDir . '/' . $spec->filename . '.' . $format->extension();
+            $this->filesystem->dumpFile($filename, $payload);
+
+            $counts[$spec->filename] = count($entities);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizationContext(EntityExportSpec $spec): array
+    {
+        return [
+            AbstractObjectNormalizer::ATTRIBUTES => $spec->includedProperties,
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => false,
+            AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
+            AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true,
+        ];
+    }
+
+    private function archivePath(ExportJob $job): string
+    {
+        return sprintf(
+            'var/exports/%s/%s.zip',
+            $job->getCompany()->getId()->toBase58(),
+            $job->getId()->toBase58(),
+        );
+    }
+
+    private function zipDirectory(string $sourceDir, string $zipPath): void
+    {
+        $zip = new ZipArchive();
+        $result = $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        if ($result !== true) {
+            throw new RuntimeException(sprintf(
+                'Could not create archive at "%s" (ZipArchive error code %d).',
+                $zipPath,
+                $result,
+            ));
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourceDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            $relativePath = substr($file->getPathname(), strlen($sourceDir) + 1);
+            $zip->addFile($file->getPathname(), $relativePath);
+        }
+
+        $zip->close();
+    }
+}

--- a/src/CoreBundle/Export/CompanyExporter.php
+++ b/src/CoreBundle/Export/CompanyExporter.php
@@ -91,9 +91,15 @@ final class CompanyExporter
             $counts = $this->writeEntityFiles($manager, $specs, $format, $stagingDir);
 
             $manifest = $this->manifestGenerator->generate($job, $counts);
+            // JSON_THROW_ON_ERROR surfaces encoder failures (e.g. a non-UTF-8 byte
+            // sneaking in via an entity field) rather than silently writing an empty
+            // manifest from a `false`-cast result.
             $this->filesystem->dumpFile(
                 $stagingDir . '/manifest.json',
-                (string) json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                json_encode(
+                    $manifest,
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+                ),
             );
 
             $relativePath = $this->archivePath($job);

--- a/src/CoreBundle/Export/CompanyExporter.php
+++ b/src/CoreBundle/Export/CompanyExporter.php
@@ -29,8 +29,9 @@ use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Filesystem\Filesystem;
 use ZipArchive;
 use function array_map;
+use function bin2hex;
+use function random_bytes;
 use function sys_get_temp_dir;
-use function uniqid;
 
 /**
  * Produces a ZIP archive containing one file per company-owned entity plus a manifest.
@@ -64,13 +65,26 @@ final class CompanyExporter
      */
     public function export(ExportJob $job): string
     {
+        // Defense in depth: the handler always switches company before invoking the
+        // exporter, but explicitly asserting it here means any future caller that
+        // forgets to switch (tests, console commands) fails loudly rather than
+        // silently exporting another tenant's rows for child entities that fall
+        // back to repository->findAll().
+        if ($this->companySelector->getCompany() === null) {
+            throw new RuntimeException('CompanyExporter requires an active company context (CompanySelector::switchCompany).');
+        }
+
         $manager = $this->registry->getManager();
         assert($manager instanceof EntityManagerInterface);
 
         $specs = $this->discovery->discover();
         $format = $job->getFormat();
 
-        $stagingDir = sys_get_temp_dir() . '/solidinvoice_export_' . $job->getId()->toBase58() . '_' . uniqid();
+        $stagingDir = sys_get_temp_dir()
+            . '/solidinvoice_export_'
+            . $job->getId()->toBase58()
+            . '_'
+            . bin2hex(random_bytes(8));
         $this->filesystem->mkdir($stagingDir, 0o755);
 
         try {

--- a/src/CoreBundle/Export/Discovery/EntityDiscovery.php
+++ b/src/CoreBundle/Export/Discovery/EntityDiscovery.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Discovery;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use ReflectionClass;
+use ReflectionProperty;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
+use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
+use function array_values;
+use function class_uses;
+use function in_array;
+use function ksort;
+use function strtolower;
+
+/**
+ * Discovers entities to include in a full company export by walking Doctrine metadata.
+ *
+ * Rules:
+ *   - Entity must use the `CompanyAware` trait (recursively through parent classes
+ *     and composed traits).
+ *   - Child entities are picked up via OneToMany/ManyToMany associations on
+ *     company-aware roots, as long as the target is not itself company-aware
+ *     (which would make it its own root).
+ *   - Entities or properties annotated with `#[ExportIgnore]` are skipped.
+ *
+ * The discovery list is stable (sorted by filename) so exports are reproducible.
+ */
+final class EntityDiscovery
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    /**
+     * @return list<EntityExportSpec>
+     */
+    public function discover(): array
+    {
+        $manager = $this->registry->getManager();
+        assert($manager instanceof EntityManagerInterface);
+
+        /** @var array<string, EntityExportSpec> $specs */
+        $specs = [];
+
+        foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
+            assert($metadata instanceof ClassMetadata);
+
+            if ($this->skipMetadata($metadata)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($metadata->getName());
+
+            if ($this->hasIgnoreAttribute($reflection)) {
+                continue;
+            }
+
+            if (! $this->usesCompanyAware($reflection)) {
+                continue;
+            }
+
+            $spec = $this->buildSpec($metadata, $reflection);
+            $specs[$spec->filename] = $spec;
+        }
+
+        foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
+            assert($metadata instanceof ClassMetadata);
+
+            if ($this->skipMetadata($metadata)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($metadata->getName());
+
+            if ($this->hasIgnoreAttribute($reflection)) {
+                continue;
+            }
+
+            if ($this->usesCompanyAware($reflection)) {
+                continue;
+            }
+
+            if (! $this->isChildOfCompanyAwareRoot($metadata)) {
+                continue;
+            }
+
+            $spec = $this->buildSpec($metadata, $reflection);
+            $specs[$spec->filename] = $spec;
+        }
+
+        ksort($specs);
+
+        return array_values($specs);
+    }
+
+    /**
+     * Skip classes that are not independently queryable entities: mapped superclasses
+     * (no table) and abstract STI parents.
+     *
+     * @param ClassMetadata<object> $metadata
+     */
+    private function skipMetadata(ClassMetadata $metadata): bool
+    {
+        if ($metadata->isMappedSuperclass) {
+            return true;
+        }
+
+        if ((new ReflectionClass($metadata->getName()))->isAbstract()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function usesCompanyAware(ReflectionClass $reflection): bool
+    {
+        return $this->traitUsedRecursively($reflection, CompanyAware::class);
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function traitUsedRecursively(ReflectionClass $reflection, string $traitName): bool
+    {
+        $classes = [];
+        $current = $reflection;
+        while ($current !== false) {
+            $classes[] = $current->getName();
+            $current = $current->getParentClass();
+        }
+
+        foreach ($classes as $class) {
+            /** @var array<string, string>|false $uses */
+            $uses = class_uses($class);
+            if ($uses === false) {
+                continue;
+            }
+
+            if (in_array($traitName, $uses, true)) {
+                return true;
+            }
+
+            foreach ($uses as $usedTrait) {
+                $usedReflection = new ReflectionClass($usedTrait);
+                if ($this->traitUsedRecursively($usedReflection, $traitName)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function hasIgnoreAttribute(ReflectionClass $reflection): bool
+    {
+        return $reflection->getAttributes(ExportIgnore::class) !== [];
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     * @param ReflectionClass<object> $reflection
+     */
+    private function buildSpec(ClassMetadata $metadata, ReflectionClass $reflection): EntityExportSpec
+    {
+        $included = [];
+
+        foreach ($metadata->fieldMappings as $fieldName => $mapping) {
+            if (! $reflection->hasProperty((string) $fieldName)) {
+                continue;
+            }
+
+            $property = $reflection->getProperty((string) $fieldName);
+            if ($this->hasPropertyIgnoreAttribute($property)) {
+                continue;
+            }
+
+            $included[] = (string) $fieldName;
+        }
+
+        foreach ($metadata->associationMappings as $assocName => $assocMapping) {
+            if (! $reflection->hasProperty((string) $assocName)) {
+                continue;
+            }
+
+            $property = $reflection->getProperty((string) $assocName);
+            if ($this->hasPropertyIgnoreAttribute($property)) {
+                continue;
+            }
+
+            // Only owning-side ToOne associations are included inline (as FK IDs).
+            // ToMany collections are handled via their child entity's own export file.
+            if ($metadata->isSingleValuedAssociation((string) $assocName)) {
+                $included[] = (string) $assocName;
+            }
+        }
+
+        $filename = $this->filenameFor($metadata);
+
+        return new EntityExportSpec(
+            entityClass: $metadata->getName(),
+            filename: $filename,
+            includedProperties: $included,
+        );
+    }
+
+    private function hasPropertyIgnoreAttribute(ReflectionProperty $property): bool
+    {
+        return $property->getAttributes(ExportIgnore::class) !== [];
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
+    private function isChildOfCompanyAwareRoot(ClassMetadata $metadata): bool
+    {
+        $manager = $this->registry->getManagerForClass($metadata->getName());
+        if (! $manager instanceof EntityManagerInterface) {
+            return false;
+        }
+
+        foreach ($metadata->associationMappings as $assocName => $assocMapping) {
+            if (! $metadata->isSingleValuedAssociation((string) $assocName)) {
+                continue;
+            }
+
+            $targetClass = is_array($assocMapping)
+                ? $assocMapping['targetEntity']
+                : $assocMapping->targetEntity;
+
+            if (! $manager->getMetadataFactory()->hasMetadataFor($targetClass)) {
+                continue;
+            }
+
+            $targetReflection = new ReflectionClass($targetClass);
+            if ($this->hasIgnoreAttribute($targetReflection)) {
+                continue;
+            }
+
+            if ($this->usesCompanyAware($targetReflection)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
+    private function filenameFor(ClassMetadata $metadata): string
+    {
+        $tableName = $metadata->getTableName();
+
+        return strtolower($tableName);
+    }
+}

--- a/src/CoreBundle/Export/Discovery/EntityDiscovery.php
+++ b/src/CoreBundle/Export/Discovery/EntityDiscovery.php
@@ -23,19 +23,23 @@ use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use function array_values;
 use function class_uses;
 use function in_array;
-use function ksort;
 use function strtolower;
+use function usort;
 
 /**
  * Discovers entities to include in a full company export by walking Doctrine metadata.
  *
  * Rules:
- *   - Entity must use the `CompanyAware` trait (recursively through parent classes
- *     and composed traits).
- *   - Child entities are picked up via OneToMany/ManyToMany associations on
- *     company-aware roots, as long as the target is not itself company-aware
- *     (which would make it its own root).
- *   - Entities or properties annotated with `#[ExportIgnore]` are skipped.
+ *   - Roots: entities that use the `CompanyAware` trait (recursively through parent
+ *     classes and composed traits) and have a real table.
+ *   - Children: non-CompanyAware entities that have an owning-side ToOne association
+ *     pointing at a CompanyAware root (e.g. `Invoice\RecurringOptions.recurringInvoice`
+ *     pointing at `RecurringInvoice`). The owning association name is recorded as
+ *     `companyScopeAssociation` on the spec so the exporter can join through it and
+ *     filter by the active company at query time — children have no `company_id`
+ *     of their own and would otherwise leak across tenants.
+ *   - Mapped superclasses, abstract STI parents, and entities/properties annotated
+ *     `#[ExportIgnore]` are skipped.
  *
  * The discovery list is stable (sorted by filename) so exports are reproducible.
  */
@@ -54,7 +58,7 @@ final class EntityDiscovery
         $manager = $this->registry->getManager();
         assert($manager instanceof EntityManagerInterface);
 
-        /** @var array<string, EntityExportSpec> $specs */
+        /** @var array<class-string, EntityExportSpec> $specs */
         $specs = [];
 
         foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
@@ -65,45 +69,23 @@ final class EntityDiscovery
             }
 
             $reflection = new ReflectionClass($metadata->getName());
-
-            if ($this->hasIgnoreAttribute($reflection)) {
-                continue;
-            }
-
-            if (! $this->usesCompanyAware($reflection)) {
-                continue;
-            }
-
-            $spec = $this->buildSpec($metadata, $reflection);
-            $specs[$spec->filename] = $spec;
-        }
-
-        foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
-            assert($metadata instanceof ClassMetadata);
-
-            if ($this->skipMetadata($metadata)) {
-                continue;
-            }
-
-            $reflection = new ReflectionClass($metadata->getName());
-
             if ($this->hasIgnoreAttribute($reflection)) {
                 continue;
             }
 
             if ($this->usesCompanyAware($reflection)) {
+                $specs[$metadata->getName()] = $this->buildSpec($metadata, $reflection, null);
                 continue;
             }
 
-            if (! $this->isChildOfCompanyAwareRoot($metadata)) {
-                continue;
+            $companyScope = $this->companyScopeAssociation($metadata);
+            if ($companyScope !== null) {
+                $specs[$metadata->getName()] = $this->buildSpec($metadata, $reflection, $companyScope);
             }
-
-            $spec = $this->buildSpec($metadata, $reflection);
-            $specs[$spec->filename] = $spec;
         }
 
-        ksort($specs);
+        // Stable order by filename for reproducible exports.
+        usort($specs, static fn (EntityExportSpec $a, EntityExportSpec $b): int => $a->filename <=> $b->filename);
 
         return array_values($specs);
     }
@@ -181,8 +163,11 @@ final class EntityDiscovery
      * @param ClassMetadata<object> $metadata
      * @param ReflectionClass<object> $reflection
      */
-    private function buildSpec(ClassMetadata $metadata, ReflectionClass $reflection): EntityExportSpec
-    {
+    private function buildSpec(
+        ClassMetadata $metadata,
+        ReflectionClass $reflection,
+        ?string $companyScopeAssociation,
+    ): EntityExportSpec {
         $included = [];
 
         foreach ($metadata->fieldMappings as $fieldName => $mapping) {
@@ -199,28 +184,30 @@ final class EntityDiscovery
         }
 
         foreach ($metadata->associationMappings as $assocName => $assocMapping) {
-            if (! $reflection->hasProperty((string) $assocName)) {
+            $name = (string) $assocName;
+
+            if (! $reflection->hasProperty($name)) {
                 continue;
             }
 
-            $property = $reflection->getProperty((string) $assocName);
+            $property = $reflection->getProperty($name);
             if ($this->hasPropertyIgnoreAttribute($property)) {
                 continue;
             }
 
             // Only owning-side ToOne associations are included inline (as FK IDs).
-            // ToMany collections are handled via their child entity's own export file.
-            if ($metadata->isSingleValuedAssociation((string) $assocName)) {
-                $included[] = (string) $assocName;
+            // ToMany collections are handled via their child entity's own export file,
+            // and inverse-side ToOne associations have no FK column on this entity.
+            if ($metadata->isSingleValuedAssociation($name) && $this->isOwningSide($assocMapping)) {
+                $included[] = $name;
             }
         }
 
-        $filename = $this->filenameFor($metadata);
-
         return new EntityExportSpec(
             entityClass: $metadata->getName(),
-            filename: $filename,
+            filename: $this->filenameFor($metadata),
             includedProperties: $included,
+            companyScopeAssociation: $companyScopeAssociation,
         );
     }
 
@@ -230,17 +217,42 @@ final class EntityDiscovery
     }
 
     /**
+     * Doctrine ORM 3.x exposes association mappings as typed value objects with an
+     * `isOwningSide` property; older array-shaped mappings used the same key. This
+     * helper handles both representations.
+     */
+    private function isOwningSide(mixed $assocMapping): bool
+    {
+        if (is_array($assocMapping)) {
+            return (bool) ($assocMapping['isOwningSide'] ?? false);
+        }
+
+        if (is_object($assocMapping) && property_exists($assocMapping, 'isOwningSide')) {
+            return (bool) $assocMapping->isOwningSide;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the owning-side ToOne association on this entity that points at a
+     * CompanyAware parent, or null if no such association exists. The returned
+     * association name is the path the exporter joins through to scope queries
+     * to the active company.
+     *
      * @param ClassMetadata<object> $metadata
      */
-    private function isChildOfCompanyAwareRoot(ClassMetadata $metadata): bool
+    private function companyScopeAssociation(ClassMetadata $metadata): ?string
     {
         $manager = $this->registry->getManagerForClass($metadata->getName());
         if (! $manager instanceof EntityManagerInterface) {
-            return false;
+            return null;
         }
 
         foreach ($metadata->associationMappings as $assocName => $assocMapping) {
-            if (! $metadata->isSingleValuedAssociation((string) $assocName)) {
+            $name = (string) $assocName;
+
+            if (! $metadata->isSingleValuedAssociation($name) || ! $this->isOwningSide($assocMapping)) {
                 continue;
             }
 
@@ -258,11 +270,11 @@ final class EntityDiscovery
             }
 
             if ($this->usesCompanyAware($targetReflection)) {
-                return true;
+                return $name;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/CoreBundle/Export/Discovery/EntityExportSpec.php
+++ b/src/CoreBundle/Export/Discovery/EntityExportSpec.php
@@ -21,11 +21,17 @@ final readonly class EntityExportSpec
     /**
      * @param class-string $entityClass
      * @param list<string> $includedProperties Property names to emit for this entity.
+     * @param string|null $companyScopeAssociation Optional dotted path of owning-side
+     *   ToOne associations on this entity that ultimately reaches a CompanyAware
+     *   parent. When set, the exporter joins through this path and filters by the
+     *   active company so child entities (which lack their own `company_id`) are
+     *   not exported across tenants.
      */
     public function __construct(
         public string $entityClass,
         public string $filename,
         public array $includedProperties,
+        public ?string $companyScopeAssociation = null,
     ) {
     }
 }

--- a/src/CoreBundle/Export/Discovery/EntityExportSpec.php
+++ b/src/CoreBundle/Export/Discovery/EntityExportSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Discovery;
+
+/**
+ * Describes an entity class that should be included in a full company export.
+ */
+final readonly class EntityExportSpec
+{
+    /**
+     * @param class-string $entityClass
+     * @param list<string> $includedProperties Property names to emit for this entity.
+     */
+    public function __construct(
+        public string $entityClass,
+        public string $filename,
+        public array $includedProperties,
+    ) {
+    }
+}

--- a/src/CoreBundle/Export/Email/ExportReadyEmail.php
+++ b/src/CoreBundle/Export/Email/ExportReadyEmail.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Email;
+
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+final class ExportReadyEmail extends TemplatedEmail
+{
+    public function __construct(
+        private readonly ExportJob $job,
+        private readonly User $user,
+        private readonly string $downloadUrl,
+    ) {
+        parent::__construct();
+
+        $this->htmlTemplate('@SolidInvoiceCore/Email/export_ready.html.twig');
+        $this->textTemplate('@SolidInvoiceCore/Email/export_ready.text.twig');
+        $this->context([
+            'job' => $this->job,
+            'user' => $this->user,
+            'downloadUrl' => $this->downloadUrl,
+        ]);
+    }
+
+    public function getJob(): ExportJob
+    {
+        return $this->job;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getDownloadUrl(): string
+    {
+        return $this->downloadUrl;
+    }
+}

--- a/src/CoreBundle/Export/Email/ExportReadyEmail.php
+++ b/src/CoreBundle/Export/Email/ExportReadyEmail.php
@@ -26,6 +26,7 @@ final class ExportReadyEmail extends TemplatedEmail
     ) {
         parent::__construct();
 
+        $this->subject('Your data export is ready');
         $this->htmlTemplate('@SolidInvoiceCore/Email/export_ready.html.twig');
         $this->textTemplate('@SolidInvoiceCore/Email/export_ready.text.twig');
         $this->context([

--- a/src/CoreBundle/Export/EntityRowNormalizer.php
+++ b/src/CoreBundle/Export/EntityRowNormalizer.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export;
+
+use BackedEnum;
+use Brick\Math\BigNumber;
+use DateTimeInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Money\Currencies\ISOCurrencies;
+use Money\Money;
+use SolidInvoice\CoreBundle\Export\Discovery\EntityExportSpec;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+use Stringable;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * Converts a managed entity into a flat associative array suitable for any
+ * export encoder (CSV / JSON / XML).
+ *
+ * Money values are flattened to `{field}_amount` + `{field}_currency`. Owning-side
+ * single-valued associations are emitted as base58 ULIDs (so the output stays
+ * relational and never recurses into related entities).
+ */
+final class EntityRowNormalizer
+{
+    private readonly ISOCurrencies $currencies;
+
+    public function __construct(
+        private readonly PropertyAccessorInterface $propertyAccessor,
+    ) {
+        $this->currencies = new ISOCurrencies();
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     * @return array<string, mixed>
+     */
+    public function normalize(object $entity, ClassMetadata $metadata, EntityExportSpec $spec): array
+    {
+        $row = [];
+
+        foreach ($spec->includedProperties as $property) {
+            $rawValue = $this->readProperty($entity, $property);
+
+            if ($metadata->hasAssociation($property)) {
+                $row[$property] = $this->normalizeAssociation($rawValue);
+                continue;
+            }
+
+            foreach ($this->normalizeScalar($property, $rawValue) as $key => $value) {
+                $row[$key] = $value;
+            }
+        }
+
+        return $row;
+    }
+
+    private function readProperty(object $entity, string $property): mixed
+    {
+        try {
+            return $this->propertyAccessor->getValue($entity, $property);
+        } catch (NoSuchPropertyException) {
+            return null;
+        }
+    }
+
+    private function normalizeAssociation(mixed $related): ?string
+    {
+        if (! is_object($related)) {
+            return null;
+        }
+
+        try {
+            $id = $this->propertyAccessor->getValue($related, 'id');
+        } catch (NoSuchPropertyException) {
+            return null;
+        }
+
+        if ($id instanceof Ulid) {
+            return $id->toBase58();
+        }
+
+        if (is_scalar($id)) {
+            return (string) $id;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeScalar(string $field, mixed $value): array
+    {
+        if ($value === null) {
+            return [$field => null];
+        }
+
+        if ($value instanceof Money) {
+            $exponent = $this->currencies->contains($value->getCurrency())
+                ? $this->currencies->subunitFor($value->getCurrency())
+                : 2;
+
+            return [
+                $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString(
+                    BigNumber::of($value->getAmount()),
+                    $exponent,
+                ),
+                $field . '_currency' => $value->getCurrency()->getCode(),
+            ];
+        }
+
+        if ($value instanceof BigNumber) {
+            return [$field => ExportMoneyNormalizer::amountToDecimalString($value, 2)];
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return [$field => $value->format(DateTimeInterface::ATOM)];
+        }
+
+        if ($value instanceof BackedEnum) {
+            return [$field => $value->value];
+        }
+
+        if ($value instanceof Ulid) {
+            return [$field => $value->toBase58()];
+        }
+
+        if (is_scalar($value)) {
+            return [$field => $value];
+        }
+
+        if ($value instanceof Stringable) {
+            return [$field => (string) $value];
+        }
+
+        return [$field => null];
+    }
+}

--- a/src/CoreBundle/Export/EntityRowNormalizer.php
+++ b/src/CoreBundle/Export/EntityRowNormalizer.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace SolidInvoice\CoreBundle\Export;
 
-use BackedEnum;
 use Brick\Math\BigNumber;
-use DateTimeInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Money\Currencies\ISOCurrencies;
 use Money\Money;
 use SolidInvoice\CoreBundle\Export\Discovery\EntityExportSpec;
 use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
-use Stringable;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Uid\Ulid;
@@ -105,48 +102,14 @@ final class EntityRowNormalizer
      */
     private function normalizeScalar(string $field, mixed $value): array
     {
-        if ($value === null) {
-            return [$field => null];
-        }
-
         if ($value instanceof Money) {
-            $exponent = $this->currencies->contains($value->getCurrency())
-                ? $this->currencies->subunitFor($value->getCurrency())
-                : 2;
-
-            return [
-                $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString(
-                    BigNumber::of($value->getAmount()),
-                    $exponent,
-                ),
-                $field . '_currency' => $value->getCurrency()->getCode(),
-            ];
+            return ValueFormatter::flattenMoney($field, $value, $this->currencies);
         }
 
         if ($value instanceof BigNumber) {
             return [$field => ExportMoneyNormalizer::amountToDecimalString($value, 2)];
         }
 
-        if ($value instanceof DateTimeInterface) {
-            return [$field => $value->format(DateTimeInterface::ATOM)];
-        }
-
-        if ($value instanceof BackedEnum) {
-            return [$field => $value->value];
-        }
-
-        if ($value instanceof Ulid) {
-            return [$field => $value->toBase58()];
-        }
-
-        if (is_scalar($value)) {
-            return [$field => $value];
-        }
-
-        if ($value instanceof Stringable) {
-            return [$field => (string) $value];
-        }
-
-        return [$field => null];
+        return [$field => ValueFormatter::formatScalar($value)];
     }
 }

--- a/src/CoreBundle/Export/Enum/ExportFormat.php
+++ b/src/CoreBundle/Export/Enum/ExportFormat.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Enum;
+
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+enum ExportFormat: string
+{
+    case Csv = 'csv';
+    case Json = 'json';
+    case Xml = 'xml';
+
+    public function extension(): string
+    {
+        return $this->value;
+    }
+
+    public function mimeType(): string
+    {
+        return match ($this) {
+            self::Csv => 'text/csv',
+            self::Json => 'application/json',
+            self::Xml => 'application/xml',
+        };
+    }
+
+    /**
+     * Format string accepted by Symfony's Serializer encoders.
+     */
+    public function encoderFormat(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function encoderContext(string $xmlRootNode = 'export'): array
+    {
+        return match ($this) {
+            self::Csv => [
+                CsvEncoder::DELIMITER_KEY => ',',
+                CsvEncoder::ENCLOSURE_KEY => '"',
+                CsvEncoder::NO_HEADERS_KEY => false,
+            ],
+            self::Json => [
+                'json_encode_options' => JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+            ],
+            self::Xml => [
+                XmlEncoder::ROOT_NODE_NAME => $xmlRootNode,
+                XmlEncoder::FORMAT_OUTPUT => true,
+                XmlEncoder::ENCODING => 'UTF-8',
+            ],
+        };
+    }
+}

--- a/src/CoreBundle/Export/Enum/ExportStatus.php
+++ b/src/CoreBundle/Export/Enum/ExportStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Enum;
+
+enum ExportStatus: string
+{
+    case Pending = 'pending';
+    case Processing = 'processing';
+    case Completed = 'completed';
+    case Failed = 'failed';
+
+    public function isTerminal(): bool
+    {
+        return $this === self::Completed || $this === self::Failed;
+    }
+}

--- a/src/CoreBundle/Export/ManifestGenerator.php
+++ b/src/CoreBundle/Export/ManifestGenerator.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export;
+
+use DateTimeInterface;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
+
+final class ManifestGenerator
+{
+    /**
+     * @param array<string, int> $entityCounts
+     * @return array<string, mixed>
+     */
+    public function generate(ExportJob $job, array $entityCounts): array
+    {
+        return [
+            'solidinvoice_version' => SolidInvoiceCoreBundle::VERSION,
+            'export_id' => $job->getId()->toBase58(),
+            'company_id' => $job->getCompany()->getId()->toBase58(),
+            'requested_by' => $job->getRequestedBy()->toBase58(),
+            'requested_at' => $job->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'format' => $job->getFormat()->value,
+            'entity_counts' => $entityCounts,
+        ];
+    }
+}

--- a/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
+++ b/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\CoreBundle\Export\Message\Handler;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\ExportJob;
@@ -46,6 +47,7 @@ use Throwable;
 final readonly class ProcessCompanyExportHandler
 {
     public function __construct(
+        private ManagerRegistry $registry,
         private EntityManagerInterface $entityManager,
         private ExportJobRepository $exportJobRepository,
         private UserRepository $userRepository,
@@ -99,13 +101,34 @@ final readonly class ProcessCompanyExportHandler
                 'exception' => $e,
             ]);
 
-            $job->markFailed(sprintf('%s: %s', $e::class, $e->getMessage()));
-            $this->entityManager->flush();
+            $this->persistFailure($job, $e);
 
             throw $e;
         } finally {
             $this->companySelector->reset();
         }
+    }
+
+    /**
+     * Persists the Failed status, reopening the EntityManager if Doctrine closed it
+     * during the original failure (constraint violation, lost connection, etc).
+     * Without this, the failure write would itself throw EntityManagerClosed and the
+     * job would be silently stuck in Processing.
+     */
+    private function persistFailure(ExportJob $job, Throwable $cause): void
+    {
+        if (! $this->entityManager->isOpen()) {
+            $this->registry->resetManager();
+        }
+
+        $manager = $this->registry->getManager();
+        assert($manager instanceof EntityManagerInterface);
+
+        $tracked = $manager->find(ExportJob::class, $job->getId()) ?? $job;
+        $tracked->markFailed(sprintf('%s: %s', $cause::class, $cause->getMessage()));
+
+        $manager->persist($tracked);
+        $manager->flush();
     }
 
     private function sendEmail(ExportJob $job, Ulid $userId): void

--- a/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
+++ b/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
@@ -46,6 +46,14 @@ use Throwable;
 #[AsMessageHandler]
 final readonly class ProcessCompanyExportHandler
 {
+    /**
+     * Generic user-facing failure message. The full exception (class, message, trace)
+     * is captured via the logger; only this safe label is persisted on the export job
+     * so the failure reason rendered in /profile/exports never leaks DB error text,
+     * file paths, or other internals.
+     */
+    private const FAILURE_REASON_USER_MESSAGE = 'Export failed. Please try again or contact support if the problem persists.';
+
     public function __construct(
         private ManagerRegistry $registry,
         private EntityManagerInterface $entityManager,
@@ -89,7 +97,11 @@ final readonly class ProcessCompanyExportHandler
             $relativePath = $this->companyExporter->export($job);
 
             $absolutePath = $this->projectDir . '/' . $relativePath;
-            $fileSize = @filesize($absolutePath);
+            // CompanyExporter::zipDirectory throws if the archive could not be written,
+            // so reaching this point means the file exists. filesize() may still return
+            // false if the file is unreadable for unrelated reasons — fall back to 0
+            // rather than swallowing the underlying I/O error silently.
+            $fileSize = is_file($absolutePath) ? filesize($absolutePath) : false;
 
             $job->markCompleted($relativePath, $fileSize === false ? 0 : $fileSize);
             $this->entityManager->flush();
@@ -101,7 +113,7 @@ final readonly class ProcessCompanyExportHandler
                 'exception' => $e,
             ]);
 
-            $this->persistFailure($job, $e);
+            $this->persistFailure($job);
 
             throw $e;
         } finally {
@@ -114,8 +126,13 @@ final readonly class ProcessCompanyExportHandler
      * during the original failure (constraint violation, lost connection, etc).
      * Without this, the failure write would itself throw EntityManagerClosed and the
      * job would be silently stuck in Processing.
+     *
+     * Note: after `resetManager()` the constructor-injected `$this->entityManager` is
+     * the stale (closed) reference. This handler does no further flushes after the
+     * catch block, so the stale reference is never reused. Any future code that
+     * touches the EM after this point must obtain a fresh manager via the registry.
      */
-    private function persistFailure(ExportJob $job, Throwable $cause): void
+    private function persistFailure(ExportJob $job): void
     {
         if (! $this->entityManager->isOpen()) {
             $this->registry->resetManager();
@@ -125,7 +142,7 @@ final readonly class ProcessCompanyExportHandler
         assert($manager instanceof EntityManagerInterface);
 
         $tracked = $manager->find(ExportJob::class, $job->getId()) ?? $job;
-        $tracked->markFailed(sprintf('%s: %s', $cause::class, $cause->getMessage()));
+        $tracked->markFailed(self::FAILURE_REASON_USER_MESSAGE);
 
         $manager->persist($tracked);
         $manager->flush();

--- a/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
+++ b/src/CoreBundle/Export/Message/Handler/ProcessCompanyExportHandler.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Message\Handler;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\CompanyExporter;
+use SolidInvoice\CoreBundle\Export\Email\ExportReadyEmail;
+use SolidInvoice\CoreBundle\Export\Enum\ExportStatus;
+use SolidInvoice\CoreBundle\Export\Message\RequestCompanyExport;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Repository\UserRepository;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Ulid;
+use Throwable;
+
+/**
+ * Handles the async export pipeline: load job → switch company → export → email.
+ *
+ * Idempotency: re-delivery skips any job whose status is no longer Pending. This means
+ * a Failed job will NOT be retried by Messenger; the user must request a new export.
+ *
+ * TODO(stuck-processing-recovery): if a worker is hard-killed (OOM, SIGKILL) AFTER
+ *   markProcessing() flushed but BEFORE the catch block runs, the job stays in
+ *   Processing forever and the idempotency guard prevents recovery. Add a CronBundle
+ *   command that finds jobs in Processing older than ~30 minutes, marks them Failed
+ *   with reason "worker timed out" so the user can request a fresh export.
+ */
+#[AsMessageHandler]
+final readonly class ProcessCompanyExportHandler
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ExportJobRepository $exportJobRepository,
+        private UserRepository $userRepository,
+        private CompanyExporter $companyExporter,
+        private CompanySelector $companySelector,
+        private MailerInterface $mailer,
+        private UrlGeneratorInterface $urlGenerator,
+        private LoggerInterface $logger,
+        private string $projectDir,
+    ) {
+    }
+
+    public function __invoke(RequestCompanyExport $message): void
+    {
+        $job = $this->exportJobRepository->find($message->exportJobId);
+
+        if (! $job instanceof ExportJob) {
+            $this->logger->warning('Export job not found, skipping', [
+                'export_job_id' => $message->exportJobId->toString(),
+            ]);
+            return;
+        }
+
+        // Idempotency: on Messenger retry, a job that already failed or completed must not be re-run.
+        if ($job->getStatus() !== ExportStatus::Pending) {
+            $this->logger->info('Export job is no longer pending, skipping', [
+                'export_job_id' => $job->getId()->toString(),
+                'current_status' => $job->getStatus()->value,
+            ]);
+            return;
+        }
+
+        $this->companySelector->switchCompany($message->companyId);
+
+        try {
+            $job->markProcessing();
+            $this->entityManager->flush();
+
+            $relativePath = $this->companyExporter->export($job);
+
+            $absolutePath = $this->projectDir . '/' . $relativePath;
+            $fileSize = @filesize($absolutePath);
+
+            $job->markCompleted($relativePath, $fileSize === false ? 0 : $fileSize);
+            $this->entityManager->flush();
+
+            $this->sendEmail($job, $message->userId);
+        } catch (Throwable $e) {
+            $this->logger->error('Export job failed', [
+                'export_job_id' => $job->getId()->toString(),
+                'exception' => $e,
+            ]);
+
+            $job->markFailed(sprintf('%s: %s', $e::class, $e->getMessage()));
+            $this->entityManager->flush();
+
+            throw $e;
+        } finally {
+            $this->companySelector->reset();
+        }
+    }
+
+    private function sendEmail(ExportJob $job, Ulid $userId): void
+    {
+        $user = $this->userRepository->find($userId);
+        if (! $user instanceof User) {
+            $this->logger->warning('Export requester not found, skipping email', [
+                'export_job_id' => $job->getId()->toString(),
+                'user_id' => $userId->toString(),
+            ]);
+            return;
+        }
+
+        $downloadUrl = $this->urlGenerator->generate(
+            '_export_download',
+            ['id' => $job->getId()->toBase58()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $email = (new ExportReadyEmail($job, $user, $downloadUrl))
+            ->to($user->getEmail());
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/CoreBundle/Export/Message/RequestCompanyExport.php
+++ b/src/CoreBundle/Export/Message/RequestCompanyExport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Message;
+
+use Symfony\Component\Uid\Ulid;
+
+final readonly class RequestCompanyExport
+{
+    public function __construct(
+        public Ulid $exportJobId,
+        public Ulid $companyId,
+        public Ulid $userId,
+    ) {
+    }
+}

--- a/src/CoreBundle/Export/Security/Voter/ExportJobVoter.php
+++ b/src/CoreBundle/Export/Security/Voter/ExportJobVoter.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Security\Voter;
+
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<string, ExportJob>
+ */
+final class ExportJobVoter extends Voter
+{
+    public const DOWNLOAD = 'EXPORT_DOWNLOAD';
+
+    public function __construct(
+        private readonly CompanySelector $companySelector,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $attribute === self::DOWNLOAD && $subject instanceof ExportJob;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        assert($subject instanceof ExportJob);
+
+        if (! $subject->getRequestedBy()->equals($user->getId())) {
+            return false;
+        }
+
+        $activeCompanyId = $this->companySelector->getCompany();
+        if ($activeCompanyId === null) {
+            return false;
+        }
+
+        return $subject->getCompany()->getId()->equals($activeCompanyId);
+    }
+}

--- a/src/CoreBundle/Export/Serializer/ExportSerializer.php
+++ b/src/CoreBundle/Export/Serializer/ExportSerializer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer;
+
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Facade over a dedicated Symfony Serializer configured for export output.
+ *
+ * The inner serializer is composed in CoreBundle service config and is
+ * independent of API Platform's normalizer chain, so it produces raw,
+ * predictable values suitable for user-facing data exports.
+ */
+final class ExportSerializer
+{
+    public function __construct(
+        private readonly SerializerInterface&NormalizerInterface&EncoderInterface $inner,
+    ) {
+    }
+
+    /**
+     * Encode an already-normalized array payload (e.g. grid rows) to the given format.
+     *
+     * @param array<mixed> $data
+     * @param array<string, mixed> $context
+     */
+    public function encode(array $data, ExportFormat $format, array $context = []): string
+    {
+        return $this->inner->encode($data, $format->encoderFormat(), $context);
+    }
+
+    /**
+     * Fully serialize an object graph to the given format.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function serialize(mixed $data, ExportFormat $format, array $context = []): string
+    {
+        return $this->inner->serialize($data, $format->encoderFormat(), $context);
+    }
+
+    /**
+     * Normalize a value for the given format without encoding it.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function normalize(mixed $data, ExportFormat $format, array $context = []): mixed
+    {
+        return $this->inner->normalize($data, $format->encoderFormat(), $context);
+    }
+}

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportCurrencyNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportCurrencyNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer\Normalizer;
+
+use Money\Currency;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ExportCurrencyNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    {
+        assert($object instanceof Currency);
+
+        return $object->getCode();
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Currency;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Currency::class => true];
+    }
+}

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportDateTimeNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportDateTimeNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer\Normalizer;
+
+use DateTimeInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ExportDateTimeNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    {
+        assert($object instanceof DateTimeInterface);
+
+        return $object->format(DateTimeInterface::ATOM);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof DateTimeInterface;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [DateTimeInterface::class => true];
+    }
+}

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportEnumNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportEnumNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer\Normalizer;
+
+use BackedEnum;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ExportEnumNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = []): int|string
+    {
+        assert($object instanceof BackedEnum);
+
+        return $object->value;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof BackedEnum;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [BackedEnum::class => true];
+    }
+}

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportMoneyNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportMoneyNormalizer.php
@@ -66,9 +66,10 @@ final class ExportMoneyNormalizer implements NormalizerInterface
     public static function amountToDecimalString(BigNumber $amount, int $subunitExponent): string
     {
         $divisor = 10 ** $subunitExponent;
-        $scale = max($subunitExponent, 1);
 
-        return $amount->toBigDecimal()->dividedBy($divisor, $scale, RoundingMode::HALF_EVEN)->__toString();
+        return $amount->toBigDecimal()
+            ->dividedBy($divisor, $subunitExponent, RoundingMode::HalfEven)
+            ->__toString();
     }
 
     private function subunitExponent(Currency $currency): int

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportMoneyNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportMoneyNormalizer.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer\Normalizer;
+
+use Brick\Math\BigNumber;
+use Brick\Math\RoundingMode;
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Money\Money;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes Money and BigNumber values to decimal strings (major units) for export.
+ *
+ * Money values are divided by the currency's actual subunit exponent (e.g. /100 for
+ * USD, /1 for JPY, /1000 for KWD). BigNumber values lack currency context and assume
+ * the project's default 2-decimal subunit — this matches how the rest of the app
+ * stores amounts as integer cents.
+ */
+final class ExportMoneyNormalizer implements NormalizerInterface
+{
+    private const DEFAULT_SUBUNIT_EXPONENT = 2;
+
+    private readonly ISOCurrencies $currencies;
+
+    public function __construct()
+    {
+        $this->currencies = new ISOCurrencies();
+    }
+
+    /**
+     * @return array{amount: string, currency: string}|string
+     */
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string
+    {
+        if ($object instanceof Money) {
+            return [
+                'amount' => self::amountToDecimalString(
+                    BigNumber::of($object->getAmount()),
+                    $this->subunitExponent($object->getCurrency()),
+                ),
+                'currency' => $object->getCurrency()->getCode(),
+            ];
+        }
+
+        assert($object instanceof BigNumber);
+
+        return self::amountToDecimalString($object, self::DEFAULT_SUBUNIT_EXPONENT);
+    }
+
+    /**
+     * Shared helper for converting a minor-unit BigNumber to a decimal string.
+     * Used by GridRowExtractor to keep the conversion arithmetic in one place.
+     */
+    public static function amountToDecimalString(BigNumber $amount, int $subunitExponent): string
+    {
+        $divisor = 10 ** $subunitExponent;
+        $scale = max($subunitExponent, 1);
+
+        return $amount->toBigDecimal()->dividedBy($divisor, $scale, RoundingMode::HALF_EVEN)->__toString();
+    }
+
+    private function subunitExponent(Currency $currency): int
+    {
+        if (! $this->currencies->contains($currency)) {
+            return self::DEFAULT_SUBUNIT_EXPONENT;
+        }
+
+        return $this->currencies->subunitFor($currency);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Money || $data instanceof BigNumber;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Money::class => true,
+            BigNumber::class => true,
+        ];
+    }
+}

--- a/src/CoreBundle/Export/Serializer/Normalizer/ExportUlidNormalizer.php
+++ b/src/CoreBundle/Export/Serializer/Normalizer/ExportUlidNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Uid\Ulid;
+
+final class ExportUlidNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    {
+        assert($object instanceof Ulid);
+
+        return $object->toBase58();
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Ulid;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Ulid::class => true];
+    }
+}

--- a/src/CoreBundle/Export/ValueFormatter.php
+++ b/src/CoreBundle/Export/ValueFormatter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Export;
+
+use BackedEnum;
+use Brick\Math\BigNumber;
+use DateTimeInterface;
+use Money\Currencies\ISOCurrencies;
+use Money\Money;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+use Stringable;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * Type-aware value formatting shared by GridRowExtractor (per-grid export) and
+ * EntityRowNormalizer (full-company export). Keeps Money/DateTime/Ulid/enum
+ * handling in a single place so the two export paths stay in lock-step.
+ */
+final class ValueFormatter
+{
+    /**
+     * @return array{0: string, 1: string} `{$field}_amount` + `{$field}_currency`
+     *                                     keys plus their values (returned as a
+     *                                     `[key => value]` map below)
+     *
+     * @return array<string, string>
+     */
+    public static function flattenMoney(string $field, Money $money, ISOCurrencies $currencies): array
+    {
+        $exponent = $currencies->contains($money->getCurrency())
+            ? $currencies->subunitFor($money->getCurrency())
+            : 2;
+
+        return [
+            $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString(
+                BigNumber::of($money->getAmount()),
+                $exponent,
+            ),
+            $field . '_currency' => $money->getCurrency()->getCode(),
+        ];
+    }
+
+    /**
+     * Returns a scalar representation for the value, or null when no shared
+     * formatting applies (Money / BigNumber are caller-specific and handled by
+     * the caller, not here).
+     */
+    public static function formatScalar(mixed $value): int|float|string|bool|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ATOM);
+        }
+
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        if ($value instanceof Ulid) {
+            return $value->toBase58();
+        }
+
+        if (is_scalar($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/CoreBundle/Repository/ExportJobRepository.php
+++ b/src/CoreBundle/Repository/ExportJobRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @extends ServiceEntityRepository<ExportJob>
+ */
+final class ExportJobRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ExportJob::class);
+    }
+
+    /**
+     * Returns all export jobs for the currently-active company (CompanyFilter applies),
+     * requested by the given user, most recent first.
+     *
+     * @return list<ExportJob>
+     */
+    public function findForUser(Ulid $userId): array
+    {
+        /** @var list<ExportJob> $result */
+        $result = $this->createQueryBuilder('j')
+            ->andWhere('j.requestedBy = :userId')
+            ->setParameter('userId', $userId, UlidType::NAME)
+            ->orderBy('j.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    public function save(ExportJob $job): void
+    {
+        $this->getEntityManager()->persist($job);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/src/CoreBundle/Repository/ExportJobRepository.php
+++ b/src/CoreBundle/Repository/ExportJobRepository.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace SolidInvoice\CoreBundle\Repository;
 
-use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
 
 /**
- * @extends ServiceEntityRepository<ExportJob>
+ * @extends EntityRepository<ExportJob>
  */
-final class ExportJobRepository extends ServiceEntityRepository
+final class ExportJobRepository extends EntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -46,11 +46,5 @@ final class ExportJobRepository extends ServiceEntityRepository
             ->getResult();
 
         return $result;
-    }
-
-    public function save(ExportJob $job): void
-    {
-        $this->getEntityManager()->persist($job);
-        $this->getEntityManager()->flush();
     }
 }

--- a/src/CoreBundle/Resources/config/routing.php
+++ b/src/CoreBundle/Resources/config/routing.php
@@ -17,6 +17,9 @@ use SolidInvoice\CoreBundle\Action\Search;
 use SolidInvoice\CoreBundle\Action\SearchSuggestions;
 use SolidInvoice\CoreBundle\Action\SelectCompany;
 use SolidInvoice\CoreBundle\Action\ViewBilling;
+use SolidInvoice\CoreBundle\Export\Action\DownloadExport;
+use SolidInvoice\CoreBundle\Export\Action\ListExports;
+use SolidInvoice\CoreBundle\Export\Action\RequestExport;
 use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
@@ -69,5 +72,20 @@ return static function (RoutingConfigurator $routingConfigurator): void {
     $routingConfigurator
         ->add('_search_suggestions', '/search/suggestions')
         ->controller(SearchSuggestions::class)
+        ->methods(['GET']);
+
+    $routingConfigurator
+        ->add('_export_list', '/profile/exports')
+        ->controller(ListExports::class)
+        ->methods(['GET']);
+
+    $routingConfigurator
+        ->add('_export_request', '/profile/exports')
+        ->controller(RequestExport::class)
+        ->methods(['POST']);
+
+    $routingConfigurator
+        ->add('_export_download', '/profile/exports/{id}/download')
+        ->controller(DownloadExport::class)
         ->methods(['GET']);
 };

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -80,6 +80,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire(true)
         ->tag('controller.service_arguments');
 
+    $services
+        ->load(SolidInvoiceCoreBundle::NAMESPACE . '\\Export\\Action\\', dirname(__DIR__, 3) . '/Export/Action')
+        ->autowire(true)
+        ->tag('controller.service_arguments');
+
     $services->set(\SolidInvoice\CoreBundle\Email\NullEmailVerificationGate::class);
     $services->alias(
         \SolidInvoice\CoreBundle\Contracts\EmailVerificationGateInterface::class,

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -15,16 +15,14 @@ use Gedmo\Timestampable\TimestampableListener;
 use Mpociot\VatCalculator\VatCalculator;
 use SolidInvoice\CoreBundle\DummyData\DummyDataLoader;
 use SolidInvoice\CoreBundle\Export\Serializer\ExportSerializer;
-use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportCurrencyNormalizer;
-use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportDateTimeNormalizer;
-use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportEnumNormalizer;
-use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
-use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportUlidNormalizer;
 use SolidInvoice\CoreBundle\Routing\Loader\AbstractDirectoryLoader;
 use SolidInvoice\CoreBundle\Search\MultiSearchService;
 use SolidInvoice\CoreBundle\Search\SearchQueryParser;
 use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Symfony\Component\Uid\Command\GenerateUlidCommand;
 use Symfony\Component\Uid\Command\GenerateUuidCommand;
@@ -32,6 +30,7 @@ use Symfony\Component\Uid\Command\InspectUlidCommand;
 use Symfony\Component\Uid\Command\InspectUuidCommand;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
@@ -53,8 +52,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->load(SolidInvoiceCoreBundle::NAMESPACE . '\\', dirname(__DIR__, 3))
+        // Export/Serializer/Normalizer is excluded so the normalizers there are NOT
+        // registered as global `serializer.normalizer` services. They are loaded
+        // inline as fresh instances inside the dedicated export Serializer below
+        // (see solidinvoice.core.export.serializer) so they never pollute the API
+        // Platform normalizer chain.
         ->exclude([
-            dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests}',
+            dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests,Export/Serializer/Normalizer}',
             dirname(__DIR__, 3) . '/Twig/Extension/FeatureExtension.php',
             dirname(__DIR__, 3) . '/Form/Extension/FeatureRestrictedExtension.php',
         ]);
@@ -119,33 +123,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SearchQueryParser::class)
         ->arg('$formatters', tagged_iterator('solidinvoice.search.result_formatter'));
 
-    // Export normalizers are composed into a dedicated serializer below and must not
-    // be tagged as global serializer.normalizer (they would conflict with the API
-    // Platform normalizer chain).
-    foreach ([
-        ExportUlidNormalizer::class,
-        ExportMoneyNormalizer::class,
-        ExportEnumNormalizer::class,
-        ExportDateTimeNormalizer::class,
-        ExportCurrencyNormalizer::class,
-    ] as $normalizerClass) {
-        $services->set($normalizerClass)->autoconfigure(false);
-    }
-
+    // Dedicated encoder chain for the export feature. The export pipeline does its
+    // own value normalisation (GridRowExtractor / EntityRowNormalizer produce flat
+    // associative arrays), so the inner Serializer is wired with NO normalizers and
+    // fresh encoder instances. Reusing the global `serializer.encoder.*` services or
+    // the global `serializer.normalizer.object` would cause Symfony's Serializer
+    // constructor to call setSerializer() on the shared instance and silently
+    // replace the API Platform serializer reference — breaking JSON-LD output.
     $services->set('solidinvoice.core.export.serializer', SymfonySerializer::class)
         ->args([
+            [],
             [
-                service(ExportUlidNormalizer::class),
-                service(ExportMoneyNormalizer::class),
-                service(ExportEnumNormalizer::class),
-                service(ExportDateTimeNormalizer::class),
-                service(ExportCurrencyNormalizer::class),
-                service('serializer.normalizer.object'),
-            ],
-            [
-                service('serializer.encoder.json'),
-                service('serializer.encoder.csv'),
-                service('serializer.encoder.xml'),
+                inline_service(JsonEncoder::class),
+                inline_service(CsvEncoder::class),
+                inline_service(XmlEncoder::class),
             ],
         ]);
 

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -14,11 +14,18 @@ declare(strict_types=1);
 use Gedmo\Timestampable\TimestampableListener;
 use Mpociot\VatCalculator\VatCalculator;
 use SolidInvoice\CoreBundle\DummyData\DummyDataLoader;
+use SolidInvoice\CoreBundle\Export\Serializer\ExportSerializer;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportCurrencyNormalizer;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportDateTimeNormalizer;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportEnumNormalizer;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportUlidNormalizer;
 use SolidInvoice\CoreBundle\Routing\Loader\AbstractDirectoryLoader;
 use SolidInvoice\CoreBundle\Search\MultiSearchService;
 use SolidInvoice\CoreBundle\Search\SearchQueryParser;
 use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Symfony\Component\Uid\Command\GenerateUlidCommand;
 use Symfony\Component\Uid\Command\GenerateUuidCommand;
 use Symfony\Component\Uid\Command\InspectUlidCommand;
@@ -111,4 +118,37 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SearchQueryParser::class)
         ->arg('$formatters', tagged_iterator('solidinvoice.search.result_formatter'));
+
+    // Export normalizers are composed into a dedicated serializer below and must not
+    // be tagged as global serializer.normalizer (they would conflict with the API
+    // Platform normalizer chain).
+    foreach ([
+        ExportUlidNormalizer::class,
+        ExportMoneyNormalizer::class,
+        ExportEnumNormalizer::class,
+        ExportDateTimeNormalizer::class,
+        ExportCurrencyNormalizer::class,
+    ] as $normalizerClass) {
+        $services->set($normalizerClass)->autoconfigure(false);
+    }
+
+    $services->set('solidinvoice.core.export.serializer', SymfonySerializer::class)
+        ->args([
+            [
+                service(ExportUlidNormalizer::class),
+                service(ExportMoneyNormalizer::class),
+                service(ExportEnumNormalizer::class),
+                service(ExportDateTimeNormalizer::class),
+                service(ExportCurrencyNormalizer::class),
+                service('serializer.normalizer.object'),
+            ],
+            [
+                service('serializer.encoder.json'),
+                service('serializer.encoder.csv'),
+                service('serializer.encoder.xml'),
+            ],
+        ]);
+
+    $services->set(ExportSerializer::class)
+        ->args([service('solidinvoice.core.export.serializer')]);
 };

--- a/src/CoreBundle/Resources/views/Email/export_ready.html.twig
+++ b/src/CoreBundle/Resources/views/Email/export_ready.html.twig
@@ -1,0 +1,57 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/Email/notification.html.twig" %}
+{% import "@SolidInvoiceCore/Layout/Email/components.html.twig" as email %}
+
+{%- block title -%}
+    {{ 'Your data export is ready'|trans }}
+{%- endblock -%}
+
+{%- block content -%}
+    {% apply inky_to_html %}
+        <row>
+            <columns>
+                <p style="color: #0891b2; font-size: 18px; font-weight: 600; line-height: 1.5; margin: 0 0 16px 0; Margin: 0 0 16px 0;">
+                    📦 {{ 'Export ready for download'|trans }}
+                </p>
+                <p style="color: #1e293b; font-size: 16px; line-height: 1.5; margin: 0 0 24px 0; Margin: 0 0 24px 0;">
+                    {{ 'The full data export you requested has completed. The archive contains one file per entity type plus a manifest describing the contents.'|trans }}
+                </p>
+            </columns>
+        </row>
+    {% endapply %}
+
+    {{ email.spacer('sm') }}
+
+    {{ email.info_row('Format', job.format.value|upper) }}
+    {{ email.spacer('xs') }}
+    {{ email.info_row('Requested', job.createdAt|date('Y-m-d H:i')) }}
+
+    {% if job.fileSize %}
+        {{ email.spacer('xs') }}
+        {{ email.info_row('Archive size', (job.fileSize / 1024 / 1024)|number_format(2) ~ ' MB') }}
+    {% endif %}
+
+    {{ email.divider('md') }}
+
+    {{ email.button('Download Export'|trans, downloadUrl, 'primary', 'large') }}
+
+    {{ email.spacer('md') }}
+
+    {% apply inky_to_html %}
+        <row>
+            <columns>
+                <p style="color: #64748b; font-size: 13px; line-height: 1.5; margin: 0; Margin: 0;">
+                    {{ 'This download link requires authentication as the user who requested the export.'|trans }}
+                </p>
+            </columns>
+        </row>
+    {% endapply %}
+{%- endblock -%}

--- a/src/CoreBundle/Resources/views/Email/export_ready.html.twig
+++ b/src/CoreBundle/Resources/views/Email/export_ready.html.twig
@@ -19,7 +19,7 @@
         <row>
             <columns>
                 <p style="color: #0891b2; font-size: 18px; font-weight: 600; line-height: 1.5; margin: 0 0 16px 0; Margin: 0 0 16px 0;">
-                    📦 {{ 'Export ready for download'|trans }}
+                    {{ 'Export ready for download'|trans }}
                 </p>
                 <p style="color: #1e293b; font-size: 16px; line-height: 1.5; margin: 0 0 24px 0; Margin: 0 0 24px 0;">
                     {{ 'The full data export you requested has completed. The archive contains one file per entity type plus a manifest describing the contents.'|trans }}

--- a/src/CoreBundle/Resources/views/Email/export_ready.html.twig
+++ b/src/CoreBundle/Resources/views/Email/export_ready.html.twig
@@ -30,13 +30,13 @@
 
     {{ email.spacer('sm') }}
 
-    {{ email.info_row('Format', job.format.value|upper) }}
+    {{ email.info_row('Format'|trans, job.format.value|upper) }}
     {{ email.spacer('xs') }}
-    {{ email.info_row('Requested', job.createdAt|date('Y-m-d H:i')) }}
+    {{ email.info_row('Requested'|trans, job.createdAt|date('Y-m-d H:i')) }}
 
     {% if job.fileSize %}
         {{ email.spacer('xs') }}
-        {{ email.info_row('Archive size', (job.fileSize / 1024 / 1024)|number_format(2) ~ ' MB') }}
+        {{ email.info_row('Archive size'|trans, (job.fileSize / 1024 / 1024)|number_format(2) ~ ' MB') }}
     {% endif %}
 
     {{ email.divider('md') }}

--- a/src/CoreBundle/Resources/views/Email/export_ready.text.twig
+++ b/src/CoreBundle/Resources/views/Email/export_ready.text.twig
@@ -1,0 +1,22 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+{{ 'Your data export is ready'|trans|upper }}
+
+{{ 'The full data export you requested has completed. The archive contains one file per entity type plus a manifest describing the contents.'|trans }}
+
+{{ 'Details'|trans }}:
+----------------
+{{ 'Format'|trans }}: {{ job.format.value|upper }}
+{{ 'Requested'|trans }}: {{ job.createdAt|date('Y-m-d H:i') }}
+{% if job.fileSize %}{{ 'Archive size'|trans }}: {{ (job.fileSize / 1024 / 1024)|number_format(2) }} MB
+{% endif %}
+
+{{ 'Download your export'|trans }}: {{ downloadUrl }}
+
+{{ 'This download link requires authentication as the user who requested the export.'|trans }}

--- a/src/CoreBundle/Resources/views/Export/list.html.twig
+++ b/src/CoreBundle/Resources/views/Export/list.html.twig
@@ -1,0 +1,128 @@
+{##
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% set menuItem = 'data-export' %}
+
+{% extends "@SolidInvoiceUser/Layout/profile.html.twig" %}
+
+{% block title %}{{ ux_icon('tabler:database-export', {width: 24, height: 24, class: 'me-2'}) }}{{ 'Data Export'|trans }}{% endblock title %}
+
+{% block profile_content %}
+    {% if app.request.hasPreviousSession %}
+        {% for message in app.flashes('success') %}
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+        {% for message in app.flashes('error') %}
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+
+    <twig:Ui:Card>
+        <twig:block name="header">
+            <div class="w-100">
+                <h3 class="mb-1">{{ 'Request a new export'|trans }}</h3>
+                <p class="text-muted mb-3">
+                    {{ 'Exports run in the background. You will receive an email with a download link once the archive is ready.'|trans }}
+                </p>
+                <form method="post" action="{{ path('_export_request') }}" class="d-flex align-items-end gap-3 flex-wrap">
+                    <div>
+                        <label for="export-format" class="form-label">{{ 'Format'|trans }}</label>
+                        <select name="format" id="export-format" class="form-select" required>
+                            {% for format in formats %}
+                                <option value="{{ format.value }}">{{ format.value|upper }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <input type="hidden" name="_token" value="{{ csrf_token('export.request') }}">
+                    <button type="submit" class="btn btn-primary">
+                        {{ ux_icon('tabler:download', {width: 18, height: 18}) }}
+                        {{ 'Request Export'|trans }}
+                    </button>
+                </form>
+            </div>
+        </twig:block>
+    </twig:Ui:Card>
+
+    <div class="mt-4">
+        <twig:Ui:Card>
+            <twig:block name="header">
+                <h3 class="mb-0">{{ 'Export history'|trans }}</h3>
+            </twig:block>
+
+            {% if jobs is empty %}
+                <div class="text-center py-5 text-muted">
+                    {{ ux_icon('tabler:database-off', {width: 40, height: 40}) }}
+                    <p class="mt-3 mb-0">{{ 'You have not requested any exports yet.'|trans }}</p>
+                </div>
+            {% else %}
+                <table class="table table-vcenter">
+                    <thead>
+                        <tr>
+                            <th>{{ 'Requested'|trans }}</th>
+                            <th>{{ 'Format'|trans }}</th>
+                            <th>{{ 'Status'|trans }}</th>
+                            <th>{{ 'Size'|trans }}</th>
+                            <th>{{ 'Completed'|trans }}</th>
+                            <th class="text-end">{{ 'Actions'|trans }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for job in jobs %}
+                            <tr>
+                                <td>{{ job.createdAt|date('Y-m-d H:i') }}</td>
+                                <td><span class="badge bg-secondary">{{ job.format.value|upper }}</span></td>
+                                <td>
+                                    {% set status = job.status.value %}
+                                    {% set badgeClass = {
+                                        'pending': 'bg-info',
+                                        'processing': 'bg-warning',
+                                        'completed': 'bg-success',
+                                        'failed': 'bg-danger',
+                                    }[status] %}
+                                    <span class="badge {{ badgeClass }}">{{ status|title|trans }}</span>
+                                    {% if job.status.value == 'failed' and job.failureReason %}
+                                        <div class="small text-muted">{{ job.failureReason }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if job.fileSize %}
+                                        {{ (job.fileSize / 1024 / 1024)|number_format(2) }} MB
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if job.completedAt %}
+                                        {{ job.completedAt|date('Y-m-d H:i') }}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td class="text-end">
+                                    {% if job.status.value == 'completed' %}
+                                        <a href="{{ path('_export_download', {id: job.id.toBase58}) }}" class="btn btn-sm btn-primary">
+                                            {{ ux_icon('tabler:download', {width: 16, height: 16}) }}
+                                            {{ 'Download'|trans }}
+                                        </a>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </twig:Ui:Card>
+    </div>
+{% endblock profile_content %}

--- a/src/CoreBundle/Resources/views/Export/list.html.twig
+++ b/src/CoreBundle/Resources/views/Export/list.html.twig
@@ -16,16 +16,10 @@
 {% block profile_content %}
     {% if app.request.hasPreviousSession %}
         {% for message in app.flashes('success') %}
-            <div class="alert alert-success alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
+            <twig:Ui:Alert type="success" :dismissible="true">{{ message }}</twig:Ui:Alert>
         {% endfor %}
         {% for message in app.flashes('error') %}
-            <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
+            <twig:Ui:Alert type="danger" :dismissible="true">{{ message }}</twig:Ui:Alert>
         {% endfor %}
     {% endif %}
 

--- a/src/CoreBundle/Resources/views/Export/list.html.twig
+++ b/src/CoreBundle/Resources/views/Export/list.html.twig
@@ -25,34 +25,33 @@
 
     <twig:Ui:Card>
         <twig:block name="header">
-            <div class="w-100">
-                <h3 class="mb-1">{{ 'Request a new export'|trans }}</h3>
-                <p class="text-muted mb-3">
-                    {{ 'Exports run in the background. You will receive an email with a download link once the archive is ready.'|trans }}
-                </p>
-                <form method="post" action="{{ path('_export_request') }}" class="d-flex align-items-end gap-3 flex-wrap">
-                    <div>
-                        <label for="export-format" class="form-label">{{ 'Format'|trans }}</label>
-                        <select name="format" id="export-format" class="form-select" required>
-                            {% for format in formats %}
-                                <option value="{{ format.value }}">{{ format.value|upper }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('export.request') }}">
-                    <button type="submit" class="btn btn-primary">
-                        {{ ux_icon('tabler:download', {width: 18, height: 18}) }}
-                        {{ 'Request Export'|trans }}
-                    </button>
-                </form>
-            </div>
+            <h3 class="card-title mb-0">{{ 'Request a new export'|trans }}</h3>
         </twig:block>
+
+        <p class="text-muted mb-3">
+            {{ 'Exports run in the background. You will receive an email with a download link once the archive is ready.'|trans }}
+        </p>
+        <form method="post" action="{{ path('_export_request') }}" class="d-flex align-items-end gap-3 flex-wrap">
+            <div>
+                <label for="export-format" class="form-label">{{ 'Format'|trans }}</label>
+                <select name="format" id="export-format" class="form-select" required>
+                    {% for format in formats %}
+                        <option value="{{ format.value }}">{{ format.value|upper }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <input type="hidden" name="_token" value="{{ csrf_token('export.request') }}">
+            <button type="submit" class="btn btn-primary">
+                {{ ux_icon('tabler:download', {width: 18, height: 18}) }}
+                {{ 'Request Export'|trans }}
+            </button>
+        </form>
     </twig:Ui:Card>
 
     <div class="mt-4">
         <twig:Ui:Card>
             <twig:block name="header">
-                <h3 class="mb-0">{{ 'Export history'|trans }}</h3>
+                <h3 class="card-title mb-0">{{ 'Export history'|trans }}</h3>
             </twig:block>
 
             {% if jobs is empty %}
@@ -76,14 +75,14 @@
                         {% for job in jobs %}
                             <tr>
                                 <td>{{ job.createdAt|date('Y-m-d H:i') }}</td>
-                                <td><span class="badge bg-secondary">{{ job.format.value|upper }}</span></td>
+                                <td><span class="badge bg-secondary-lt text-uppercase">{{ job.format.value }}</span></td>
                                 <td>
                                     {% set status = job.status.value %}
                                     {% set badgeClass = {
-                                        'pending': 'bg-info',
-                                        'processing': 'bg-warning',
-                                        'completed': 'bg-success',
-                                        'failed': 'bg-danger',
+                                        'pending': 'bg-info-lt',
+                                        'processing': 'bg-warning-lt',
+                                        'completed': 'bg-success-lt',
+                                        'failed': 'bg-danger-lt',
                                     }[status] %}
                                     <span class="badge {{ badgeClass }}">{{ status|title|trans }}</span>
                                     {% if job.status.value == 'failed' and job.failureReason %}

--- a/src/CoreBundle/Resources/views/Menu/top.html.twig
+++ b/src/CoreBundle/Resources/views/Menu/top.html.twig
@@ -78,6 +78,10 @@
                             {{ ux_icon('tabler:lock', {width: 16, height: 16}) }}
                             {{ 'API Keys'|trans }}
                         </a>
+                        <a href="{{ path('_export_list') }}" class="dropdown-item">
+                            {{ ux_icon('tabler:database-export', {width: 16, height: 16}) }}
+                            {{ 'Data Export'|trans }}
+                        </a>
                         <twig:Ui:Security:LogoutLink />
                     </div>
                 </div>

--- a/src/CoreBundle/Tests/Export/Message/Handler/ProcessCompanyExportHandlerTest.php
+++ b/src/CoreBundle/Tests/Export/Message/Handler/ProcessCompanyExportHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Export\Message\Handler;
+
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Enum\ExportStatus;
+use SolidInvoice\CoreBundle\Export\Message\Handler\ProcessCompanyExportHandler;
+use SolidInvoice\CoreBundle\Export\Message\RequestCompanyExport;
+use SolidInvoice\CoreBundle\Repository\ExportJobRepository;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Mailer\Test\InteractsWithMailer;
+use ZipArchive;
+
+/**
+ * @covers \SolidInvoice\CoreBundle\Export\Message\Handler\ProcessCompanyExportHandler
+ * @covers \SolidInvoice\CoreBundle\Export\CompanyExporter
+ * @covers \SolidInvoice\CoreBundle\Export\Discovery\EntityDiscovery
+ */
+final class ProcessCompanyExportHandlerTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+    use InteractsWithMailer;
+
+    public function testHandlerBuildsArchiveAndNotifiesUser(): void
+    {
+        $user = UserFactory::createOne([
+            'email' => 'exporter@example.com',
+            'companies' => [$this->company],
+        ]);
+
+        $repository = $this->exportJobRepository();
+        $job = (new ExportJob($user->getId(), ExportFormat::Json))->setCompany($this->company);
+        $repository->save($job);
+
+        $handler = self::getContainer()->get(ProcessCompanyExportHandler::class);
+        $handler(new RequestCompanyExport($job->getId(), $this->company->getId(), $user->getId()));
+
+        self::getContainer()->get(CompanySelector::class)->switchCompany($this->company->getId());
+
+        $reloaded = $repository->find($job->getId());
+        self::assertInstanceOf(ExportJob::class, $reloaded);
+        self::assertSame(ExportStatus::Completed, $reloaded->getStatus());
+        self::assertNotNull($reloaded->getArchivePath());
+
+        $absolutePath = $reloaded->resolveAbsolutePath(self::getContainer()->getParameter('kernel.project_dir'));
+        self::assertNotNull($absolutePath);
+        self::assertFileExists($absolutePath);
+
+        $this->assertArchiveContainsManifest($absolutePath);
+
+        $this->mailer()->sentEmails()->assertCount(1);
+        $this->mailer()->sentEmails()->first()->assertTo('exporter@example.com');
+
+        (new Filesystem())->remove($absolutePath);
+    }
+
+    public function testSkipsWhenJobIsNotPending(): void
+    {
+        $user = UserFactory::createOne([
+            'email' => 'exporter-idempotent@example.com',
+            'companies' => [$this->company],
+        ]);
+
+        $repository = $this->exportJobRepository();
+        $job = (new ExportJob($user->getId(), ExportFormat::Json))->setCompany($this->company);
+        $job->markFailed('pre-existing failure');
+        $repository->save($job);
+
+        $handler = self::getContainer()->get(ProcessCompanyExportHandler::class);
+        $handler(new RequestCompanyExport($job->getId(), $this->company->getId(), $user->getId()));
+
+        self::getContainer()->get(CompanySelector::class)->switchCompany($this->company->getId());
+
+        $reloaded = $repository->find($job->getId());
+        self::assertInstanceOf(ExportJob::class, $reloaded);
+        self::assertSame(ExportStatus::Failed, $reloaded->getStatus());
+        self::assertSame('pre-existing failure', $reloaded->getFailureReason());
+    }
+
+    private function exportJobRepository(): ExportJobRepository
+    {
+        /** @var ExportJobRepository $repository */
+        $repository = self::getContainer()->get(ExportJobRepository::class);
+        return $repository;
+    }
+
+    private function assertArchiveContainsManifest(string $archivePath): void
+    {
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($archivePath) === true);
+
+        $manifestContents = $zip->getFromName('manifest.json');
+        $zip->close();
+
+        self::assertNotFalse($manifestContents);
+
+        $manifest = json_decode($manifestContents, true, 8, JSON_THROW_ON_ERROR);
+        self::assertIsArray($manifest);
+        self::assertArrayHasKey('solidinvoice_version', $manifest);
+        self::assertArrayHasKey('entity_counts', $manifest);
+    }
+}

--- a/src/CoreBundle/Tests/Export/Security/Voter/ExportJobVoterTest.php
+++ b/src/CoreBundle/Tests/Export/Security/Voter/ExportJobVoterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Export\Security\Voter;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Entity\ExportJob;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Security\Voter\ExportJobVoter;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Uid\Ulid;
+
+/** @covers \SolidInvoice\CoreBundle\Export\Security\Voter\ExportJobVoter */
+final class ExportJobVoterTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testGrantsAccessWhenUserAndCompanyMatch(): void
+    {
+        $userId = new Ulid();
+        $companyId = new Ulid();
+
+        $voter = $this->makeVoter($companyId);
+        $token = $this->tokenForUser($userId);
+        $job = $this->job($userId, $companyId);
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_GRANTED,
+            $voter->vote($token, $job, [ExportJobVoter::DOWNLOAD]),
+        );
+    }
+
+    public function testDeniesWhenRequestingUserIsDifferent(): void
+    {
+        $companyId = new Ulid();
+
+        $voter = $this->makeVoter($companyId);
+        $token = $this->tokenForUser(new Ulid());
+        $job = $this->job(requestedBy: new Ulid(), company: $companyId);
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_DENIED,
+            $voter->vote($token, $job, [ExportJobVoter::DOWNLOAD]),
+        );
+    }
+
+    public function testDeniesWhenJobCompanyIsDifferentFromActive(): void
+    {
+        $userId = new Ulid();
+
+        $voter = $this->makeVoter(activeCompany: new Ulid());
+        $token = $this->tokenForUser($userId);
+        $job = $this->job(requestedBy: $userId, company: new Ulid());
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_DENIED,
+            $voter->vote($token, $job, [ExportJobVoter::DOWNLOAD]),
+        );
+    }
+
+    public function testDeniesWhenNoCompanyIsActive(): void
+    {
+        $userId = new Ulid();
+
+        $voter = $this->makeVoter(activeCompany: null);
+        $token = $this->tokenForUser($userId);
+        $job = $this->job(requestedBy: $userId, company: new Ulid());
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_DENIED,
+            $voter->vote($token, $job, [ExportJobVoter::DOWNLOAD]),
+        );
+    }
+
+    public function testAbstainsOnUnsupportedAttribute(): void
+    {
+        $voter = $this->makeVoter(new Ulid());
+        $token = $this->tokenForUser(new Ulid());
+        $job = $this->job(new Ulid(), new Ulid());
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_ABSTAIN,
+            $voter->vote($token, $job, ['SOMETHING_ELSE']),
+        );
+    }
+
+    public function testAbstainsOnNonExportJobSubject(): void
+    {
+        $voter = $this->makeVoter(new Ulid());
+        $token = $this->tokenForUser(new Ulid());
+
+        self::assertSame(
+            ExportJobVoter::ACCESS_ABSTAIN,
+            $voter->vote($token, new \stdClass(), [ExportJobVoter::DOWNLOAD]),
+        );
+    }
+
+    private function makeVoter(?Ulid $activeCompany): ExportJobVoter
+    {
+        // CompanySelector is final, so we construct a real instance with a dummy
+        // registry (only touched by switchCompany/reset which the voter never calls)
+        // and force the active company via reflection.
+        $selector = new CompanySelector(M::mock(ManagerRegistry::class));
+
+        $companyIdProp = new ReflectionProperty(CompanySelector::class, 'companyId');
+        $companyIdProp->setValue($selector, $activeCompany);
+
+        return new ExportJobVoter($selector);
+    }
+
+    private function tokenForUser(Ulid $userId): TokenInterface
+    {
+        $user = M::mock(User::class);
+        $user->shouldReceive('getId')->andReturn($userId);
+
+        $token = M::mock(TokenInterface::class);
+        $token->shouldReceive('getUser')->andReturn($user);
+
+        return $token;
+    }
+
+    private function job(Ulid $requestedBy, Ulid $company): ExportJob
+    {
+        $companyEntity = M::mock(Company::class);
+        $companyEntity->shouldReceive('getId')->andReturn($company);
+
+        $job = new ExportJob($requestedBy, ExportFormat::Json);
+        $job->setCompany($companyEntity);
+
+        return $job;
+    }
+}

--- a/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportMoneyNormalizerTest.php
+++ b/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportMoneyNormalizerTest.php
@@ -39,6 +39,16 @@ final class ExportMoneyNormalizerTest extends TestCase
         );
     }
 
+    public function testZeroDecimalCurrencySerializesAsWholeNumber(): void
+    {
+        $money = new Money(1500, new Currency('JPY'));
+
+        self::assertSame(
+            ['amount' => '1500', 'currency' => 'JPY'],
+            $this->normalizer->normalize($money),
+        );
+    }
+
     public function testNormalizesBigNumberToDecimalString(): void
     {
         $result = $this->normalizer->normalize(BigInteger::of(5000));

--- a/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportMoneyNormalizerTest.php
+++ b/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportMoneyNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Export\Serializer\Normalizer;
+
+use Brick\Math\BigInteger;
+use Money\Currency;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+
+/** @covers \SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer */
+final class ExportMoneyNormalizerTest extends TestCase
+{
+    private ExportMoneyNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ExportMoneyNormalizer();
+    }
+
+    public function testNormalizesMoneyObjectToAmountAndCurrency(): void
+    {
+        $money = new Money(12345, new Currency('USD'));
+
+        self::assertSame(
+            ['amount' => '123.45', 'currency' => 'USD'],
+            $this->normalizer->normalize($money),
+        );
+    }
+
+    public function testNormalizesBigNumberToDecimalString(): void
+    {
+        $result = $this->normalizer->normalize(BigInteger::of(5000));
+
+        self::assertSame('50.00', $result);
+    }
+
+    public function testSupportsMoneyAndBigNumberOnly(): void
+    {
+        self::assertTrue($this->normalizer->supportsNormalization(new Money(1, new Currency('USD'))));
+        self::assertTrue($this->normalizer->supportsNormalization(BigInteger::of(1)));
+        self::assertFalse($this->normalizer->supportsNormalization('string'));
+        self::assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+}

--- a/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportUlidNormalizerTest.php
+++ b/src/CoreBundle/Tests/Export/Serializer/Normalizer/ExportUlidNormalizerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Export\Serializer\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportUlidNormalizer;
+use Symfony\Component\Uid\Ulid;
+
+/** @covers \SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportUlidNormalizer */
+final class ExportUlidNormalizerTest extends TestCase
+{
+    public function testNormalizesUlidToBase58(): void
+    {
+        $ulid = new Ulid();
+        $normalizer = new ExportUlidNormalizer();
+
+        self::assertSame($ulid->toBase58(), $normalizer->normalize($ulid));
+    }
+
+    public function testSupportsUlidOnly(): void
+    {
+        $normalizer = new ExportUlidNormalizer();
+
+        self::assertTrue($normalizer->supportsNormalization(new Ulid()));
+        self::assertFalse($normalizer->supportsNormalization('string'));
+        self::assertFalse($normalizer->supportsNormalization(new \stdClass()));
+    }
+}

--- a/src/DataGridBundle/Action/ExportAction.php
+++ b/src/DataGridBundle/Action/ExportAction.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Action;
+
+use JsonException;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\DataGridBundle\Exception\InvalidGridException;
+use SolidInvoice\DataGridBundle\Export\ExportFilenameGenerator;
+use SolidInvoice\DataGridBundle\Export\GridExporter;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use ValueError;
+use function is_array;
+use function is_string;
+use function json_decode;
+
+#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
+final class ExportAction
+{
+    public function __construct(
+        private readonly GridExporter $exporter,
+        private readonly ExportFilenameGenerator $filenameGenerator,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $gridName = $request->query->get('grid');
+        if (! is_string($gridName) || $gridName === '') {
+            throw new BadRequestHttpException('Missing required "grid" query parameter.');
+        }
+
+        $format = $this->resolveFormat($request);
+        $context = $this->resolveContext($request);
+
+        $sort = (string) $request->query->get('sort', '');
+        $search = (string) $request->query->get('search', '');
+        $gridFilters = $request->query->all('gridFilters');
+
+        try {
+            $payload = $this->exporter->export($gridName, $format, $context, $sort, $search, $gridFilters);
+        } catch (InvalidGridException $e) {
+            throw new NotFoundHttpException($e->getMessage(), $e);
+        }
+
+        $filename = $this->filenameGenerator->generate($gridName, $format, $gridFilters);
+
+        $response = new Response($payload);
+        $response->headers->set('Content-Type', $format->mimeType() . '; charset=UTF-8');
+        $response->headers->set(
+            'Content-Disposition',
+            HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $filename),
+        );
+
+        return $response;
+    }
+
+    private function resolveFormat(Request $request): ExportFormat
+    {
+        $format = (string) $request->query->get('format', ExportFormat::Csv->value);
+
+        try {
+            return ExportFormat::from($format);
+        } catch (ValueError) {
+            throw new BadRequestHttpException(sprintf('Unsupported export format "%s".', $format));
+        }
+    }
+
+    /**
+     * Decodes the JSON-encoded context query parameter (grid render context such as
+     * `client_id` on a client detail page). Base58 ULID strings are consumed by each
+     * grid's `query()` method via Doctrine's UlidType string coercion.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveContext(Request $request): array
+    {
+        $raw = (string) $request->query->get('context', '');
+
+        if ($raw === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 8, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new BadRequestHttpException('Invalid JSON in "context" query parameter.', $e);
+        }
+
+        if (! is_array($decoded)) {
+            throw new BadRequestHttpException('"context" must decode to an object.');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/src/DataGridBundle/Action/ExportAction.php
+++ b/src/DataGridBundle/Action/ExportAction.php
@@ -176,6 +176,20 @@ final class ExportAction
             throw new BadRequestHttpException('"context" must decode to an object.');
         }
 
+        // Defense-in-depth: context values are forwarded to each grid's initialize()
+        // method, which typically binds them as Doctrine parameters. Match the same
+        // key whitelist used for `gridFilters` so a tampered context cannot smuggle
+        // unexpected identifier shapes through.
+        foreach ($decoded as $key => $value) {
+            if (! is_string($key) || ! preg_match('/^[A-Za-z0-9_]+$/', $key)) {
+                throw new BadRequestHttpException('Invalid context key.');
+            }
+
+            if ($value !== null && ! is_scalar($value)) {
+                throw new BadRequestHttpException(sprintf('Context value for "%s" must be a scalar or null.', $key));
+            }
+        }
+
         /** @var array<string, mixed> $decoded */
         return $decoded;
     }

--- a/src/DataGridBundle/Action/ExportAction.php
+++ b/src/DataGridBundle/Action/ExportAction.php
@@ -25,9 +25,13 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use ValueError;
+use function array_filter;
+use function explode;
 use function is_array;
+use function is_scalar;
 use function is_string;
 use function json_decode;
+use function preg_match;
 
 #[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
 final class ExportAction
@@ -48,9 +52,9 @@ final class ExportAction
         $format = $this->resolveFormat($request);
         $context = $this->resolveContext($request);
 
-        $sort = (string) $request->query->get('sort', '');
+        $sort = $this->resolveSort($request);
         $search = (string) $request->query->get('search', '');
-        $gridFilters = $request->query->all('gridFilters');
+        $gridFilters = $this->resolveGridFilters($request);
 
         try {
             $payload = $this->exporter->export($gridName, $format, $context, $sort, $search, $gridFilters);
@@ -79,6 +83,72 @@ final class ExportAction
         } catch (ValueError) {
             throw new BadRequestHttpException(sprintf('Unsupported export format "%s".', $format));
         }
+    }
+
+    /**
+     * Validates the `sort` query parameter to one of: empty string, `field`, or
+     * `field,direction`. Anything else is rejected. This keeps malformed input from
+     * unpacking into SortFilter's two-argument constructor and triggering
+     * ArgumentCountError downstream.
+     */
+    private function resolveSort(Request $request): string
+    {
+        $sort = (string) $request->query->get('sort', '');
+
+        if ($sort === '') {
+            return '';
+        }
+
+        $parts = explode(',', $sort);
+        if (count($parts) > 2) {
+            throw new BadRequestHttpException('Malformed "sort" query parameter.');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9_.]+$/', $parts[0])) {
+            throw new BadRequestHttpException('Invalid sort field.');
+        }
+
+        $direction = strtolower($parts[1] ?? 'asc');
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new BadRequestHttpException('Sort direction must be "asc" or "desc".');
+        }
+
+        return $parts[0] . ',' . $direction;
+    }
+
+    /**
+     * Validates `gridFilters` shape. Each value must be a scalar, an array of scalars,
+     * or an associative array with `start`/`end` keys (the date-range filter). Anything
+     * else is rejected before reaching column filter implementations, which assume
+     * specific shapes via assertions disabled in production.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveGridFilters(Request $request): array
+    {
+        $raw = $request->query->all('gridFilters');
+
+        foreach ($raw as $key => $value) {
+            if (! is_string($key) || ! preg_match('/^[A-Za-z0-9_]+$/', $key)) {
+                throw new BadRequestHttpException('Invalid grid filter key.');
+            }
+
+            if (is_scalar($value) || $value === null) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $allScalar = array_filter($value, static fn ($v): bool => ! (is_scalar($v) || $v === null)) === [];
+                if (! $allScalar) {
+                    throw new BadRequestHttpException(sprintf('Filter "%s" has unsupported nested values.', $key));
+                }
+                continue;
+            }
+
+            throw new BadRequestHttpException(sprintf('Filter "%s" has unsupported value type.', $key));
+        }
+
+        return $raw;
     }
 
     /**

--- a/src/DataGridBundle/Export/ExportFilenameGenerator.php
+++ b/src/DataGridBundle/Export/ExportFilenameGenerator.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Export;
+
+use DateTimeImmutable;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use function array_filter;
+use function array_map;
+use function implode;
+use function is_array;
+use function preg_replace;
+use function strtolower;
+use function substr;
+
+final class ExportFilenameGenerator
+{
+    private const MAX_FILTER_SUMMARY_LENGTH = 60;
+
+    /**
+     * @param array<string, mixed> $gridFilters
+     */
+    public function generate(
+        string $gridName,
+        ExportFormat $format,
+        array $gridFilters = [],
+        ?DateTimeImmutable $date = null,
+    ): string {
+        $date ??= new DateTimeImmutable();
+
+        $summary = $this->buildFilterSummary($gridFilters);
+
+        $filename = sprintf('%s-%s', $gridName, $date->format('Y-m-d'));
+        if ($summary !== '') {
+            $filename .= '.' . $summary;
+        }
+
+        return $filename . '.' . $format->extension();
+    }
+
+    /**
+     * @param array<string, mixed> $gridFilters
+     */
+    private function buildFilterSummary(array $gridFilters): string
+    {
+        if ($gridFilters === []) {
+            return '';
+        }
+
+        $parts = [];
+
+        foreach ($gridFilters as $key => $value) {
+            $safeKey = $this->sanitizeFilterKey((string) $key);
+
+            if ($safeKey === '') {
+                continue;
+            }
+
+            $parts[] = $safeKey . '-' . $this->sanitizeFilterValue($value);
+        }
+
+        $summary = implode('.', array_filter($parts, static fn (string $part): bool => $part !== ''));
+
+        return substr($summary, 0, self::MAX_FILTER_SUMMARY_LENGTH);
+    }
+
+    private function sanitizeFilterKey(string $key): string
+    {
+        return (string) preg_replace('/[^a-z0-9]/', '', strtolower($key));
+    }
+
+    private function sanitizeFilterValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            if (isset($value['start']) || isset($value['end'])) {
+                $range = array_filter([
+                    isset($value['start']) ? (string) $value['start'] : null,
+                    isset($value['end']) ? (string) $value['end'] : null,
+                ]);
+                return (string) preg_replace('/[^a-z0-9_]/', '', strtolower(implode('_', $range)));
+            }
+
+            return implode('_', array_filter(array_map(
+                fn (mixed $v): string => $this->sanitizeFilterKey((string) $v),
+                $value,
+            )));
+        }
+
+        return $this->sanitizeFilterKey((string) $value);
+    }
+}

--- a/src/DataGridBundle/Export/GridExporter.php
+++ b/src/DataGridBundle/Export/GridExporter.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Export;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\CoreBundle\Export\Serializer\ExportSerializer;
+use SolidInvoice\DataGridBundle\Attributes\AsDataGrid;
+use SolidInvoice\DataGridBundle\Exception\InvalidGridException;
+use SolidInvoice\DataGridBundle\GridBuilder\Query;
+use SolidInvoice\DataGridBundle\GridInterface;
+use SolidInvoice\DataGridBundle\Source\SourceInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * Runs a grid's filter pipeline end-to-end and encodes the full (unpaginated) result
+ * set into the chosen export format.
+ *
+ * Only sync/in-memory exports are supported today. The full result set is materialized
+ * before encoding.
+ *
+ * TODO(async-export): when datasets grow large enough to cause memory pressure, move
+ *   this behind a Messenger job that writes chunks to disk and emails the user a
+ *   download link, mirroring the full-company export flow.
+ */
+final class GridExporter
+{
+    /**
+     * @param ServiceLocator<GridInterface> $gridLocator
+     */
+    public function __construct(
+        #[TaggedLocator(AsDataGrid::DI_TAG, 'name')]
+        private readonly ServiceLocator $gridLocator,
+        private readonly SourceInterface $source,
+        private readonly GridQueryService $gridQueryService,
+        private readonly GridRowExtractor $rowExtractor,
+        private readonly ExportSerializer $serializer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @param array<string, mixed> $gridFilters
+     *
+     * @throws InvalidGridException
+     * @throws ContainerExceptionInterface
+     */
+    public function export(
+        string $gridName,
+        ExportFormat $format,
+        array $context,
+        string $sort,
+        string $search,
+        array $gridFilters,
+    ): string {
+        $grid = $this->resolveGrid($gridName);
+        $grid->initialize($context);
+
+        $query = $this->source->fetch($grid);
+        $builder = $query->getQueryBuilder();
+
+        $this->gridQueryService->applyFilters($grid, $builder, $sort, $search, $gridFilters);
+
+        $beforeQuery = $query->getCallback(Query::BEFORE_QUERY);
+        if ($beforeQuery !== null) {
+            $beforeQuery($builder);
+        }
+
+        /** @var list<object> $results */
+        $results = $builder->getQuery()->getResult();
+
+        $afterQuery = $query->getCallback(Query::AFTER_QUERY);
+        if ($afterQuery !== null) {
+            $afterQuery($results);
+        }
+
+        $columns = $grid->columns();
+        // TODO(export-columns): allow users to select which columns are included.
+        // For now every declared column is exported regardless of hiddenColumns.
+
+        $rows = [];
+        foreach ($results as $entity) {
+            $rows[] = $this->rowExtractor->extract($columns, $entity);
+        }
+
+        // XML element names cannot contain most punctuation. Grid names are snake_case
+        // identifiers so this is mostly defensive.
+        $xmlRoot = (string) preg_replace('/[^A-Za-z0-9_]/', '_', $gridName);
+
+        return $this->serializer->encode($rows, $format, $format->encoderContext($xmlRoot));
+    }
+
+    /**
+     * @throws InvalidGridException
+     * @throws ContainerExceptionInterface
+     */
+    private function resolveGrid(string $gridName): GridInterface
+    {
+        try {
+            return $this->gridLocator->get($gridName);
+        } catch (NotFoundExceptionInterface $e) {
+            throw new InvalidGridException($gridName, $e);
+        }
+    }
+}

--- a/src/DataGridBundle/Export/GridQueryService.php
+++ b/src/DataGridBundle/Export/GridQueryService.php
@@ -40,7 +40,13 @@ final class GridQueryService
         string $search,
         array $gridFilters,
     ): void {
-        (new SortFilter(...explode(',', $sort)))->filter($builder, null);
+        // SortFilter's constructor expects (field, direction = ASC); explode on an
+        // empty string yields a single empty element which SortFilter::filter()
+        // already treats as a no-op. The early return keeps intent obvious and
+        // avoids constructing a throw-away filter when sort is unset.
+        if ($sort !== '') {
+            (new SortFilter(...explode(',', $sort, 2)))->filter($builder, null);
+        }
 
         $searchFields = array_filter($grid->columns(), static fn (Column $column): bool => $column->isSearchable());
         $searchFields = array_map(static fn (Column $column): string => $column->getField(), $searchFields);

--- a/src/DataGridBundle/Export/GridQueryService.php
+++ b/src/DataGridBundle/Export/GridQueryService.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Export;
+
+use Doctrine\ORM\QueryBuilder;
+use SolidInvoice\DataGridBundle\Filter\SearchFilter;
+use SolidInvoice\DataGridBundle\Filter\SortFilter;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\Column;
+use SolidInvoice\DataGridBundle\GridInterface;
+use function array_filter;
+use function array_map;
+use function explode;
+
+/**
+ * Applies a grid's sort, search, and per-column filter state to a QueryBuilder.
+ *
+ * Extracted from the DataGrid LiveComponent so the same filter pipeline can be
+ * shared by the paginator path (for rendering a grid) and the export path.
+ */
+final class GridQueryService
+{
+    /**
+     * @param array<string, mixed> $gridFilters
+     */
+    public function applyFilters(
+        GridInterface $grid,
+        QueryBuilder $builder,
+        string $sort,
+        string $search,
+        array $gridFilters,
+    ): void {
+        (new SortFilter(...explode(',', $sort)))->filter($builder, null);
+
+        $searchFields = array_filter($grid->columns(), static fn (Column $column): bool => $column->isSearchable());
+        $searchFields = array_map(static fn (Column $column): string => $column->getField(), $searchFields);
+        (new SearchFilter($searchFields))->filter($builder, $search);
+
+        foreach ($grid->filters() as $column => $filter) {
+            $filterValue = $gridFilters[$column] ?? '';
+
+            if ($filterValue === '' || $filterValue === []) {
+                continue;
+            }
+
+            $filter->filter($builder, $filterValue);
+        }
+    }
+}

--- a/src/DataGridBundle/Export/GridRowExtractor.php
+++ b/src/DataGridBundle/Export/GridRowExtractor.php
@@ -13,17 +13,15 @@ declare(strict_types=1);
 
 namespace SolidInvoice\DataGridBundle\Export;
 
-use BackedEnum;
 use Brick\Math\BigNumber;
-use DateTimeInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currencies\ISOCurrencies;
 use Money\Money;
 use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+use SolidInvoice\CoreBundle\Export\ValueFormatter;
 use SolidInvoice\DataGridBundle\GridBuilder\Column\Column;
 use SolidInvoice\DataGridBundle\GridBuilder\Column\MoneyColumn;
-use Stringable;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Uid\Ulid;
@@ -156,22 +154,8 @@ final class GridRowExtractor
      */
     private function normalizeValue(Column $column, string $field, mixed $value): array
     {
-        if ($value === null) {
-            return [$field => null];
-        }
-
         if ($value instanceof Money) {
-            $exponent = $this->currencies->contains($value->getCurrency())
-                ? $this->currencies->subunitFor($value->getCurrency())
-                : 2;
-
-            return [
-                $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString(
-                    BigNumber::of($value->getAmount()),
-                    $exponent,
-                ),
-                $field . '_currency' => $value->getCurrency()->getCode(),
-            ];
+            return ValueFormatter::flattenMoney($field, $value, $this->currencies);
         }
 
         if ($value instanceof BigNumber) {
@@ -182,30 +166,13 @@ final class GridRowExtractor
                 ];
             }
 
+            // Non-MoneyColumn BigNumber falls through to its raw string form. Grids
+            // that use BigNumber values typically attach a formatValue closure that
+            // converts to Money, so this branch is rarely hit in practice.
             return [$field => $value->__toString()];
         }
 
-        if ($value instanceof DateTimeInterface) {
-            return [$field => $value->format(DateTimeInterface::ATOM)];
-        }
-
-        if ($value instanceof BackedEnum) {
-            return [$field => $value->value];
-        }
-
-        if ($value instanceof Ulid) {
-            return [$field => $value->toBase58()];
-        }
-
-        if (is_scalar($value)) {
-            return [$field => $value];
-        }
-
-        if ($value instanceof Stringable) {
-            return [$field => (string) $value];
-        }
-
-        return [$field => null];
+        return [$field => ValueFormatter::formatScalar($value)];
     }
 
     private function extractUlid(object $related): ?string

--- a/src/DataGridBundle/Export/GridRowExtractor.php
+++ b/src/DataGridBundle/Export/GridRowExtractor.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Export;
+
+use BackedEnum;
+use Brick\Math\BigNumber;
+use DateTimeInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Money\Currencies\ISOCurrencies;
+use Money\Money;
+use SolidInvoice\CoreBundle\Export\Serializer\Normalizer\ExportMoneyNormalizer;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\Column;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\MoneyColumn;
+use Stringable;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Uid\Ulid;
+use function is_scalar;
+use function str_contains;
+use function strstr;
+
+/**
+ * Extracts raw, export-friendly values from entities using grid column definitions.
+ *
+ * Relation columns (backed by a Doctrine association) emit two keys per column:
+ *   - `{field}`     the display label (column's formatValue output, or the related entity's __toString)
+ *   - `{field}_id`  the related entity's ULID (base58)
+ *
+ * Money columns emit two keys per column:
+ *   - `{field}_amount`    the decimal amount (major units)
+ *   - `{field}_currency`  the ISO currency code
+ *
+ * All formats (CSV / JSON / XML) receive the same flat key shape for consistency.
+ */
+final class GridRowExtractor
+{
+    private readonly ISOCurrencies $currencies;
+
+    public function __construct(
+        private readonly PropertyAccessorInterface $propertyAccessor,
+        private readonly ManagerRegistry $registry,
+    ) {
+        $this->currencies = new ISOCurrencies();
+    }
+
+    /**
+     * @param list<Column> $columns
+     * @return array<string, scalar|null>
+     */
+    public function extract(array $columns, object $entity): array
+    {
+        $metadata = $this->metadataFor($entity::class);
+        $row = [];
+
+        foreach ($columns as $column) {
+            foreach ($this->extractColumn($column, $entity, $metadata) as $key => $value) {
+                $row[$key] = $value;
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    private function extractColumn(Column $column, object $entity, ?ClassMetadata $metadata): array
+    {
+        $field = $column->getField();
+        $associationField = $this->associationField($field, $metadata);
+
+        if ($associationField !== null) {
+            return $this->extractRelation($column, $entity, $associationField);
+        }
+
+        try {
+            $raw = $this->propertyAccessor->getValue($entity, $field);
+        } catch (NoSuchPropertyException) {
+            $raw = $entity;
+        }
+
+        $value = $column->getFormatValue()($raw, $entity);
+
+        return $this->normalizeValue($column, $field, $value);
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    private function extractRelation(Column $column, object $entity, string $associationField): array
+    {
+        try {
+            $related = $this->propertyAccessor->getValue($entity, $associationField);
+        } catch (NoSuchPropertyException) {
+            return [$column->getField() => null, $column->getField() . '_id' => null];
+        }
+
+        if (! is_object($related)) {
+            return [$column->getField() => null, $column->getField() . '_id' => null];
+        }
+
+        $formatted = $column->getFormatValue()($related, $entity);
+        $display = $this->toDisplayString($formatted, $related);
+
+        $relatedId = $this->extractUlid($related);
+
+        return [
+            $column->getField() => $display,
+            $column->getField() . '_id' => $relatedId,
+        ];
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    private function normalizeValue(Column $column, string $field, mixed $value): array
+    {
+        if ($value === null) {
+            return [$field => null];
+        }
+
+        if ($value instanceof Money) {
+            $exponent = $this->currencies->contains($value->getCurrency())
+                ? $this->currencies->subunitFor($value->getCurrency())
+                : 2;
+
+            return [
+                $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString(
+                    BigNumber::of($value->getAmount()),
+                    $exponent,
+                ),
+                $field . '_currency' => $value->getCurrency()->getCode(),
+            ];
+        }
+
+        if ($value instanceof BigNumber) {
+            if ($column instanceof MoneyColumn) {
+                return [
+                    $field . '_amount' => ExportMoneyNormalizer::amountToDecimalString($value, 2),
+                    $field . '_currency' => null,
+                ];
+            }
+
+            return [$field => $value->__toString()];
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return [$field => $value->format(DateTimeInterface::ATOM)];
+        }
+
+        if ($value instanceof BackedEnum) {
+            return [$field => $value->value];
+        }
+
+        if ($value instanceof Ulid) {
+            return [$field => $value->toBase58()];
+        }
+
+        if (is_scalar($value)) {
+            return [$field => $value];
+        }
+
+        if ($value instanceof Stringable) {
+            return [$field => (string) $value];
+        }
+
+        return [$field => null];
+    }
+
+    private function toDisplayString(mixed $formatted, object $related): ?string
+    {
+        if ($formatted instanceof BackedEnum) {
+            return (string) $formatted->value;
+        }
+
+        if (is_scalar($formatted)) {
+            return (string) $formatted;
+        }
+
+        if ($formatted instanceof Stringable) {
+            return (string) $formatted;
+        }
+
+        if ($related instanceof Stringable) {
+            return (string) $related;
+        }
+
+        return null;
+    }
+
+    private function extractUlid(object $related): ?string
+    {
+        try {
+            $id = $this->propertyAccessor->getValue($related, 'id');
+        } catch (NoSuchPropertyException) {
+            return null;
+        }
+
+        if ($id instanceof Ulid) {
+            return $id->toBase58();
+        }
+
+        if (is_scalar($id)) {
+            return (string) $id;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the association field name on the entity class, or null if the column
+     * does not map to a Doctrine association.
+     */
+    private function associationField(string $field, ?ClassMetadata $metadata): ?string
+    {
+        if ($metadata === null) {
+            return null;
+        }
+
+        $rootField = str_contains($field, '.') ? strstr($field, '.', true) : $field;
+
+        if ($rootField === false) {
+            return null;
+        }
+
+        return $metadata->hasAssociation($rootField) ? $rootField : null;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function metadataFor(string $class): ?ClassMetadata
+    {
+        $manager = $this->registry->getManagerForClass($class);
+
+        if ($manager === null) {
+            return null;
+        }
+
+        $metadata = $manager->getClassMetadata($class);
+        assert($metadata instanceof ClassMetadata);
+
+        return $metadata;
+    }
+}

--- a/src/DataGridBundle/Export/GridRowExtractor.php
+++ b/src/DataGridBundle/Export/GridRowExtractor.php
@@ -34,6 +34,10 @@ use function strstr;
 /**
  * Extracts raw, export-friendly values from entities using grid column definitions.
  *
+ * Every row starts with the entity's primary identifier as `id` (base58 for ULIDs),
+ * regardless of whether the grid exposes an `id` column — this guarantees exported
+ * rows are uniquely addressable for downstream import/sync flows.
+ *
  * Relation columns (backed by a Doctrine association) emit two keys per column:
  *   - `{field}`     the display label (column's formatValue output, or the related entity's __toString)
  *   - `{field}_id`  the related entity's ULID (base58)
@@ -62,7 +66,7 @@ final class GridRowExtractor
     public function extract(array $columns, object $entity): array
     {
         $metadata = $this->metadataFor($entity::class);
-        $row = [];
+        $row = ['id' => $this->extractEntityId($entity, $metadata)];
 
         foreach ($columns as $column) {
             foreach ($this->extractColumn($column, $entity, $metadata) as $key => $value) {
@@ -71,6 +75,41 @@ final class GridRowExtractor
         }
 
         return $row;
+    }
+
+    /**
+     * Returns the entity's primary identifier as a string. ULIDs are encoded as
+     * base58 for compactness and consistency with relation `_id` fields.
+     */
+    private function extractEntityId(object $entity, ?ClassMetadata $metadata): ?string
+    {
+        if ($metadata !== null) {
+            $values = $metadata->getIdentifierValues($entity);
+            if ($values !== []) {
+                return $this->stringifyIdentifier(reset($values));
+            }
+        }
+
+        try {
+            $id = $this->propertyAccessor->getValue($entity, 'id');
+        } catch (NoSuchPropertyException) {
+            return null;
+        }
+
+        return $this->stringifyIdentifier($id);
+    }
+
+    private function stringifyIdentifier(mixed $id): ?string
+    {
+        if ($id instanceof Ulid) {
+            return $id->toBase58();
+        }
+
+        if (is_scalar($id)) {
+            return (string) $id;
+        }
+
+        return null;
     }
 
     /**
@@ -177,15 +216,7 @@ final class GridRowExtractor
             return null;
         }
 
-        if ($id instanceof Ulid) {
-            return $id->toBase58();
-        }
-
-        if (is_scalar($id)) {
-            return (string) $id;
-        }
-
-        return null;
+        return $this->stringifyIdentifier($id);
     }
 
     /**

--- a/src/DataGridBundle/Export/GridRowExtractor.php
+++ b/src/DataGridBundle/Export/GridRowExtractor.php
@@ -81,10 +81,6 @@ final class GridRowExtractor
         $field = $column->getField();
         $associationField = $this->associationField($field, $metadata);
 
-        if ($associationField !== null) {
-            return $this->extractRelation($column, $entity, $associationField);
-        }
-
         try {
             $raw = $this->propertyAccessor->getValue($entity, $field);
         } catch (NoSuchPropertyException) {
@@ -92,34 +88,28 @@ final class GridRowExtractor
         }
 
         $value = $column->getFormatValue()($raw, $entity);
+        $normalized = $this->normalizeValue($column, $field, $value);
 
-        return $this->normalizeValue($column, $field, $value);
+        if ($associationField !== null) {
+            $normalized[$associationField . '_id'] = $this->extractRelationId($entity, $associationField);
+        }
+
+        return $normalized;
     }
 
-    /**
-     * @return array<string, scalar|null>
-     */
-    private function extractRelation(Column $column, object $entity, string $associationField): array
+    private function extractRelationId(object $entity, string $associationField): ?string
     {
         try {
             $related = $this->propertyAccessor->getValue($entity, $associationField);
         } catch (NoSuchPropertyException) {
-            return [$column->getField() => null, $column->getField() . '_id' => null];
+            return null;
         }
 
         if (! is_object($related)) {
-            return [$column->getField() => null, $column->getField() . '_id' => null];
+            return null;
         }
 
-        $formatted = $column->getFormatValue()($related, $entity);
-        $display = $this->toDisplayString($formatted, $related);
-
-        $relatedId = $this->extractUlid($related);
-
-        return [
-            $column->getField() => $display,
-            $column->getField() . '_id' => $relatedId,
-        ];
+        return $this->extractUlid($related);
     }
 
     /**
@@ -177,27 +167,6 @@ final class GridRowExtractor
         }
 
         return [$field => null];
-    }
-
-    private function toDisplayString(mixed $formatted, object $related): ?string
-    {
-        if ($formatted instanceof BackedEnum) {
-            return (string) $formatted->value;
-        }
-
-        if (is_scalar($formatted)) {
-            return (string) $formatted;
-        }
-
-        if ($formatted instanceof Stringable) {
-            return (string) $formatted;
-        }
-
-        if ($related instanceof Stringable) {
-            return (string) $related;
-        }
-
-        return null;
     }
 
     private function extractUlid(object $related): ?string

--- a/src/DataGridBundle/Resources/config/routing.php
+++ b/src/DataGridBundle/Resources/config/routing.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use SolidInvoice\DataGridBundle\Action\ExportAction;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routingConfigurator): void {
+    $routingConfigurator
+        ->add('_datagrid_export', '/datagrid/export')
+        ->controller(ExportAction::class)
+        ->methods(['GET']);
+};

--- a/src/DataGridBundle/Resources/config/services/services.php
+++ b/src/DataGridBundle/Resources/config/services/services.php
@@ -29,4 +29,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services
         ->load(SolidInvoiceDataGridBundle::NAMESPACE . '\\', dirname(__DIR__, 3))
         ->exclude(dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests}');
+
+    $services
+        ->load(SolidInvoiceDataGridBundle::NAMESPACE . '\\Action\\', dirname(__DIR__, 3) . '/Action')
+        ->autowire(true)
+        ->tag('controller.service_arguments');
 };

--- a/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
+++ b/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
@@ -153,30 +153,50 @@
                     gridFilters: gridFilters,
                     context: context|json_encode,
                 } %}
+                {% set exportFormats = [
+                    {value: 'csv',  label: 'CSV',  icon: 'tabler:file-type-csv',  hint: 'Spreadsheet-friendly'},
+                    {value: 'json', label: 'JSON', icon: 'tabler:braces',         hint: 'Machine-readable'},
+                    {value: 'xml',  label: 'XML',  icon: 'tabler:file-type-xml',  hint: 'Structured markup'},
+                ] %}
                 <div class="dropdown datagrid-export-dropdown">
                     <button
                         type="button"
-                        class="dropdown-toggle"
+                        class="btn btn-sm btn-ghost"
                         data-bs-toggle="dropdown"
                         aria-expanded="false"
                         aria-label="{{ 'Export'|trans }}"
-                        title="{{ 'Export'|trans }}"
                     >
                         {{ ux_icon('tabler:download', {width: 18, height: 18}) }}
+                        <span class="d-none d-sm-inline ms-1">{{ 'Export'|trans }}</span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-end">
-                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'csv'})) }}" class="dropdown-item" target="_blank" rel="noopener">
-                            {{ ux_icon('tabler:file-type-csv', {width: 16, height: 16}) }}
-                            {{ 'Export as CSV'|trans }}
-                        </a>
-                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'json'})) }}" class="dropdown-item" target="_blank" rel="noopener">
-                            {{ ux_icon('tabler:braces', {width: 16, height: 16}) }}
-                            {{ 'Export as JSON'|trans }}
-                        </a>
-                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'xml'})) }}" class="dropdown-item" target="_blank" rel="noopener">
-                            {{ ux_icon('tabler:file-type-xml', {width: 16, height: 16}) }}
-                            {{ 'Export as XML'|trans }}
-                        </a>
+                    <div class="dropdown-menu dropdown-menu-end datagrid-export-menu">
+                        <div class="datagrid-export-menu-header">
+                            <h6 class="datagrid-export-menu-title">
+                                {{ ux_icon('tabler:download', {width: 16, height: 16}) }}
+                                {{ 'Export'|trans }}
+                            </h6>
+                            <p class="datagrid-export-menu-subtitle">
+                                {{ 'Choose a format to download the filtered results.'|trans }}
+                            </p>
+                        </div>
+                        <div class="datagrid-export-menu-body">
+                            {% for format in exportFormats %}
+                                <a
+                                    href="{{ path('_datagrid_export', exportQuery|merge({format: format.value})) }}"
+                                    class="datagrid-export-option"
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    <span class="datagrid-export-option-icon">
+                                        {{ ux_icon(format.icon, {width: 20, height: 20}) }}
+                                    </span>
+                                    <span class="datagrid-export-option-text">
+                                        <span class="datagrid-export-option-label">{{ format.label|trans }}</span>
+                                        <span class="datagrid-export-option-hint">{{ format.hint|trans }}</span>
+                                    </span>
+                                </a>
+                            {% endfor %}
+                        </div>
                     </div>
                 </div>
 

--- a/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
+++ b/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
@@ -145,6 +145,41 @@
                     </div>
                 {% endif %}
 
+                {# Export button with format picker #}
+                {% set exportQuery = {
+                    grid: name,
+                    sort: sort,
+                    search: search,
+                    gridFilters: gridFilters,
+                    context: context|json_encode,
+                } %}
+                <div class="dropdown datagrid-export-dropdown">
+                    <button
+                        type="button"
+                        class="dropdown-toggle"
+                        data-bs-toggle="dropdown"
+                        aria-expanded="false"
+                        aria-label="{{ 'Export'|trans }}"
+                        title="{{ 'Export'|trans }}"
+                    >
+                        {{ ux_icon('tabler:download', {width: 18, height: 18}) }}
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-end">
+                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'csv'})) }}" class="dropdown-item" target="_blank" rel="noopener">
+                            {{ ux_icon('tabler:file-type-csv', {width: 16, height: 16}) }}
+                            {{ 'Export as CSV'|trans }}
+                        </a>
+                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'json'})) }}" class="dropdown-item" target="_blank" rel="noopener">
+                            {{ ux_icon('tabler:braces', {width: 16, height: 16}) }}
+                            {{ 'Export as JSON'|trans }}
+                        </a>
+                        <a href="{{ path('_datagrid_export', exportQuery|merge({format: 'xml'})) }}" class="dropdown-item" target="_blank" rel="noopener">
+                            {{ ux_icon('tabler:file-type-xml', {width: 16, height: 16}) }}
+                            {{ 'Export as XML'|trans }}
+                        </a>
+                    </div>
+                </div>
+
                 {# Column Visibility Picker #}
                 {% block column_picker %}
                     {% if grid.columns|length > 3 %}

--- a/src/DataGridBundle/Tests/Export/ExportFilenameGeneratorTest.php
+++ b/src/DataGridBundle/Tests/Export/ExportFilenameGeneratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Tests\Export;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Export\Enum\ExportFormat;
+use SolidInvoice\DataGridBundle\Export\ExportFilenameGenerator;
+
+/** @covers \SolidInvoice\DataGridBundle\Export\ExportFilenameGenerator */
+final class ExportFilenameGeneratorTest extends TestCase
+{
+    private ExportFilenameGenerator $generator;
+
+    private DateTimeImmutable $date;
+
+    protected function setUp(): void
+    {
+        $this->generator = new ExportFilenameGenerator();
+        $this->date = new DateTimeImmutable('2026-04-24');
+    }
+
+    public function testGeneratesBasicFilenameWithoutFilters(): void
+    {
+        $filename = $this->generator->generate('invoice_grid', ExportFormat::Csv, [], $this->date);
+
+        self::assertSame('invoice_grid-2026-04-24.csv', $filename);
+    }
+
+    public function testAppendsSingleFilterSummary(): void
+    {
+        $filename = $this->generator->generate(
+            'invoice_grid',
+            ExportFormat::Json,
+            ['status' => 'paid'],
+            $this->date,
+        );
+
+        self::assertSame('invoice_grid-2026-04-24.status-paid.json', $filename);
+    }
+
+    public function testAppendsMultiSelectFilterSummary(): void
+    {
+        $filename = $this->generator->generate(
+            'invoice_grid',
+            ExportFormat::Xml,
+            ['status' => ['paid', 'draft']],
+            $this->date,
+        );
+
+        self::assertSame('invoice_grid-2026-04-24.status-paid_draft.xml', $filename);
+    }
+
+    public function testHandlesDateRangeFilter(): void
+    {
+        $filename = $this->generator->generate(
+            'invoice_grid',
+            ExportFormat::Csv,
+            ['invoiceDate' => ['start' => '2026-01-01', 'end' => '2026-03-31']],
+            $this->date,
+        );
+
+        self::assertSame('invoice_grid-2026-04-24.invoicedate-20260101_20260331.csv', $filename);
+    }
+
+    public function testTruncatesLongFilterSummaries(): void
+    {
+        $filename = $this->generator->generate(
+            'invoice_grid',
+            ExportFormat::Csv,
+            ['status' => str_repeat('a', 200)],
+            $this->date,
+        );
+
+        $summarySection = explode('.', $filename)[1];
+        self::assertLessThanOrEqual(60, strlen($summarySection));
+    }
+
+    public function testUsesCurrentDateWhenNotSupplied(): void
+    {
+        $filename = $this->generator->generate('grid', ExportFormat::Csv);
+
+        self::assertMatchesRegularExpression('/^grid-\d{4}-\d{2}-\d{2}\.csv$/', $filename);
+    }
+}

--- a/src/DataGridBundle/Tests/Export/GridRowExtractorTest.php
+++ b/src/DataGridBundle/Tests/Export/GridRowExtractorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Tests\Export;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\DataGridBundle\Export\GridRowExtractor;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\StringColumn;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Uid\Ulid;
+
+/** @covers \SolidInvoice\DataGridBundle\Export\GridRowExtractor */
+final class GridRowExtractorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testRowPrependsEntityIdAsBase58(): void
+    {
+        $ulid = new Ulid();
+        $entity = new class($ulid) {
+            public function __construct(
+                public Ulid $id
+            ) {
+            }
+
+            public function getName(): string
+            {
+                return 'Acme';
+            }
+        };
+
+        $row = $this->makeExtractor($entity, [])->extract(
+            [StringColumn::new('name')],
+            $entity,
+        );
+
+        self::assertSame(['id', 'name'], array_keys($row));
+        self::assertSame($ulid->toBase58(), $row['id']);
+        self::assertSame('Acme', $row['name']);
+    }
+
+    public function testEntityIdIsPresentEvenWhenGridHasNoIdColumn(): void
+    {
+        $ulid = new Ulid();
+        $entity = new class($ulid) {
+            public function __construct(
+                public Ulid $id
+            ) {
+            }
+        };
+
+        $row = $this->makeExtractor($entity, [])->extract([], $entity);
+
+        self::assertArrayHasKey('id', $row);
+        self::assertSame($ulid->toBase58(), $row['id']);
+    }
+
+    /**
+     * @param list<string> $associations
+     */
+    private function makeExtractor(object $entity, array $associations): GridRowExtractor
+    {
+        $metadata = M::mock(ClassMetadata::class);
+        $metadata->shouldReceive('getIdentifierValues')
+            ->with($entity)
+            ->andReturn(['id' => $entity->id]);
+        $metadata->shouldReceive('hasAssociation')
+            ->andReturnUsing(static fn (string $name): bool => in_array($name, $associations, true));
+
+        $manager = M::mock(ObjectManager::class);
+        $manager->shouldReceive('getClassMetadata')
+            ->with($entity::class)
+            ->andReturn($metadata);
+
+        $registry = M::mock(ManagerRegistry::class);
+        $registry->shouldReceive('getManagerForClass')
+            ->with($entity::class)
+            ->andReturn($manager);
+
+        return new GridRowExtractor(
+            PropertyAccess::createPropertyAccessor(),
+            $registry,
+        );
+    }
+}

--- a/src/DataGridBundle/Twig/Components/DataGrid.php
+++ b/src/DataGridBundle/Twig/Components/DataGrid.php
@@ -22,8 +22,7 @@ use Psr\Container\NotFoundExceptionInterface;
 use ReflectionObject;
 use SolidInvoice\DataGridBundle\Attributes\AsDataGrid;
 use SolidInvoice\DataGridBundle\Exception\InvalidGridException;
-use SolidInvoice\DataGridBundle\Filter\SearchFilter;
-use SolidInvoice\DataGridBundle\Filter\SortFilter;
+use SolidInvoice\DataGridBundle\Export\GridQueryService;
 use SolidInvoice\DataGridBundle\GridBuilder\Column\Column;
 use SolidInvoice\DataGridBundle\GridBuilder\Query;
 use SolidInvoice\DataGridBundle\GridInterface;
@@ -46,7 +45,6 @@ use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Attribute\PostMount;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
-use function array_map;
 use function explode;
 use function unserialize;
 
@@ -150,6 +148,7 @@ class DataGrid extends AbstractController
         private readonly SourceInterface $source,
         #[TaggedLocator(AsDataGrid::DI_TAG, 'name')]
         private readonly ServiceLocator $serviceLocator,
+        private readonly GridQueryService $gridQueryService,
     ) {
     }
 
@@ -444,19 +443,7 @@ class DataGrid extends AbstractController
 
     private function filterQuery(GridInterface $grid, QueryBuilder $builder): void
     {
-        (new SortFilter(...explode(',', $this->sort)))->filter($builder, null);
-
-        $searchFields = array_filter($grid->columns(), static fn (Column $column) => $column->isSearchable());
-        $searchFields = array_map(static fn (Column $column) => $column->getField(), $searchFields);
-        (new SearchFilter($searchFields))->filter($builder, $this->search);
-
-        // Use the filters LiveProp (URL-persisted) instead of formValues
-        foreach ($grid->filters() as $column => $filter) {
-            $filterValue = $this->gridFilters[$column] ?? '';
-            if ($filterValue !== '' && $filterValue !== []) {
-                $filter->filter($builder, $filterValue);
-            }
-        }
+        $this->gridQueryService->applyFilters($grid, $builder, $this->sort, $this->search, $this->gridFilters);
     }
 
     public function title(): ?string

--- a/src/NotificationBundle/Entity/TransportSetting.php
+++ b/src/NotificationBundle/Entity/TransportSetting.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\NotificationBundle\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\NotificationBundle\Repository\TransportSettingRepository;
 use SolidInvoice\UserBundle\Entity\User;
@@ -53,6 +54,7 @@ class TransportSetting implements Stringable
      * @var array<string, mixed>
      */
     #[ORM\Column(type: Types::JSON)]
+    #[ExportIgnore]
     private array $settings = [];
 
     #[ORM\ManyToOne(targetEntity: User::class)]

--- a/src/PaymentBundle/Entity/PaymentMethod.php
+++ b/src/PaymentBundle/Entity/PaymentMethod.php
@@ -18,6 +18,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Payum\Core\Model\GatewayConfigInterface;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\PaymentBundle\Repository\PaymentMethodRepository;
@@ -63,6 +64,7 @@ class PaymentMethod implements GatewayConfigInterface, Stringable
      * @var array<string, string>
      */
     #[ORM\Column(name: 'config', type: 'array', nullable: true)]
+    #[ExportIgnore]
     private array $config = [];
 
     #[ORM\Column(name: 'internal', type: Types::BOOLEAN, nullable: true)]

--- a/src/UserBundle/Entity/ApiToken.php
+++ b/src/UserBundle/Entity/ApiToken.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Mapping as ORM;
 use SolidInvoice\ApiBundle\State\Processor\ApiTokenCreateProcessor;
 use SolidInvoice\ApiBundle\State\Provider\ApiTokenCollectionProvider;
 use SolidInvoice\ApiBundle\State\Provider\ApiTokenItemProvider;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\UserBundle\Repository\ApiTokenRepository;
@@ -39,6 +40,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(ApiToken::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: ApiTokenRepository::class)]
+#[ExportIgnore]
 #[UniqueEntity(['name', 'user'])]
 #[ApiResource(
     uriTemplate: '/profile/api-tokens',

--- a/src/UserBundle/Entity/ApiTokenHistory.php
+++ b/src/UserBundle/Entity/ApiTokenHistory.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\UserBundle\Repository\ApiTokenHistoryRepository;
@@ -24,6 +25,7 @@ use Symfony\Component\Uid\Ulid;
 
 #[ORM\Table(name: ApiTokenHistory::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: ApiTokenHistoryRepository::class)]
+#[ExportIgnore]
 class ApiTokenHistory
 {
     final public const TABLE_NAME = 'api_token_history';

--- a/src/UserBundle/Entity/User.php
+++ b/src/UserBundle/Entity/User.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\UserBundle\Repository\UserRepository;
 use SolidWorx\Platform\PlatformBundle\Security\TwoFactor\Traits\UserTwoFactor;
@@ -24,6 +25,7 @@ use SolidWorx\Platform\SaasBundle\Trial\TrialUserInterface;
 
 #[ORM\Table(name: User::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ExportIgnore]
 class User extends \SolidWorx\Platform\PlatformBundle\Model\User implements TrialUserInterface
 {
     final public const string TABLE_NAME = 'users';

--- a/src/UserBundle/Resources/views/Layout/_partial/nav.html.twig
+++ b/src/UserBundle/Resources/views/Layout/_partial/nav.html.twig
@@ -37,6 +37,12 @@
                 </span>
                 <span class="profile-nav-text">{{ 'Connected Apps'|trans }}</span>
             </a>
+            <a href="{{ path('_export_list') }}" class="profile-nav-item{{ menuItem is defined and menuItem is same as('data-export') ? ' active' : '' }}">
+                <span class="profile-nav-icon">
+                    {{ ux_icon('tabler:database-export', {width: 20, height: 20}) }}
+                </span>
+                <span class="profile-nav-text">{{ 'Data Export'|trans }}</span>
+            </a>
         </nav>
     </div>
 </aside>


### PR DESCRIPTION
## Summary

Adds two complementary data-export pathways:

- **Per-grid export** — every datagrid gains a CSV/JSON/XML toolbar dropdown that respects the user's current filters, search, sort, and page-level context (e.g. `client_id` on a client detail page) and exports the **full filtered dataset** without pagination. Money values use a currency-aware subunit divisor; relations emit both the display label (e.g. `client: "Acme"`) and the related record's base58 ULID (`client_id: "01H…"`).
- **Full company export** — a new `/profile/exports` page lets any user request a JSON/XML/CSV dump of every company-owned entity. A Symfony Messenger handler runs the export in the background, walks Doctrine metadata for `CompanyAware` entities, serializes via a dedicated export `Serializer` (independent of API Platform), zips one file per entity plus a `manifest.json`, stores under `var/exports/{companyId}/`, and emails the requester a download link. `ExportJob` tracks status (Pending → Processing → Completed | Failed); `ExportJobVoter` plus a path-traversal containment check restrict downloads to the requesting user.

## Implementation notes

- Refactored `DataGrid` LiveComponent to share its filter pipeline with the new export controller via an extracted `GridQueryService` (no behavior change for the grid itself).
- New `#[ExportIgnore]` attribute opts entities or properties out of the full export. Applied to `ApiToken` and `ApiTokenHistory` (class level), `User` (class level), `PaymentMethod.config`, and `TransportSetting.settings` so credentials and PII never make it into a dump.
- Dedicated `ExportSerializer` composed of `ExportUlidNormalizer`, `ExportMoneyNormalizer`, `ExportEnumNormalizer`, `ExportDateTimeNormalizer`, `ExportCurrencyNormalizer`, and `ObjectNormalizer` — wired so it does not pollute the global serializer chain.
- Profile sidebar gets a new "Data Export" entry; same link added to the user dropdown in the top nav.
- Migration `Version30000_6` creates the `export_jobs` table.
- 11 new unit tests (filename generator, money/Ulid normalizers) and 2 integration tests covering the full handler flow including idempotency on retry.

## Known follow-ups (TODOs in code)

- Streaming/async path for very large tenants — current `findAll()` materialization will OOM on tens of thousands of records.
- Cron command to recover exports stuck in `Processing` (e.g. after a hard worker kill).
- Cron cleanup of old archives + per-company concurrent-job rate limit.
- User-selectable export columns and binary attachments (PDFs, logos) in the archive.

## Test plan

- [x] `bin/ecs check` — clean
- [x] `bin/phpstan analyse` (level 6) — clean
- [x] `bin/phpunit src/CoreBundle/Tests/Export src/DataGridBundle/Tests` — 188 tests pass
- [x] `bin/console debug:container` — all export services wired
- [x] `bin/console debug:router` — `_datagrid_export`, `_export_list`, `_export_request`, `_export_download` registered
- [ ] Manual: trigger an export from the invoice grid in CSV/JSON/XML and confirm the file matches the on-screen filter
- [ ] Manual: request a full export from `/profile/exports`, confirm email arrives, download the ZIP, validate `manifest.json` and per-entity files