### PR TITLE
fix(core): always resolve loopback hosts as the default host

### DIFF
--- a/src/CoreBundle/Company/CompanyDomainResolver.php
+++ b/src/CoreBundle/Company/CompanyDomainResolver.php
@@ -17,11 +17,15 @@ use League\Uri\Uri;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use Symfony\Contracts\Service\ResetInterface;
 use Throwable;
+use function in_array;
 use function rtrim;
 use function strtolower;
+use function trim;
 
 final class CompanyDomainResolver implements ResetInterface
 {
+    private const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1', '[::1]'];
+
     /**
      * @var array<string, ResolvedHost>
      */
@@ -51,7 +55,7 @@ final class CompanyDomainResolver implements ResetInterface
 
         $this->parseDefaultHost();
 
-        if ($this->defaultHost === null || $host === $this->defaultHost) {
+        if ($this->defaultHost === null || $host === $this->defaultHost || $this->isLoopbackHost($host)) {
             return $this->cache[$host] = new ResolvedHost(
                 HostType::DefaultHost,
                 $this->defaultHost ?? $host,
@@ -85,6 +89,12 @@ final class CompanyDomainResolver implements ResetInterface
         $this->cache = [];
         $this->defaultHostParsed = false;
         $this->defaultHost = null;
+    }
+
+    private function isLoopbackHost(string $host): bool
+    {
+        return in_array(trim($host, '[]'), ['localhost', '127.0.0.1', '::1'], true)
+            || in_array($host, self::LOOPBACK_HOSTS, true);
     }
 
     private function parseDefaultHost(): void

--- a/src/CoreBundle/Tests/Company/CompanyDomainResolverTest.php
+++ b/src/CoreBundle/Tests/Company/CompanyDomainResolverTest.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\CoreBundle\Tests\Company;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as M;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\CoreBundle\Company\CompanyDomainResolver;
 use SolidInvoice\CoreBundle\Company\HostType;
@@ -72,6 +73,31 @@ final class CompanyDomainResolverTest extends TestCase
         self::assertSame('https', $resolved->scheme);
         self::assertSame(443, $resolved->port);
         self::assertSame($company, $resolved->company);
+    }
+
+    #[DataProvider('provideLoopbackHosts')]
+    public function testTreatsLoopbackHostsAsDefault(string $host): void
+    {
+        $repository = M::mock(CompanyRepository::class);
+        $repository->shouldNotReceive('findOneByCustomDomain');
+
+        $resolver = new CompanyDomainResolver($repository, 'https://app.example.com');
+
+        $resolved = $resolver->resolve($host);
+
+        self::assertTrue($resolved->isDefaultHost(), 'Loopback host ' . $host . ' should resolve as DefaultHost');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideLoopbackHosts(): iterable
+    {
+        yield 'localhost' => ['localhost'];
+        yield 'localhost with port stripped' => ['LOCALHOST'];
+        yield 'IPv4 loopback' => ['127.0.0.1'];
+        yield 'IPv6 loopback' => ['::1'];
+        yield 'IPv6 loopback bracketed' => ['[::1]'];
     }
 
     public function testReturnsUnknownWhenHostNotFound(): void


### PR DESCRIPTION
## Summary
- Container healthchecks (and any internal/loopback traffic) hit the app on `http://localhost:<port>/`. Once `SOLIDINVOICE_APPLICATION_URL` is set to the public URL, those loopback requests no longer match the default host and got classified as `Unknown` by `CompanyDomainResolver`, so `HostRoutingListener` returned 404 — failing the Coolify/Docker healthcheck and rolling the deployment back.
- `CompanyDomainResolver::resolve()` now treats loopback hosts (`localhost`, `127.0.0.1`, `::1`, `[::1]`) as the default host regardless of the configured application URL.

## Test plan
- [x] PHPUnit: new data-provider test covering each loopback variant resolves to `DefaultHost`.
- [x] PHPStan + ECS clean.
- [ ] Re-deploy to Coolify and verify the healthcheck against `http://localhost:8765/login` returns 200.