### PR TITLE
Add multi-plan SaaS support with plan picker UI

### DIFF
--- a/assets/scss/components/_subscription-pages.scss
+++ b/assets/scss/components/_subscription-pages.scss
@@ -367,6 +367,121 @@
 }
 
 // ============================================================================
+// PRICING PAGE
+// ============================================================================
+
+.subscription-pricing-page {
+
+    .subscription-container {
+        max-width: 1100px;
+        text-align: center;
+    }
+}
+
+.plan-card {
+    position: relative;
+    overflow: hidden;
+    transition:
+        transform var(--swp-transition-base),
+        box-shadow var(--swp-transition-base),
+        border-color var(--swp-transition-base);
+
+    &:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--swp-shadow-md);
+    }
+}
+
+.plan-card-recommended {
+    border-width: 2px;
+    box-shadow: var(--swp-shadow-md);
+
+    &:hover {
+        transform: translateY(-4px);
+        box-shadow: var(--swp-shadow-xl);
+    }
+}
+
+.plan-card-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--swp-space-1);
+    padding: var(--swp-space-2) var(--swp-space-3);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #fff;
+    background: var(--tblr-primary, #206bc4);
+
+    svg {
+        flex-shrink: 0;
+    }
+}
+
+// Free plan: presented as a slim secondary card below the main grid.
+
+.plan-card-free {
+    background: var(--swp-gray-50, #f8f9fa);
+    border: 1px dashed var(--swp-border, #dee2e6);
+    box-shadow: none;
+    transition:
+        border-color var(--swp-transition-base),
+        background var(--swp-transition-base);
+
+    &:hover {
+        border-color: var(--tblr-primary, #206bc4);
+        background: var(--swp-surface, #fff);
+    }
+
+    .card-body {
+        padding: var(--swp-space-4) var(--swp-space-6);
+    }
+
+    .plan-card-features {
+        font-size: 0.875rem;
+
+        li {
+            margin-bottom: var(--swp-space-1);
+        }
+    }
+}
+
+.plan-card-free-header {
+    flex-shrink: 0;
+    min-width: 0;
+}
+
+.plan-card-free-cta {
+    flex-shrink: 0;
+}
+
+// Inline feature list flows horizontally and wraps; keeps the free strip slim.
+
+.plan-card-features-inline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--swp-space-2) var(--swp-space-4);
+    font-size: 0.875rem;
+
+    li {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--swp-space-1);
+        white-space: nowrap;
+    }
+}
+
+.plan-card-price {
+    line-height: 1;
+}
+
+.plan-card-features {
+    text-align: start;
+}
+
+// ============================================================================
 // RESPONSIVE DESIGN
 // ============================================================================
 

--- a/assets/scss/components/_subscription-pages.scss
+++ b/assets/scss/components/_subscription-pages.scss
@@ -412,7 +412,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: #fff;
+    color: #ffffff;
     background: var(--tblr-primary, #206bc4);
 
     svg {
@@ -432,7 +432,7 @@
 
     &:hover {
         border-color: var(--tblr-primary, #206bc4);
-        background: var(--swp-surface, #fff);
+        background: var(--swp-surface, #ffffff);
     }
 
     .card-body {

--- a/src/CoreBundle/Action/CreateCompany.php
+++ b/src/CoreBundle/Action/CreateCompany.php
@@ -19,9 +19,9 @@ use Money\Money;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Form\Type\CompanyType;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\SaasBundle\Plan\DefaultPlanProvider;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
-use SolidWorx\Platform\SaasBundle\Repository\PlanRepository;
 use SolidWorx\Platform\SaasBundle\Trial\TrialManagerInterface;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -40,7 +40,7 @@ final class CreateCompany extends AbstractController
         private readonly RouterInterface $router,
         private readonly ToggleInterface $toggler,
         private readonly ?TrialManagerInterface $trialManager = null,
-        private readonly ?PlanRepository $planRepository = null,
+        private readonly ?DefaultPlanProvider $defaultPlanProvider = null,
     ) {
     }
 
@@ -73,16 +73,22 @@ final class CreateCompany extends AbstractController
 
         if ($this->toggler->isActive('saas_enabled')) {
             $userHasTrial = $this->trialManager?->userHasTrial($user) ?? false;
-            $plan = $this->planRepository?->findOneBy([]);
-            if ($plan instanceof Plan) {
-                $formatter = new IntlMoneyFormatter(
-                    new \NumberFormatter('en_US', \NumberFormatter::CURRENCY),
-                    new ISOCurrencies()
-                );
-                $planPrice = $formatter->format(Money::USD($plan->getPrice()));
 
-                $trialDuration = $plan->getTrialDuration();
-                $planHasTrial = $trialDuration !== null;
+            // Only surface the default plan's price/trial when this is the
+            // user's first company — additional companies route through the
+            // plan picker after creation, so the price isn't known yet.
+            if (! $userHasTrial) {
+                $plan = $this->defaultPlanProvider?->get();
+                if ($plan instanceof Plan) {
+                    $formatter = new IntlMoneyFormatter(
+                        new \NumberFormatter('en_US', \NumberFormatter::CURRENCY),
+                        new ISOCurrencies()
+                    );
+                    $planPrice = $formatter->format(Money::USD($plan->getPrice()));
+
+                    $trialDuration = $plan->getTrialDuration();
+                    $planHasTrial = $trialDuration !== null;
+                }
             }
         }
 

--- a/src/CoreBundle/Resources/views/Company/create.html.twig
+++ b/src/CoreBundle/Resources/views/Company/create.html.twig
@@ -122,9 +122,7 @@
                                                 <div class="text-secondary">
                                                     {% if userHasTrial %}
                                                         {{ 'You have already used your free trial.'|trans }}
-                                                    {% endif %}
-                                                    {% if planPrice %}
-                                                        {{ 'Creating this company will start a subscription at'|trans }} <strong>{{ planPrice }}</strong> {{ 'and require payment.'|trans }}
+                                                        {{ 'After creating this company, you\'ll choose a plan and proceed to checkout.'|trans }}
                                                     {% else %}
                                                         {{ 'Creating this company will require payment.'|trans }}
                                                     {% endif %}

--- a/src/SaasBundle/Action/ChoosePlanAction.php
+++ b/src/SaasBundle/Action/ChoosePlanAction.php
@@ -40,6 +40,12 @@ final class ChoosePlanAction extends AbstractController
 
     public function __invoke(Request $request): Response
     {
+        if (! $this->isCsrfTokenValid('choose_plan', (string) $request->request->get('_token', ''))) {
+            $this->addFlash('error', 'Invalid security token, please try again.');
+
+            return $this->redirectToRoute('saas_subscription_plans');
+        }
+
         $subscription = $this->getSubscription();
 
         if (! $subscription instanceof Subscription) {

--- a/src/SaasBundle/Action/ChoosePlanAction.php
+++ b/src/SaasBundle/Action/ChoosePlanAction.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Action;
+
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Exception\ActiveSubscriptionPlanChangeException;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Ulid;
+
+final class ChoosePlanAction extends AbstractController
+{
+    public function __construct(
+        private readonly PlanRepositoryInterface $planRepository,
+        private readonly SubscriptionManager $subscriptionManager,
+        private readonly SubscriptionProviderInterface $subscriptionProvider,
+        private readonly CompanyRepository $companyRepository,
+        private readonly CompanySelector $companySelector,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $subscription = $this->getSubscription();
+
+        if (! $subscription instanceof Subscription) {
+            $this->addFlash('error', 'No subscription found');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        if ($subscription->getStatus() === SubscriptionStatus::ACTIVE) {
+            $this->addFlash('info', 'Changing plans on an active subscription is not supported yet.');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        $planId = (string) $request->request->get('plan', '');
+        $plan = $planId === '' ? null : $this->planRepository->find($planId);
+
+        if (! $plan instanceof Plan || ! $plan->isActive()) {
+            $this->addFlash('error', 'The selected plan is invalid.');
+
+            return $this->redirectToRoute('saas_subscription_plans');
+        }
+
+        if ($subscription->getPlan()->getPlanId() !== $plan->getPlanId()) {
+            try {
+                $this->subscriptionManager->changePlan($subscription, $plan);
+            } catch (ActiveSubscriptionPlanChangeException) {
+                $this->addFlash('info', 'Changing plans on an active subscription is not supported yet.');
+
+                return $this->redirectToRoute('_dashboard');
+            }
+        }
+
+        if ($plan->isFree()) {
+            $this->subscriptionManager->activate($subscription);
+            $this->addFlash('success', 'Your free plan is now active.');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        return $this->redirectToRoute('saas_subscription_checkout');
+    }
+
+    private function getSubscription(): ?Subscription
+    {
+        $companyId = $this->companySelector->getCompany();
+
+        if (! $companyId instanceof Ulid) {
+            return null;
+        }
+
+        $company = $this->companyRepository->find($companyId);
+
+        if ($company === null) {
+            return null;
+        }
+
+        return $this->subscriptionProvider->getSubscriptionFor($company);
+    }
+}

--- a/src/SaasBundle/Action/SelectPlanAction.php
+++ b/src/SaasBundle/Action/SelectPlanAction.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Action;
+
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Ulid;
+
+final class SelectPlanAction extends AbstractController
+{
+    public function __construct(
+        private readonly PlanRepositoryInterface $planRepository,
+        private readonly SubscriptionProviderInterface $subscriptionProvider,
+        private readonly CompanyRepository $companyRepository,
+        private readonly CompanySelector $companySelector,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $subscription = $this->getSubscription();
+
+        if ($subscription instanceof Subscription && $subscription->getStatus() === SubscriptionStatus::ACTIVE) {
+            $this->addFlash('info', 'Changing plans on an active subscription is not supported yet.');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        $plans = $this->planRepository->findAllOrdered();
+
+        if ($plans === []) {
+            $this->addFlash('error', 'No subscription plans are available.');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        if (count($plans) === 1) {
+            return $this->redirectToRoute('saas_subscription_checkout');
+        }
+
+        return $this->render('@SolidInvoiceSaas/subscription/pricing.html.twig', [
+            'plans' => $plans,
+            'subscription' => $subscription,
+        ]);
+    }
+
+    private function getSubscription(): ?Subscription
+    {
+        $companyId = $this->companySelector->getCompany();
+
+        if (! $companyId instanceof Ulid) {
+            return null;
+        }
+
+        $company = $this->companyRepository->find($companyId);
+
+        if ($company === null) {
+            return null;
+        }
+
+        return $this->subscriptionProvider->getSubscriptionFor($company);
+    }
+}

--- a/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
+++ b/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
@@ -15,13 +15,11 @@ namespace SolidInvoice\SaasBundle\EventSubscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
 use SolidInvoice\CoreBundle\Event\CompanyCreatedEvent;
+use SolidInvoice\SaasBundle\Plan\DefaultPlanProvider;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Exception\TrialAlreadyExistsException;
-use SolidWorx\Platform\SaasBundle\Integration\Options;
-use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
-use SolidWorx\Platform\SaasBundle\Repository\PlanRepository;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
 use SolidWorx\Platform\SaasBundle\Trial\TrialManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -29,6 +27,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use function assert;
 
 #[AsEventListener(CompanyCreatedEvent::class, 'onCompanyCreated')]
@@ -38,19 +37,18 @@ final class CompanyEventSubscriber
     private ?Subscription $subscription = null;
 
     public function __construct(
-        private readonly PlanRepository $planRepository,
+        private readonly DefaultPlanProvider $defaultPlanProvider,
         private readonly SubscriptionManager $subscriptionManager,
-        private readonly PaymentIntegrationInterface $paymentIntegration,
         private readonly Security $security,
         private readonly TrialManagerInterface $trialManager,
         private readonly EntityManagerInterface $entityManager,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
     public function onCompanyCreated(CompanyCreatedEvent $event): void
     {
-        // We only have a single plan for now, so we can just get the first one
-        $plan = $this->planRepository->findOneBy([]);
+        $plan = $this->defaultPlanProvider->get();
 
         if ($plan instanceof Plan) {
             $this->subscription = $this->subscriptionManager->createSubscription(
@@ -77,24 +75,20 @@ final class CompanyEventSubscriber
                     });
                 } catch (TrialAlreadyExistsException) {
                     // Race condition: another request already created a trial for this user
-                    $event->setResponse($this->createCheckoutRedirect($this->subscription, $user));
+                    $event->setResponse($this->createPlanSelectionRedirect());
                 }
             } else {
-                // User already had a trial or plan has no trial, redirect to checkout
-                $event->setResponse($this->createCheckoutRedirect($this->subscription, $user));
+                // User already had a trial — let them pick a plan for this new
+                // company instead of silently checking them out on the default.
+                $event->setResponse($this->createPlanSelectionRedirect());
             }
 
             $this->subscription = null;
         }
     }
 
-    private function createCheckoutRedirect(Subscription $subscription, User $user): RedirectResponse
+    private function createPlanSelectionRedirect(): RedirectResponse
     {
-        $checkoutUrl = $this->paymentIntegration->checkout(
-            $subscription,
-            Options::new()->withEmail($user->getEmail())->withSkipTrial(true),
-        );
-
-        return new RedirectResponse($checkoutUrl);
+        return new RedirectResponse($this->urlGenerator->generate('saas_subscription_plans'));
     }
 }

--- a/src/SaasBundle/EventSubscriber/RequestListener.php
+++ b/src/SaasBundle/EventSubscriber/RequestListener.php
@@ -16,6 +16,7 @@ use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -37,6 +38,8 @@ final readonly class RequestListener implements EventSubscriberInterface
         '_view_invoice_external',
         'billing_index',
         'saas_subscription_checkout',
+        'saas_subscription_plans',
+        'saas_subscription_choose',
         'saas_payment_success',
 
         // Debug routes
@@ -53,6 +56,7 @@ final readonly class RequestListener implements EventSubscriberInterface
         private CompanySelector $companySelector,
         private CompanyRepository $companyRepository,
         private SubscriptionProviderInterface $subscriptionManager,
+        private PlanRepositoryInterface $planRepository,
         private Environment $twig,
         private Security $security,
         private UrlGeneratorInterface $urlGenerator,
@@ -84,6 +88,7 @@ final readonly class RequestListener implements EventSubscriberInterface
                     new Response(
                         $this->twig->render('@SolidInvoiceSaas/subscription/pending.html.twig', [
                             'subscription' => $subscription,
+                            'plans' => $this->planRepository->findAllOrdered(),
                         ]),
                     )
                 );

--- a/src/SaasBundle/Plan/DefaultPlanProvider.php
+++ b/src/SaasBundle/Plan/DefaultPlanProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Plan;
+
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+
+final readonly class DefaultPlanProvider
+{
+    public function __construct(
+        private PlanRepositoryInterface $planRepository,
+    ) {
+    }
+
+    public function get(): ?Plan
+    {
+        return $this->planRepository->findDefault();
+    }
+}

--- a/src/SaasBundle/Resources/config/routing.php
+++ b/src/SaasBundle/Resources/config/routing.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
+use SolidInvoice\SaasBundle\Action\SelectPlanAction;
 use SolidInvoice\SaasBundle\Controller\BillingController;
 use SolidInvoice\SaasBundle\Controller\PaymentSuccess;
 use SolidInvoice\SaasBundle\Controller\SubscribeController;
@@ -25,4 +27,12 @@ return static function (RoutingConfigurator $routingConfigurator): void {
 
     $routingConfigurator->add('saas_subscription_checkout', '/subscription/activate')
         ->controller(SubscribeController::class);
+
+    $routingConfigurator->add('saas_subscription_plans', '/subscription/plans')
+        ->controller(SelectPlanAction::class)
+        ->methods(['GET']);
+
+    $routingConfigurator->add('saas_subscription_choose', '/subscription/plans/choose')
+        ->controller(ChoosePlanAction::class)
+        ->methods(['POST']);
 };

--- a/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
@@ -1,0 +1,163 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #
+ # Renders the plan picker grid. Expects:
+ #   - plans: list<Plan>
+ #}
+
+{% import _self as macros %}
+
+{# Free plan rendered separately below the main grid. #}
+{% set freePlan = null %}
+{% set paidPlans = [] %}
+{% for plan in plans %}
+    {% if plan.isFree() %}
+        {% set freePlan = plan %}
+    {% else %}
+        {% set paidPlans = paidPlans|merge([plan]) %}
+    {% endif %}
+{% endfor %}
+
+{# Highlight the second-to-last paid plan as recommended (e.g. middle of 3, third of 4). #}
+{% set recommendedIndex = paidPlans|length >= 2 ? paidPlans|length - 2 : -1 %}
+
+<div class="row row-cards row-deck g-4 justify-content-center">
+    {% for plan in paidPlans %}
+        {% set isRecommended = loop.index0 == recommendedIndex %}
+        <div class="col-md-6 col-lg-4 d-flex">
+            <div class="card flex-fill plan-card {{ isRecommended ? 'plan-card-recommended border-primary' : '' }}">
+                {% if isRecommended %}
+                    <div class="plan-card-banner">
+                        {{ ux_icon('tabler:star-filled', {width: 14, height: 14, class: 'me-1'}) }}
+                        {{ 'Recommended'|trans }}
+                    </div>
+                {% endif %}
+                <div class="card-body d-flex flex-column text-start">
+                    <h2 class="card-title mb-3">{{ plan.name }}</h2>
+
+                    <div class="plan-card-price mb-3">
+                        <span class="display-5 fw-bold">{{ plan.price|formatCurrency('USD') }}</span>
+                        <span class="text-secondary">{{ '/month'|trans }}</span>
+                    </div>
+
+                    {% if plan.description is not empty %}
+                        <p class="text-secondary">{{ plan.description }}</p>
+                    {% endif %}
+
+                    {{ macros.feature_list(plan.features) }}
+
+                    <form method="post" action="{{ path('saas_subscription_choose') }}" class="mt-auto">
+                        <input type="hidden" name="plan" value="{{ plan.planId }}">
+                        <button type="submit" class="btn w-100 {{ isRecommended ? 'btn-primary' : 'btn-outline-primary' }}">
+                            {{ ux_icon('tabler:credit-card', {width: 18, height: 18}) }}
+                            {{ 'Choose plan'|trans }}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>
+
+{% if freePlan is not null %}
+    <div class="row justify-content-center mt-4">
+        <div class="col-md-11 d-flex">
+            <div class="card flex-fill plan-card-free">
+                <div class="card-body">
+                    <div class="d-flex flex-column flex-lg-row gap-4 align-items-lg-center">
+                        <div class="text-lg-start text-center plan-card-free-header">
+                            <div class="text-uppercase text-secondary small fw-semibold mb-1">
+                                {{ 'Just getting started?'|trans }}
+                            </div>
+                            <h3 class="h4 mb-1">{{ freePlan.name }}</h3>
+                            <div class="text-secondary small">
+                                {{ 'No credit card required'|trans }}
+                            </div>
+                        </div>
+
+                        <div class="flex-grow-1">
+                            {{ macros.feature_list_inline(freePlan.features) }}
+                        </div>
+
+                        <div class="plan-card-free-cta">
+                            <form method="post" action="{{ path('saas_subscription_choose') }}">
+                                <input type="hidden" name="plan" value="{{ freePlan.planId }}">
+                                <button type="submit" class="btn btn-outline-secondary">
+                                    {{ ux_icon('tabler:gift', {width: 18, height: 18}) }}
+                                    {{ 'Continue with Free'|trans }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}
+
+{% macro feature_list(features) %}
+    {% import _self as macros %}
+    {% if features|length > 0 %}
+        <ul class="list-unstyled mb-4 plan-card-features">
+            {% for feature in features %}
+                {% set isBool = feature.type.value == 'boolean' %}
+                {% set isEnabled = feature.value matches '/^(1|true)$/i' or feature.value is same as(true) %}
+                <li class="d-flex align-items-start gap-2 mb-2">
+                    {% if isBool and isEnabled %}
+                        {{ ux_icon('tabler:check', {width: 18, height: 18, class: 'text-success mt-1 flex-shrink-0'}) }}
+                    {% elseif isBool %}
+                        {{ ux_icon('tabler:x', {width: 18, height: 18, class: 'text-secondary mt-1 flex-shrink-0'}) }}
+                    {% else %}
+                        {{ ux_icon('tabler:check', {width: 18, height: 18, class: 'text-success mt-1 flex-shrink-0'}) }}
+                    {% endif %}
+                    <span>{{ macros.feature_label(feature, isBool, isEnabled) }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endmacro %}
+
+{% macro feature_list_inline(features) %}
+    {% import _self as macros %}
+    {% if features|length > 0 %}
+        <ul class="list-unstyled mb-0 plan-card-features-inline">
+            {% for feature in features %}
+                {% set isBool = feature.type.value == 'boolean' %}
+                {% set isEnabled = feature.value matches '/^(1|true)$/i' or feature.value is same as(true) %}
+                <li>
+                    {% if isBool and isEnabled %}
+                        {{ ux_icon('tabler:check', {width: 16, height: 16, class: 'text-success flex-shrink-0'}) }}
+                    {% elseif isBool %}
+                        {{ ux_icon('tabler:x', {width: 16, height: 16, class: 'text-secondary flex-shrink-0'}) }}
+                    {% else %}
+                        {{ ux_icon('tabler:check', {width: 16, height: 16, class: 'text-success flex-shrink-0'}) }}
+                    {% endif %}
+                    <span>{{ macros.feature_label(feature, isBool, isEnabled) }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endmacro %}
+
+{% macro feature_label(feature, isBool, isEnabled) %}
+    {% set label = feature.description ?: feature.featureKey %}
+    {% set value = feature.value %}
+    {% if isBool %}
+        {% if isEnabled %}
+            <strong>{{ label }}</strong>
+        {% else %}
+            <span class="text-secondary">{{ label }}</span>
+        {% endif %}
+    {% elseif value is iterable %}
+        <strong>{{ label }}:</strong> {{ value|join(', ') }}
+    {% elseif value == -1 %}
+        <strong>{{ 'Unlimited'|trans }} {{ label }}</strong>
+    {% else %}
+        <strong>{{ label }}:</strong> {{ value }}
+    {% endif %}
+{% endmacro %}

--- a/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
@@ -53,6 +53,7 @@
 
                     <form method="post" action="{{ path('saas_subscription_choose') }}" class="mt-auto">
                         <input type="hidden" name="plan" value="{{ plan.planId }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('choose_plan') }}">
                         <button type="submit" class="btn w-100 {{ isRecommended ? 'btn-primary' : 'btn-outline-primary' }}">
                             {{ ux_icon('tabler:credit-card', {width: 18, height: 18}) }}
                             {{ 'Choose plan'|trans }}
@@ -87,6 +88,7 @@
                         <div class="plan-card-free-cta">
                             <form method="post" action="{{ path('saas_subscription_choose') }}">
                                 <input type="hidden" name="plan" value="{{ freePlan.planId }}">
+                                <input type="hidden" name="_token" value="{{ csrf_token('choose_plan') }}">
                                 <button type="submit" class="btn btn-outline-secondary">
                                     {{ ux_icon('tabler:gift', {width: 18, height: 18}) }}
                                     {{ 'Continue with Free'|trans }}

--- a/src/SaasBundle/Resources/views/subscription/cancelled.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/cancelled.html.twig
@@ -60,7 +60,7 @@
 
             {# Primary CTA #}
             <div class="subscription-actions">
-                <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
+                <a href="{{ path('saas_subscription_plans') }}" class="btn btn-primary btn-lg">
                     {{ ux_icon('tabler:arrow-back-up', {width: 20, height: 20}) }} {{ 'Reactivate Subscription'|trans }}
                 </a>
                 <a href="https://solidinvoice.co/contact" class="btn btn-ghost" target="_blank" rel="external noreferrer noopener">

--- a/src/SaasBundle/Resources/views/subscription/pending.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/pending.html.twig
@@ -16,57 +16,36 @@
 {% block content %}
     {% set availableCompanies = app.user.companies|filter(v => v.id != company_id()) %}
 
-    <div class="subscription-page subscription-pending-page">
+    <div class="subscription-page subscription-pricing-page subscription-pending-page">
         <div class="subscription-container">
-            {# Hero Icon #}
+            {# Hero #}
             <div class="subscription-icon subscription-icon-info">
                 {{ ux_icon('tabler:rocket', {width: 32, height: 32}) }}
             </div>
 
-            {# Headline #}
             <h1 class="subscription-title">{{ 'Activate Your Subscription'|trans }}</h1>
             <p class="subscription-subtitle">
-                {% trans with {'%price%': subscription.plan.price|formatCurrency('USD')} %}
-                    Start using SolidInvoice by activating your subscription at %price%/month. Get access to all features and start managing your invoices today.
-                {% endtrans %}
+                {{ 'Pick a plan and start running your business with SolidInvoice in minutes.'|trans }}
             </p>
 
-            {# Benefits Reminder #}
-            <div class="subscription-benefits">
-                <h3>{{ 'Get started with these features:'|trans }}</h3>
-                <ul>
-                    <li>
-                        {{ ux_icon('tabler:check', {width: 20, height: 20}) }}
-                        {{ 'Unlimited invoices and quotes'|trans }}
-                    </li>
-                    <li>
-                        {{ ux_icon('tabler:check', {width: 20, height: 20}) }}
-                        {{ 'Professional payment processing'|trans }}
-                    </li>
-                    <li>
-                        {{ ux_icon('tabler:check', {width: 20, height: 20}) }}
-                        {{ 'Client and contact management'|trans }}
-                    </li>
-                    <li>
-                        {{ ux_icon('tabler:check', {width: 20, height: 20}) }}
-                        {{ 'Financial reports and insights'|trans }}
-                    </li>
-                    <li>
-                        {{ ux_icon('tabler:check', {width: 20, height: 20}) }}
-                        {{ 'Recurring invoices and subscriptions'|trans }}
-                    </li>
-                </ul>
-            </div>
+            {# Plan picker #}
+            {% if plans|default([])|length > 0 %}
+                <div class="mt-4 mb-2">
+                    {% include '@SolidInvoiceSaas/subscription/_plans_grid.html.twig' with { plans: plans } only %}
+                </div>
 
-            {# Primary CTA #}
-            <div class="subscription-actions">
-                <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
-                    {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }} {{ 'Activate Subscription'|trans }}
-                </a>
-                <a href="https://solidinvoice.co/contact" class="btn btn-ghost" target="_blank" rel="external noreferrer noopener">
-                    {{ ux_icon('tabler:help', {width: 18, height: 18}) }} {{ 'Contact Support'|trans }}
-                </a>
-            </div>
+                <p class="text-secondary small mt-3 mb-0">
+                    {{ ux_icon('tabler:lock', {width: 14, height: 14, class: 'me-1'}) }}
+                    {{ 'Secure checkout · Cancel anytime · No hidden fees'|trans }}
+                </p>
+            {% else %}
+                {# Fallback when no plans are configured — keep the original CTA so the user can still complete activation. #}
+                <div class="subscription-actions mt-4">
+                    <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
+                        {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }} {{ 'Activate Subscription'|trans }}
+                    </a>
+                </div>
+            {% endif %}
 
             {# Edge Case: Just Completed Payment #}
             <twig:Ui:Alert type="info" class="mt-4 text-start">
@@ -81,7 +60,7 @@
                 </div>
             </twig:Ui:Alert>
 
-            {# Info Alert for Multiple Companies #}
+            {# Multiple Companies #}
             {% if availableCompanies|length > 0 %}
                 <twig:Ui:Alert type="info" class="mt-3 text-start">
                     <div class="d-flex align-items-center gap-2">
@@ -95,6 +74,14 @@
                     </div>
                 </twig:Ui:Alert>
             {% endif %}
+
+            {# Help #}
+            <p class="text-secondary small mt-4 mb-0">
+                {{ 'Need a hand?'|trans }}
+                <a href="https://solidinvoice.co/contact" target="_blank" rel="external noreferrer noopener">
+                    {{ 'Contact support'|trans }}
+                </a>
+            </p>
         </div>
     </div>
 {% endblock content %}

--- a/src/SaasBundle/Resources/views/subscription/pricing.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/pricing.html.twig
@@ -1,0 +1,29 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends '@SolidInvoiceCore/Layout/default_no_nav.html.twig' %}
+
+{% block heading %}
+    {% include '@SolidInvoiceSaas/subscription/_header.html.twig' %}
+{% endblock heading %}
+
+{% block content %}
+    <div class="subscription-page subscription-pricing-page">
+        <div class="subscription-container">
+            <h1 class="subscription-title">{{ 'Choose your plan'|trans }}</h1>
+            <p class="subscription-subtitle">
+                {{ 'Pick the plan that fits your needs. You can change it later.'|trans }}
+            </p>
+
+            <div class="mt-4">
+                {% include '@SolidInvoiceSaas/subscription/_plans_grid.html.twig' with { plans: plans } only %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/src/SaasBundle/Resources/views/subscription/trial_expired.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/trial_expired.html.twig
@@ -87,7 +87,7 @@
 
             {# Primary CTA #}
             <div class="subscription-actions">
-                <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
+                <a href="{{ path('saas_subscription_plans') }}" class="btn btn-primary btn-lg">
                     {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }}
                     {% if coupon_code|default('') is not empty %}
                         {{ 'Activate & Save 20%'|trans }}

--- a/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
@@ -25,6 +25,7 @@ use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -296,6 +297,11 @@ final class RequestListenerTest extends KernelTestCase
         $companyRepository = self::getContainer()->get(CompanyRepository::class);
         $urlGenerator = self::getContainer()->get(UrlGeneratorInterface::class);
 
+        // Mock PlanRepository — the Plan entity isn't part of the default
+        // test kernel's Doctrine mapping, so we can't fetch a real one here.
+        $planRepository = M::mock(PlanRepositoryInterface::class);
+        $planRepository->shouldReceive('findAllOrdered')->andReturn([]);
+
         // Mock SubscriptionProviderInterface
         $subscriptionManager = M::mock(SubscriptionProviderInterface::class);
         if ($subscription !== null) {
@@ -340,6 +346,7 @@ final class RequestListenerTest extends KernelTestCase
             $companySelector,
             $companyRepository,
             $subscriptionManager,
+            $planRepository,
             $twig,
             $security,
             $urlGenerator,


### PR DESCRIPTION
## Summary

Adds multi-plan support for SaaS deployments. Users can now choose between
multiple plans on signup, after trial expiry, after a cancelled subscription,
or when spinning up an additional company. Single-plan deployments behave
exactly as before — the picker short-circuits to checkout when only one plan
is configured.

## What changed

**Plan selection flow**

- `SelectPlanAction` (`GET /subscription/plans`) — renders the picker; if
  only one plan exists it redirects straight to `saas_subscription_checkout`,
  preserving today's UX. Refuses to render for `ACTIVE` subscriptions
  (changing plans on an active subscription is out of scope for this iteration).
- `ChoosePlanAction` (`POST /subscription/plans/choose`) — validates the
  chosen plan, swaps it on the user's subscription via
  `SubscriptionManager::changePlan()`, then either activates free plans
  in-place or redirects to LemonSqueezy checkout for paid plans.
- `DefaultPlanProvider` — small wrapper around `PlanRepository::findDefault()`,
  used by `CompanyEventSubscriber` and `CreateCompany` so the host app no
  longer reaches into the repo directly for "the plan".
- `CompanyEventSubscriber.onResponse` now redirects existing-trial users to
  the plan picker (instead of silently checking them out on the default
  plan) when they create an additional company.

**Conversion-focused pending page**

- `pending.html.twig` now embeds the plan grid inline so the user can
  pick + activate without an extra navigation step. The standalone
  `pricing.html.twig` is kept for the trial-expired and cancelled flows,
  and both share a new `_plans_grid.html.twig` partial.
- Trial-expired and cancelled pages re-target their CTA to
  `saas_subscription_plans`.

**Plan grid UI**

- Paid plans render as a 3-up card grid; the second-to-last paid plan
  gets a full-width "Recommended" banner with a star icon and a primary
  CTA, while the others use an outline button.
- Free plans (when present) render as a slim secondary strip below the
  grid: dashed border, inline-flowing feature list (wraps horizontally
  rather than growing tall), and a "Continue with Free" CTA. Free plans
  bypass checkout entirely — the new
  `SubscriptionManager::activate()` flips the subscription to `ACTIVE`
  and the action redirects to the dashboard with a success flash.
- Features render with type-aware UI: booleans become check/cross icons,
  integer `-1` renders as "Unlimited X", arrays as a comma-joined list.
  All disabled features still show on the free strip so the upgrade FOMO
  is preserved.

**Self-hosted deployments**

All changes are gated behind `saas_enabled` or live in the SaaS bundle.
`CreateCompany` now skips the default-plan price/trial lookup for
existing-trial users (they will pick later) and the create-company
template's "Payment Required" branch reflects this.

## Test plan

- [ ] Single-plan regression: with one Plan row in DB, sign up a new user
      → trial starts on that plan; let trial expire → "Activate Subscription"
      CTA loads `/subscription/plans` and **immediately** redirects to
      `/subscription/activate` (LemonSqueezy). No new UI surfaced.
- [ ] Default plan on signup: with two plans, mark plan B as `default = true`
      → new signup creates subscription on plan B with plan B's trial duration.
- [ ] Multi-plan picker: with 3+ plans, expire a trial → pricing grid
      renders, second-to-last paid plan badged "Recommended". Pick a
      non-default plan → subscription's `plan_id` updates, redirected to
      LemonSqueezy with the chosen plan's `planId`.
- [ ] Cancelled subscription: same retarget; CTA hits the picker.
- [ ] Additional-company flow: existing-trial user creates a new company →
      lands on picker (not default-plan checkout). Pick → checkout.
- [ ] Free plan: configure a plan with `planId === '0'` and `price === 0`
      → renders as the slim strip below the grid; "Continue with Free"
      activates the subscription and lands on the dashboard with no
      checkout redirect.
- [ ] Active-subscription guard: hit `/subscription/plans` directly with
      an `ACTIVE` subscription → redirected to dashboard with flash.
- [ ] Static checks: `bin/ecs check`, `bin/phpstan analyse`,
      `bin/phpunit src/SaasBundle/Tests/` (88 tests pass).