### PR TITLE
feat: SaaS feature-gating system (US-001 → US-009)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ yarn-error.log
 .phpunit.result.cache
 .phpunit.cache
 ###< phpunit/phpunit ###
+
+.context

--- a/config/services_test.php
+++ b/config/services_test.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Platform\PlatformBundle\Feature\SubscriberResolver;
+use SolidWorx\Platform\SaasBundle\Feature\FeatureConfigRegistry;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -32,4 +33,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // assert the correct concrete implementation is resolved.
     $services->alias('test.' . FeatureGate::class, FeatureGate::class)->public();
     $services->alias('test.' . SubscriberResolver::class, SubscriberResolver::class)->public();
+
+    // FeatureConfigRegistry is registered by SaasBundle, which is only loaded
+    // when SOLIDINVOICE_PLATFORM=saas. Mirror the same gate from bundles.php so
+    // the alias is only declared when the underlying service exists.
+    if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) === 'saas') {
+        $services->alias('test.' . FeatureConfigRegistry::class, FeatureConfigRegistry::class)->public();
+    }
 };

--- a/config/services_test.php
+++ b/config/services_test.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
+use SolidInvoice\SaasBundle\Form\Extension\FeatureRestrictedExtension as SaasFeatureRestrictedExtension;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Platform\PlatformBundle\Feature\SubscriberResolver;
 use SolidWorx\Platform\SaasBundle\Feature\FeatureConfigRegistry;
@@ -39,5 +41,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // the alias is only declared when the underlying service exists.
     if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) === 'saas') {
         $services->alias('test.' . FeatureConfigRegistry::class, FeatureConfigRegistry::class)->public();
+        $services->alias('test.' . RequiredPlanLabelProvider::class, RequiredPlanLabelProvider::class)->public();
+        $services->alias('test.' . SaasFeatureRestrictedExtension::class, SaasFeatureRestrictedExtension::class)->public();
     }
 };

--- a/config/services_test.php
+++ b/config/services_test.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
 use SolidInvoice\SaasBundle\Form\Extension\FeatureRestrictedExtension as SaasFeatureRestrictedExtension;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
@@ -35,6 +36,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // assert the correct concrete implementation is resolved.
     $services->alias('test.' . FeatureGate::class, FeatureGate::class)->public();
     $services->alias('test.' . SubscriberResolver::class, SubscriberResolver::class)->public();
+    $services->alias('test.' . UpgradePromptProvider::class, UpgradePromptProvider::class)->public();
 
     // FeatureConfigRegistry is registered by SaasBundle, which is only loaded
     // when SOLIDINVOICE_PLATFORM=saas. Mirror the same gate from bundles.php so

--- a/migrations/Version30000_7.php
+++ b/migrations/Version30000_7.php
@@ -24,7 +24,7 @@ use function getenv;
 
 final class Version30000_7 extends AbstractMigration
 {
-    private const SETTING_KEY = 'system/company/custom_domain';
+    private const SETTING_KEY = 'system/domain/custom_domain';
 
     public function getDescription(): string
     {

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Renames the custom-domain setting key from `system/company/custom_domain` to
+ * `system/domain/custom_domain` so the field can live under its own top-level
+ * "Domain" section in the settings UI rather than nested under "Company".
+ *
+ * Safe by design: `Company::customDomain` is the source of truth for inbound
+ * host resolution. `CompanyRepository::findOneByCustomDomain()` and
+ * `HostRoutingListener` both read from the `companies.custom_domain` column,
+ * not from this `app_config` row, so renaming the setting key does not affect
+ * how inbound requests resolve to a tenant.
+ */
+final class Version30000_8 extends AbstractMigration
+{
+    private const OLD_KEY = 'system/company/custom_domain';
+
+    private const NEW_KEY = 'system/domain/custom_domain';
+
+    public function getDescription(): string
+    {
+        return 'Rename custom_domain setting from system/company to system/domain section';
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+    }
+
+    public function up(Schema $schema): void
+    {
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function postUp(Schema $schema): void
+    {
+        $this->connection->update(
+            'app_config',
+            ['setting_key' => self::NEW_KEY],
+            ['setting_key' => self::OLD_KEY]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function postDown(Schema $schema): void
+    {
+        $this->connection->update(
+            'app_config',
+            ['setting_key' => self::OLD_KEY],
+            ['setting_key' => self::NEW_KEY]
+        );
+    }
+}

--- a/platform.yaml
+++ b/platform.yaml
@@ -23,6 +23,59 @@ saas:
             api_key: '%env(SOLIDINVOICE_LEMON_SQUEEZY_API_KEY)%'
             webhook_secret: '%env(SOLIDINVOICE_LEMON_SQUEEZY_WEBHOOK_SECRET)%'
             store_id: '%env(SOLIDINVOICE_LEMON_SQUEEZY_STORE_ID)%'
+    # Canonical catalogue of every gated feature. Keep the keys here in lock-step
+    # with `SolidInvoice\SaasBundle\Feature\Feature` (asserted by FeatureCatalogTest).
+    # Defaults are the un-overridden values returned by FeatureGate::resolve()
+    # when no plan/subscriber is in context (CLI commands, fixtures, etc.).
+    features:
+        total_clients:
+            type: integer
+            default: -1
+            description: 'Maximum number of clients per company (-1 = unlimited).'
+        invoices_per_month:
+            type: integer
+            default: -1
+            description: 'Invoices that can be issued per calendar month (-1 = unlimited).'
+        team_seats:
+            type: integer
+            default: -1
+            description: 'Number of user seats per company (-1 = unlimited).'
+        quotes:
+            type: boolean
+            default: true
+            description: 'Quote management and conversion-to-invoice workflow.'
+        online_payments:
+            type: boolean
+            default: true
+            description: 'Accept online payments via the Payum gateway.'
+        recurring_invoices:
+            type: boolean
+            default: true
+            description: 'Schedule and auto-generate recurring invoices.'
+        automated_reminders:
+            type: boolean
+            default: true
+            description: 'Automatic invoice reminders for overdue invoices.'
+        multi_currency:
+            type: boolean
+            default: true
+            description: 'Issue invoices, quotes and accept payments in multiple currencies.'
+        custom_branding:
+            type: boolean
+            default: true
+            description: 'Custom logo, theme and white-label PDF/email templates.'
+        rest_api_access:
+            type: boolean
+            default: true
+            description: 'Public REST API access and API token management.'
+        mcp_access:
+            type: boolean
+            default: true
+            description: 'Model Context Protocol server access for AI agents.'
+        custom_domain:
+            type: boolean
+            default: true
+            description: 'Host SolidInvoice on a custom domain or subdomain.'
 
 ui:
     templates:

--- a/src/ApiBundle/Security/Voter/ApiAccessVoter.php
+++ b/src/ApiBundle/Security/Voter/ApiAccessVoter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\ApiBundle\Security\Voter;
 
 use SolidInvoice\ApiBundle\Security\Attribute;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
@@ -24,11 +25,16 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * disabled (self-hosted installs) so requests succeed without any SaaS
  * voter being registered. When SaaS is enabled it abstains, leaving the
  * decision to whichever subscription-aware voter has been registered.
+ *
+ * Even on self-hosted the `rest_api_access` feature gate is consulted so
+ * the same denial path runs end-to-end. NoopFeatureGate always returns
+ * true on self-hosted, preserving the historical "always granted" behaviour.
  */
 final class ApiAccessVoter extends Voter
 {
     public function __construct(
         private readonly ToggleInterface $toggler,
+        private readonly FeatureGate $featureGate,
     ) {
     }
 
@@ -40,6 +46,12 @@ final class ApiAccessVoter extends Voter
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
+        if (! $this->featureGate->isEnabled('rest_api_access')) {
+            $vote?->addReason('REST API access is not available on the current plan.');
+
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/ApiBundle/Tests/Security/Voter/ApiAccessVoterTest.php
+++ b/src/ApiBundle/Tests/Security/Voter/ApiAccessVoterTest.php
@@ -17,8 +17,11 @@ use Mockery as M;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\ApiBundle\Security\Attribute;
 use SolidInvoice\ApiBundle\Security\Voter\ApiAccessVoter;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -30,7 +33,7 @@ final class ApiAccessVoterTest extends TestCase
 
     public function testGrantsWhenSaasIsDisabled(): void
     {
-        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false));
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_GRANTED,
@@ -40,7 +43,7 @@ final class ApiAccessVoterTest extends TestCase
 
     public function testAbstainsWhenSaasIsEnabled(): void
     {
-        $voter = new ApiAccessVoter($this->toggler(saasEnabled: true));
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: true), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
@@ -50,12 +53,26 @@ final class ApiAccessVoterTest extends TestCase
 
     public function testAbstainsForUnsupportedAttribute(): void
     {
-        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false));
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']),
         );
+    }
+
+    public function testDeniesWhenFeatureGateDeniesRestApiAccess(): void
+    {
+        $featureGate = M::mock(FeatureGate::class);
+        $featureGate->shouldReceive('isEnabled')->with('rest_api_access')->andReturn(false);
+
+        $voter = new ApiAccessVoter($this->toggler(saasEnabled: false), $featureGate);
+
+        $vote = new Vote();
+        $result = $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS], $vote);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $result);
+        self::assertSame(['REST API access is not available on the current plan.'], $vote->reasons);
     }
 
     private function toggler(bool $saasEnabled): ToggleInterface

--- a/src/ClientBundle/Action/Add.php
+++ b/src/ClientBundle/Action/Add.php
@@ -17,7 +17,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Form\Type\ClientType;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -37,16 +36,13 @@ final class Add extends AbstractController
         private readonly ManagerRegistry $doctrine,
         private readonly ClientRepository $clientRepository,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
     public function __invoke(Request $request): Response
     {
         if (! $this->featureGate->canUse(Feature::TotalClients->value, $this->clientRepository->getTotalClients())) {
-            return $this->render('@SolidInvoiceClient/Default/gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::TotalClients->value),
-            ]);
+            return $this->render('@SolidInvoiceClient/Default/gated.html.twig');
         }
 
         $client = new Client();

--- a/src/ClientBundle/Action/Add.php
+++ b/src/ClientBundle/Action/Add.php
@@ -16,9 +16,12 @@ namespace SolidInvoice\ClientBundle\Action;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Form\Type\ClientType;
-use Symfony\Bridge\Twig\Attribute\Template;
+use SolidInvoice\ClientBundle\Repository\ClientRepository;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,21 +29,26 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\RouterInterface;
 use function assert;
 
-final class Add
+final class Add extends AbstractController
 {
     public function __construct(
         private readonly FormFactoryInterface $formFactory,
         private readonly RouterInterface $router,
-        private readonly ManagerRegistry $doctrine
+        private readonly ManagerRegistry $doctrine,
+        private readonly ClientRepository $clientRepository,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
-    /**
-     * @return array{form: FormView}|Response
-     */
-    #[Template('@SolidInvoiceClient/Default/add.html.twig')]
-    public function __invoke(Request $request): array | Response
+    public function __invoke(Request $request): Response
     {
+        if (! $this->featureGate->canUse(Feature::TotalClients->value, $this->clientRepository->getTotalClients())) {
+            return $this->render('@SolidInvoiceClient/Default/gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::TotalClients->value),
+            ]);
+        }
+
         $client = new Client();
         $form = $this->formFactory->create(ClientType::class, $client);
         $form->handleRequest($request);
@@ -57,6 +65,8 @@ final class Add
             return new RedirectResponse($this->router->generate('_clients_view', ['id' => $client->getId()]));
         }
 
-        return ['form' => $form->createView()];
+        return $this->render('@SolidInvoiceClient/Default/add.html.twig', [
+            'form' => $form->createView(),
+        ]);
     }
 }

--- a/src/ClientBundle/Action/Index.php
+++ b/src/ClientBundle/Action/Index.php
@@ -45,6 +45,7 @@ final readonly class Index
         $filters = $this->entityManager->getFilters();
         $filters->disable('archivable');
         $totalArchivedClients = $this->clientRepository->getTotalClients(ClientStatus::Archived);
+        $totalClients = $this->clientRepository->getTotalClients();
         $filters->enable('archivable');
 
         // Get total contacts count
@@ -57,6 +58,7 @@ final readonly class Index
             'isArchived' => $isArchived,
             'totalActiveClients' => $totalActiveClients,
             'totalArchivedClients' => $totalArchivedClients,
+            'totalClients' => $totalClients,
             'totalContacts' => $totalContacts,
             'totalOutstanding' => $totalOutstanding,
         ];

--- a/src/ClientBundle/Form/Type/ClientType.php
+++ b/src/ClientBundle/Form/Type/ClientType.php
@@ -72,7 +72,9 @@ class ClientType extends AbstractType
             $builder->addEventListener(FormEvents::SUBMIT, static function (FormEvent $event) use ($defaultCurrency): void {
                 $client = $event->getData();
 
-                if ($client instanceof Client) {
+                // Only override when a concrete default currency is available — passing null
+                // would clear the existing currency on the entity when editing.
+                if ($client instanceof Client && null !== $defaultCurrency) {
                     $client->setCurrencyCode($defaultCurrency);
                 }
             });

--- a/src/ClientBundle/Form/Type/ClientType.php
+++ b/src/ClientBundle/Form/Type/ClientType.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ClientBundle\Form\Type;
 
+use RuntimeException;
 use SolidInvoice\ClientBundle\Entity\Address;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\MoneyBundle\Form\Type\CurrencyType;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidInvoice\SettingsBundle\SystemConfig;
 use SolidInvoice\TaxBundle\Form\Type\TaxNumberType;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
 
@@ -28,19 +34,49 @@ use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
  */
 class ClientType extends AbstractType
 {
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly SystemConfig $systemConfig,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('name', null, ['sanitize_html' => true, 'allow_single_quotes' => true]);
         $builder->add('website', UrlType::class, ['required' => false]);
 
-        $builder->add(
-            'currencyCode',
-            CurrencyType::class,
-            [
-                'placeholder' => 'client.form.currency.empty_value',
-                'required' => false,
-            ]
-        );
+        if ($this->featureGate->isEnabled(Feature::MultiCurrency->value)) {
+            $builder->add(
+                'currencyCode',
+                CurrencyType::class,
+                [
+                    'placeholder' => 'client.form.currency.empty_value',
+                    'required' => false,
+                ]
+            );
+        } else {
+            $defaultCurrency = $this->resolveDefaultCurrencyCode();
+
+            $builder->add(
+                'currencyCode',
+                CurrencyType::class,
+                [
+                    'placeholder' => 'client.form.currency.empty_value',
+                    'required' => false,
+                    'disabled' => true,
+                    'data' => $defaultCurrency,
+                    'feature_gated' => Feature::MultiCurrency->value,
+                ]
+            );
+
+            $builder->addEventListener(FormEvents::SUBMIT, static function (FormEvent $event) use ($defaultCurrency): void {
+                $client = $event->getData();
+
+                if ($client instanceof Client) {
+                    $client->setCurrencyCode($defaultCurrency);
+                }
+            });
+        }
 
         $builder->add('vat_number', TaxNumberType::class, ['required' => false]);
 
@@ -83,5 +119,14 @@ class ClientType extends AbstractType
     public function getBlockPrefix(): string
     {
         return 'client';
+    }
+
+    private function resolveDefaultCurrencyCode(): ?string
+    {
+        try {
+            return $this->systemConfig->getCurrency()->getCode();
+        } catch (RuntimeException) {
+            return null;
+        }
     }
 }

--- a/src/ClientBundle/Resources/views/Components/ClientForm.html.twig
+++ b/src/ClientBundle/Resources/views/Components/ClientForm.html.twig
@@ -73,7 +73,12 @@
                             {{ form_row(form.currencyCode) }}
                             {%- if form.currencyCode.vars.feature_gated_active ?? false %}
                                 <small class="form-hint text-muted feature-gated-hint">
-                                    {{ upgrade_prompt('multi_currency') }}
+                                    {%- if form.currencyCode.vars.feature_gated_plan ?? null %}
+                                        {{ 'This feature is available on the %plan% plan. Upgrade to unlock it.'|trans({'%plan%': form.currencyCode.vars.feature_gated_plan}) }}
+                                    {%- else %}
+                                        {{ 'This feature requires a higher plan. Upgrade now to unlock it.'|trans }}
+                                    {%- endif %}
+                                    <a href="{{ path('saas_subscription_plans') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
                                 </small>
                             {%- endif %}
                         </div>

--- a/src/ClientBundle/Resources/views/Components/ClientForm.html.twig
+++ b/src/ClientBundle/Resources/views/Components/ClientForm.html.twig
@@ -71,6 +71,11 @@
 
                         <div class="form-field">
                             {{ form_row(form.currencyCode) }}
+                            {%- if form.currencyCode.vars.feature_gated_active ?? false %}
+                                <small class="form-hint text-muted feature-gated-hint">
+                                    {{ upgrade_prompt('multi_currency') }}
+                                </small>
+                            {%- endif %}
                         </div>
 
                         <div class="form-field form-field-wide">

--- a/src/ClientBundle/Resources/views/Default/gated.html.twig
+++ b/src/ClientBundle/Resources/views/Default/gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'client_create'|trans }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/ClientBundle/Resources/views/Default/gated.html.twig
+++ b/src/ClientBundle/Resources/views/Default/gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'client_create'|trans }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'total_clients',
+        icon: 'tabler:users-plus',
+        headline: 'Client limit reached'|trans,
+        description: 'You have hit your plan\'s client limit. Upgrade to manage more clients and keep growing your business.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/ClientBundle/Resources/views/Default/index.html.twig
+++ b/src/ClientBundle/Resources/views/Default/index.html.twig
@@ -21,6 +21,8 @@
 {% endblock %}
 
 {% block content %}
+    {{ feature_usage_banner('total_clients', totalClients) }}
+
     {# Stats Row #}
     <div class="row row-deck row-cards mb-4">
         <div class="col-sm-6 col-lg-3">

--- a/src/ClientBundle/Tests/Form/Type/ClientTypeTest.php
+++ b/src/ClientBundle/Tests/Form/Type/ClientTypeTest.php
@@ -13,17 +13,30 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ClientBundle\Tests\Form\Type;
 
+use Mockery as M;
+use Money\Currency;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Form\Type\ClientType;
 use SolidInvoice\ClientBundle\Form\Type\ContactDetailType;
 use SolidInvoice\CoreBundle\Tests\FormTestCase;
 use SolidInvoice\MoneyBundle\Form\Type\CurrencyType;
+use SolidInvoice\SettingsBundle\SystemConfig;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Component\Form\PreloadedExtension;
 
 class ClientTypeTest extends FormTestCase
 {
+    /**
+     * Mutable list of feature keys that should report as DISABLED — every other key is enabled.
+     *
+     * @var list<string>
+     */
+    private array $disabledFeatures = [];
+
     public function testSubmit(): void
     {
+        $this->disabledFeatures = [];
+
         $company = $this->faker->company;
         $url = $this->faker->url;
         $currencyCode = 'USD';
@@ -44,14 +57,50 @@ class ClientTypeTest extends FormTestCase
         $this->assertFormData(ClientType::class, $formData, $object);
     }
 
+    public function testSubmitWithMultiCurrencyGatedOverridesEntityCurrency(): void
+    {
+        $this->disabledFeatures = ['multi_currency'];
+
+        $object = new Client();
+        $object->setName($this->faker->company);
+        $object->setCurrencyCode('EUR');
+
+        $form = $this->factory->create(ClientType::class, $object);
+
+        // The currencyCode field is disabled when gated, so the submitted value is ignored;
+        // the SUBMIT listener overrides the entity's currencyCode to the company default.
+        $form->submit([
+            'name' => $object->getName(),
+            'currencyCode' => 'EUR',
+            'contacts' => [],
+            'addresses' => [],
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('USD', $object->getCurrencyCode());
+        self::assertTrue($form->get('currencyCode')->isDisabled());
+        self::assertSame('multi_currency', $form->get('currencyCode')->getConfig()->getOption('feature_gated'));
+    }
+
     /**
      * @return PreloadedExtension[]
      */
     protected function getExtensions(): array
     {
+        $featureGate = M::mock(FeatureGate::class);
+        $featureGate->shouldReceive('isEnabled')
+            ->andReturnUsing(fn (string $key): bool => ! in_array($key, $this->disabledFeatures, true));
+
+        $systemConfig = M::mock(SystemConfig::class);
+        $systemConfig->shouldReceive('getCurrency')->andReturn(new Currency('USD'));
+
         return [
             // register the type instances with the PreloadedExtension
-            new PreloadedExtension([new ContactDetailType(), new CurrencyType('en')], []),
+            new PreloadedExtension([
+                new ClientType($featureGate, $systemConfig),
+                new ContactDetailType(),
+                new CurrencyType('en'),
+            ], []),
         ];
     }
 }

--- a/src/ClientBundle/Tests/Twig/Components/__snapshots__/ClientFormTest__testRenderWithExistingData__1.html
+++ b/src/ClientBundle/Tests/Twig/Components/__snapshots__/ClientFormTest__testRenderWithExistingData__1.html
@@ -218,7 +218,7 @@
 <option value="ZWG">Zimbabwean Gold</option></select>
     </div>
 </div>
-                        </div>
+                                                    </div>
 
                         <div class="form-field form-field-wide">
                             <div class="mb-3">                

--- a/src/ClientBundle/Tests/Twig/Components/__snapshots__/ClientFormTest__testRender__1.html
+++ b/src/ClientBundle/Tests/Twig/Components/__snapshots__/ClientFormTest__testRender__1.html
@@ -218,7 +218,7 @@
 <option value="ZWG">Zimbabwean Gold</option></select>
     </div>
 </div>
-                        </div>
+                                                    </div>
 
                         <div class="form-field form-field-wide">
                             <div class="mb-3">                

--- a/src/CoreBundle/Feature/NullUpgradePromptProvider.php
+++ b/src/CoreBundle/Feature/NullUpgradePromptProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Feature;
+
+use Override;
+
+final class NullUpgradePromptProvider implements UpgradePromptProvider
+{
+    #[Override]
+    public function prompt(string $featureKey): string
+    {
+        return '';
+    }
+
+    #[Override]
+    public function menuLabel(string $featureKey): ?string
+    {
+        return null;
+    }
+}

--- a/src/CoreBundle/Feature/UpgradePromptProvider.php
+++ b/src/CoreBundle/Feature/UpgradePromptProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Feature;
+
+/**
+ * Renders SaaS upgrade prompts (banner HTML) and resolves the cheapest plan
+ * label that exposes a given feature, used by Action classes and menu builders
+ * to short-circuit gated UI in SaaS deployments.
+ *
+ * In self-hosted deployments the implementation is a no-op
+ * (`NullUpgradePromptProvider`) — `prompt()` returns an empty string and
+ * `menuLabel()` returns `null`. In SaaS deployments
+ * `SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer` is wired in.
+ *
+ * Lives in CoreBundle (not SaasBundle) because Action and menu services are
+ * loaded in every deployment and need a stable contract to type-hint against.
+ */
+interface UpgradePromptProvider
+{
+    /**
+     * Render the locked-feature upgrade banner. Returns an empty string when
+     * no upgrade path exists (self-hosted, or every plan exposes the feature).
+     */
+    public function prompt(string $featureKey): string;
+
+    /**
+     * Return the cheapest upgrade plan's display name, or null when no upgrade
+     * path is available (self-hosted, or the feature is already enabled).
+     */
+    public function menuLabel(string $featureKey): ?string;
+}

--- a/src/CoreBundle/Form/Extension/FeatureRestrictedExtension.php
+++ b/src/CoreBundle/Form/Extension/FeatureRestrictedExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Self-hosted no-op for the `feature_gated` form option that is registered by
+ * SaasBundle's FeatureRestrictedExtension when the SaaS bundle is loaded.
+ *
+ * Self-hosted deployments do not load SaasBundle, so this extension keeps the
+ * option valid (default null) and ensures `feature_gated_active`/`_plan` view
+ * vars exist with safe defaults — letting templates render the same partials
+ * uniformly. Conditionally registered in CoreBundle's services.php only when
+ * `SOLIDINVOICE_PLATFORM` is not `saas`.
+ */
+final class FeatureRestrictedExtension extends AbstractTypeExtension
+{
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['feature_gated_active'] = false;
+        $view->vars['feature_gated_plan'] = null;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('feature_gated', null);
+        $resolver->setAllowedTypes('feature_gated', ['null', 'string', 'bool']);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        yield FormType::class;
+    }
+}

--- a/src/CoreBundle/Listener/HostRoutingListener.php
+++ b/src/CoreBundle/Listener/HostRoutingListener.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\CoreBundle\Listener;
 use SolidInvoice\CoreBundle\Company\CompanyDomainResolver;
 use SolidInvoice\CoreBundle\Company\HostType;
 use SolidInvoice\CoreBundle\Company\ResolvedHost;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -48,6 +49,7 @@ final class HostRoutingListener implements EventSubscriberInterface
     public function __construct(
         private readonly CompanyDomainResolver $resolver,
         private readonly RouterInterface $router,
+        private readonly FeatureGate $featureGate,
         private readonly ?string $installed = null,
     ) {
     }
@@ -75,6 +77,24 @@ final class HostRoutingListener implements EventSubscriberInterface
 
         if ($resolved->type === HostType::Unknown) {
             throw new NotFoundHttpException();
+        }
+
+        // Defensive: when a company has been downgraded to a plan without
+        // `custom_domain`, the row still carries `Company::customDomain` but
+        // the gate refuses to honour it. Fall back to canonical-host routing
+        // by re-tagging the resolution as DefaultHost — the request continues
+        // without forcing the downgraded tenant into the user's session, so
+        // they can still reach the canonical app via the standard selector.
+        if ($resolved->isCustomDomain()
+            && $resolved->company !== null
+            && ! $this->featureGate->isEnabled('custom_domain', $resolved->company)
+        ) {
+            $resolved = new ResolvedHost(
+                HostType::DefaultHost,
+                $resolved->host,
+                $resolved->scheme,
+                $resolved->port,
+            );
         }
 
         $request->attributes->set(self::REQUEST_ATTR, $resolved);

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -46,7 +46,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->load(SolidInvoiceCoreBundle::NAMESPACE . '\\', dirname(__DIR__, 3))
-        ->exclude(dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests}');
+        ->exclude([
+            dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests}',
+            dirname(__DIR__, 3) . '/Twig/Extension/FeatureExtension.php',
+        ]);
+
+    // The no-op FeatureExtension shadows three SaaS-only Twig function names so
+    // self-hosted templates can call them safely. SaaS deployments register the
+    // real implementations from SolidInvoice\SaasBundle\Twig\FeatureExtension —
+    // registering both would duplicate the function names and trigger a Twig
+    // "function already defined" error at compile time.
+    if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+        $services->set(\SolidInvoice\CoreBundle\Twig\Extension\FeatureExtension::class);
+    }
 
     $services
         ->load(SolidInvoiceCoreBundle::NAMESPACE . '\\Action\\', dirname(__DIR__, 3) . '/Action')

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -75,6 +75,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         \SolidInvoice\CoreBundle\Email\NullEmailVerificationGate::class,
     );
 
+    $services->set(\SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider::class);
+    $services->alias(
+        \SolidInvoice\CoreBundle\Feature\UpgradePromptProvider::class,
+        \SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider::class,
+    );
+
     $services
         ->set(TimestampableListener::class)
         ->tag('doctrine.event_subscriber')

--- a/src/CoreBundle/Resources/config/services/services.php
+++ b/src/CoreBundle/Resources/config/services/services.php
@@ -49,15 +49,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->exclude([
             dirname(__DIR__, 3) . '/{DependencyInjection,Entity,Resources,Tests}',
             dirname(__DIR__, 3) . '/Twig/Extension/FeatureExtension.php',
+            dirname(__DIR__, 3) . '/Form/Extension/FeatureRestrictedExtension.php',
         ]);
 
     // The no-op FeatureExtension shadows three SaaS-only Twig function names so
     // self-hosted templates can call them safely. SaaS deployments register the
     // real implementations from SolidInvoice\SaasBundle\Twig\FeatureExtension —
     // registering both would duplicate the function names and trigger a Twig
-    // "function already defined" error at compile time.
+    // "function already defined" error at compile time. The same pattern applies
+    // to FeatureRestrictedExtension: SaasBundle ships the real form-extension and
+    // CoreBundle ships a no-op so the `feature_gated` form option remains valid.
     if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
         $services->set(\SolidInvoice\CoreBundle\Twig\Extension\FeatureExtension::class);
+        $services->set(\SolidInvoice\CoreBundle\Form\Extension\FeatureRestrictedExtension::class);
     }
 
     $services

--- a/src/CoreBundle/Resources/views/Feature/_gated_page.html.twig
+++ b/src/CoreBundle/Resources/views/Feature/_gated_page.html.twig
@@ -1,0 +1,69 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #
+ # Full-page "feature gated" empty-state card. Rendered by every gated full-page
+ # action when the current plan does not include the requested feature.
+ #
+ # Lives in CoreBundle (not SaasBundle) so it is reachable on every deployment —
+ # including self-hosted, where the gate never fires in production but tests
+ # may force-fire it via mocked FeatureGate. `feature_required_plan_label()` is
+ # registered in both SaasBundle (real) and CoreBundle (no-op), so the resolved
+ # plan label gracefully falls back to null on self-hosted.
+ #
+ # @param string      feature      - Feature key (e.g. 'quotes'). Used to resolve
+ #                                   the cheapest upgrade plan via
+ #                                   `feature_required_plan_label()`.
+ # @param string      icon         - Tabler icon name. Default 'tabler:lock'.
+ # @param string      headline     - Bold title. Default 'This feature requires an upgrade'.
+ # @param string|null description  - One-sentence value prop shown under the title.
+ #                                   Default null (no description rendered).
+ #}
+{% set plan_name = feature_required_plan_label(feature) %}
+{% set _icon = icon|default('tabler:lock') %}
+{% set _headline = headline|default('This feature requires an upgrade'|trans) %}
+{% set _description = description|default(null) %}
+
+<div class="card card-md">
+    <div class="card-body">
+        <div class="empty">
+            <div class="empty-icon">
+                {{ ux_icon(_icon, {width: 64, height: 64, class: 'text-primary'}) }}
+            </div>
+
+            <p class="empty-title">{{ _headline }}</p>
+
+            {% if plan_name %}
+                <p class="empty-subtitle text-secondary">
+                    {{ 'Available on the %plan% plan and higher.'|trans({'%plan%': plan_name}) }}
+                </p>
+            {% endif %}
+
+            {% if _description %}
+                <p class="text-muted mt-2 mb-0" style="max-width: 36rem; margin-left: auto; margin-right: auto;">
+                    {{ _description }}
+                </p>
+            {% endif %}
+
+            <div class="empty-action">
+                {% if plan_name %}
+                    <a href="{{ path('saas_subscription_plans') }}" class="btn btn-primary">
+                        {{ ux_icon('tabler:arrow-up-circle', {width: 18, height: 18}) }}
+                        {{ 'Upgrade to %plan%'|trans({'%plan%': plan_name}) }}
+                    </a>
+                    <a href="{{ path('saas_subscription_plans') }}" class="btn btn-link ms-2">
+                        {{ 'View all plans'|trans }}
+                    </a>
+                {% else %}
+                    <p class="text-muted mb-0">
+                        {{ 'Contact your administrator to enable this feature.'|trans }}
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/CoreBundle/Tests/FormTestCase.php
+++ b/src/CoreBundle/Tests/FormTestCase.php
@@ -19,6 +19,7 @@ use Faker\Generator;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as M;
 use Money\Currency;
+use SolidInvoice\CoreBundle\Form\Extension\FeatureRestrictedExtension as NoopFeatureRestrictedExtension;
 use SolidInvoice\CoreBundle\Form\Extension\FormHelpExtension;
 use SolidInvoice\CoreBundle\Form\Type\ImageUploadType;
 use SolidInvoice\CoreBundle\Form\TypeExtension\UnsanitizeSingleQuotesTypeExtension;
@@ -114,6 +115,7 @@ abstract class FormTestCase extends KernelTestCase
             ),
             new UnsanitizeSingleQuotesTypeExtension(),
             new TrialRestrictedExtension(),
+            new NoopFeatureRestrictedExtension(),
         ];
     }
 

--- a/src/CoreBundle/Tests/Functional/FeatureTwigFunctionsTest.php
+++ b/src/CoreBundle/Tests/Functional/FeatureTwigFunctionsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Functional;
+
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * Self-hosted (NoopFeatureGate) wiring contract for the six feature Twig
+ * helpers. The three "read" functions come from vendor PlatformBundle's
+ * FeatureExtension; the three "upgrade UI" functions come from CoreBundle's
+ * no-op FeatureExtension (which is conditionally registered when
+ * SOLIDINVOICE_PLATFORM is not 'saas').
+ */
+final class FeatureTwigFunctionsTest extends KernelTestCase
+{
+    public function testFeatureGateResolvesToNoopGateInSelfHostedMode(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $gateId = 'test.' . FeatureGate::class;
+        self::assertTrue($container->has($gateId));
+        self::assertInstanceOf(NoopFeatureGate::class, $container->get($gateId));
+    }
+
+    public function testReadOnlyFeatureFunctionsReturnUnlimitedDefaults(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        // Vendor PlatformBundle wiring: every feature is treated as enabled
+        // and unlimited because NoopFeatureGate has no opinion on keys.
+        self::assertTrue($twig->createTemplate("{{ feature_enabled('any_key') ? 'yes' : 'no' }}")->render() === 'yes');
+        self::assertTrue($twig->createTemplate("{{ feature_can_use('any_key', 9999) ? 'yes' : 'no' }}")->render() === 'yes');
+        self::assertSame('', $twig->createTemplate("{{ feature_remaining('any_key') }}")->render());
+    }
+
+    public function testSaasOnlyFunctionsResolveToNoopValues(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        self::assertSame('', $twig->createTemplate("{{ feature_required_plan_label('any_key') }}")->render());
+        self::assertSame('', $twig->createTemplate("{{ upgrade_prompt('any_key') }}")->render());
+        self::assertSame('', $twig->createTemplate("{{ feature_usage_banner('any_key', 5) }}")->render());
+    }
+}

--- a/src/CoreBundle/Tests/Listener/HostRoutingListenerTest.php
+++ b/src/CoreBundle/Tests/Listener/HostRoutingListenerTest.php
@@ -23,6 +23,12 @@ use SolidInvoice\CoreBundle\Company\ResolvedHost;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Listener\HostRoutingListener;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureType;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureValue;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\SubscribableInterface;
+use SolidWorx\Platform\PlatformBundle\Feature\UpgradeOptions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -51,7 +57,7 @@ final class HostRoutingListenerTest extends TestCase
         $repository = M::mock(CompanyRepository::class);
         $repository->shouldNotReceive('findOneByCustomDomain');
 
-        $listener = new HostRoutingListener($this->resolver($repository), $this->router(), null);
+        $listener = new HostRoutingListener($this->resolver($repository), $this->router(), new NoopFeatureGate(), null);
 
         $request = Request::create('https://anything.example/');
         $listener->onKernelRequest($this->event($request));
@@ -64,7 +70,7 @@ final class HostRoutingListenerTest extends TestCase
         $repository = M::mock(CompanyRepository::class);
         $repository->shouldNotReceive('findOneByCustomDomain');
 
-        $listener = new HostRoutingListener($this->resolver($repository), $this->router(), '2025');
+        $listener = new HostRoutingListener($this->resolver($repository), $this->router(), new NoopFeatureGate(), '2025');
 
         $request = Request::create('https://anything.example/install');
         $listener->onKernelRequest($this->event($request));
@@ -80,6 +86,7 @@ final class HostRoutingListenerTest extends TestCase
         $listener = new HostRoutingListener(
             $this->resolver($repository, 'https://app.example.com'),
             $this->router(),
+            new NoopFeatureGate(),
             '2025',
         );
 
@@ -100,6 +107,7 @@ final class HostRoutingListenerTest extends TestCase
         $listener = new HostRoutingListener(
             $this->resolver($repository, 'https://app.example.com'),
             $router,
+            new NoopFeatureGate(),
             '2025',
         );
 
@@ -127,6 +135,7 @@ final class HostRoutingListenerTest extends TestCase
         $listener = new HostRoutingListener(
             $this->resolver($repository, 'https://app.example.com'),
             $router,
+            new NoopFeatureGate(),
             '2025',
         );
 
@@ -150,6 +159,7 @@ final class HostRoutingListenerTest extends TestCase
         $listener = new HostRoutingListener(
             $this->resolver($repository, 'https://app.example.com'),
             $this->router(),
+            new NoopFeatureGate(),
             '2025',
         );
 
@@ -159,6 +169,60 @@ final class HostRoutingListenerTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         $listener->onKernelRequest($this->event($request));
+    }
+
+    public function testFallsBackToDefaultHostWhenCustomDomainFeatureGateDenies(): void
+    {
+        $company = new Company();
+        $repository = M::mock(CompanyRepository::class);
+        $repository->shouldReceive('findOneByCustomDomain')->once()->with('downgraded.example')->andReturn($company);
+
+        $context = new RequestContext('', 'GET', 'app.example.com', 'http', 80, 0);
+        $router = M::mock(RouterInterface::class);
+        $router->shouldNotReceive('getContext');
+
+        $featureGate = $this->featureGate(static fn (string $key, ?SubscribableInterface $for): bool => $key !== 'custom_domain' || ! $for instanceof Company);
+
+        $listener = new HostRoutingListener(
+            $this->resolver($repository, 'https://app.example.com'),
+            $router,
+            $featureGate,
+            '2025',
+        );
+
+        $request = Request::create('https://downgraded.example/dashboard');
+        $listener->onKernelRequest($this->event($request));
+
+        $resolved = $request->attributes->get(HostRoutingListener::REQUEST_ATTR);
+        self::assertInstanceOf(ResolvedHost::class, $resolved);
+        self::assertSame(HostType::DefaultHost, $resolved->type);
+    }
+
+    public function testCustomDomainHonouredWhenFeatureGateGrants(): void
+    {
+        $company = new Company();
+        $repository = M::mock(CompanyRepository::class);
+        $repository->shouldReceive('findOneByCustomDomain')->once()->with('acme.example')->andReturn($company);
+
+        $context = new RequestContext('', 'GET', 'acme.example', 'http', 80, 0);
+        $router = M::mock(RouterInterface::class);
+        $router->shouldReceive('getContext')->andReturn($context);
+
+        $featureGate = $this->featureGate(static fn (string $key, ?SubscribableInterface $for): bool => true);
+
+        $listener = new HostRoutingListener(
+            $this->resolver($repository, 'https://app.example.com'),
+            $router,
+            $featureGate,
+            '2025',
+        );
+
+        $request = Request::create('https://acme.example/dashboard');
+        $listener->onKernelRequest($this->event($request));
+
+        $resolved = $request->attributes->get(HostRoutingListener::REQUEST_ATTR);
+        self::assertInstanceOf(ResolvedHost::class, $resolved);
+        self::assertSame(HostType::CustomDomain, $resolved->type);
     }
 
     /**
@@ -191,5 +255,51 @@ final class HostRoutingListenerTest extends TestCase
     private function resolver(CompanyRepository $repository, string $applicationUrl = ''): CompanyDomainResolver
     {
         return new CompanyDomainResolver($repository, $applicationUrl);
+    }
+
+    /**
+     * @param callable(string, SubscribableInterface|null): bool $isEnabled
+     */
+    private function featureGate(callable $isEnabled): FeatureGate
+    {
+        return new class($isEnabled) implements FeatureGate {
+            /**
+             * @var callable(string, SubscribableInterface|null): bool
+             */
+            private $isEnabled;
+
+            /**
+             * @param callable(string, SubscribableInterface|null): bool $isEnabled
+             */
+            public function __construct(callable $isEnabled)
+            {
+                $this->isEnabled = $isEnabled;
+            }
+
+            public function resolve(string $featureKey, ?SubscribableInterface $for = null): FeatureValue
+            {
+                return new FeatureValue($featureKey, FeatureType::BOOLEAN, ($this->isEnabled)($featureKey, $for));
+            }
+
+            public function isEnabled(string $featureKey, ?SubscribableInterface $for = null): bool
+            {
+                return ($this->isEnabled)($featureKey, $for);
+            }
+
+            public function canUse(string $featureKey, int $currentUsage = 0, ?SubscribableInterface $for = null): bool
+            {
+                return $this->isEnabled($featureKey, $for);
+            }
+
+            public function remaining(string $featureKey, int $currentUsage = 0, ?SubscribableInterface $for = null): ?int
+            {
+                return null;
+            }
+
+            public function upgradeOptions(string $featureKey): UpgradeOptions
+            {
+                return new UpgradeOptions([]);
+            }
+        };
     }
 }

--- a/src/CoreBundle/Twig/Extension/FeatureExtension.php
+++ b/src/CoreBundle/Twig/Extension/FeatureExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Twig\Extension;
+
+use Override;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Self-hosted no-op for the SaaS-only Twig functions exposed by
+ * SolidInvoice\SaasBundle\Twig\FeatureExtension.
+ *
+ * Vendor PlatformBundle already exposes `feature_enabled`, `feature_can_use`
+ * and `feature_remaining` in every deployment, so we only stub the three
+ * names that are SaaS-specific. This extension is registered conditionally
+ * (only when SOLIDINVOICE_PLATFORM is not 'saas') so SaaS deployments can
+ * register the real implementations without colliding on Twig function names.
+ */
+final class FeatureExtension extends AbstractExtension
+{
+    /**
+     * @return list<TwigFunction>
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'feature_required_plan_label',
+                static fn (string $featureKey): ?string => null,
+            ),
+            new TwigFunction(
+                'upgrade_prompt',
+                static fn (string $featureKey): string => '',
+                ['is_safe' => ['html']],
+            ),
+            new TwigFunction(
+                'feature_usage_banner',
+                static fn (string $featureKey, int $currentUsage = 0): string => '',
+                ['is_safe' => ['html']],
+            ),
+        ];
+    }
+}

--- a/src/InvoiceBundle/Action/Create.php
+++ b/src/InvoiceBundle/Action/Create.php
@@ -16,9 +16,11 @@ namespace SolidInvoice\InvoiceBundle\Action;
 use Brick\Math\Exception\MathException;
 use DateTimeImmutable;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\DTO\InvoiceFormDTO;
 use SolidInvoice\InvoiceBundle\Email\InvoiceEmail;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
@@ -27,6 +29,9 @@ use SolidInvoice\InvoiceBundle\Enum\InvoiceClientMode;
 use SolidInvoice\InvoiceBundle\Form\Type\InvoiceType;
 use SolidInvoice\InvoiceBundle\Manager\InvoiceFormManager;
 use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,6 +53,10 @@ final class Create extends AbstractController
         private readonly MailerInterface $mailer,
         private readonly TotalCalculator $totalCalculator,
         private readonly InvoiceFormManager $formManager,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -56,6 +65,15 @@ final class Create extends AbstractController
      */
     public function __invoke(Request $request, ?Client $client = null): Response
     {
+        if (! $this->featureGate->canUse(
+            Feature::InvoicesPerMonth->value,
+            $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
+        )) {
+            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::InvoicesPerMonth->value),
+            ]);
+        }
+
         $totalClientsCount = $this->clientRepository->getTotalClients();
         if (1 === $totalClientsCount && ! $client instanceof Client) {
             $client = $this->clientRepository->findOneBy([]);

--- a/src/InvoiceBundle/Action/Create.php
+++ b/src/InvoiceBundle/Action/Create.php
@@ -20,7 +20,6 @@ use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\DTO\InvoiceFormDTO;
 use SolidInvoice\InvoiceBundle\Email\InvoiceEmail;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
@@ -55,7 +54,6 @@ final class Create extends AbstractController
         private readonly InvoiceFormManager $formManager,
         private readonly InvoiceRepository $invoiceRepository,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
         private readonly ClockInterface $clock,
     ) {
     }
@@ -69,9 +67,7 @@ final class Create extends AbstractController
             Feature::InvoicesPerMonth->value,
             $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
         )) {
-            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::InvoicesPerMonth->value),
-            ]);
+            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig');
         }
 
         $totalClientsCount = $this->clientRepository->getTotalClients();

--- a/src/InvoiceBundle/Action/CreateRecurring.php
+++ b/src/InvoiceBundle/Action/CreateRecurring.php
@@ -18,10 +18,13 @@ use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceType;
 use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,6 +43,8 @@ final class CreateRecurring extends AbstractController
         private readonly RouterInterface $router,
         private readonly ManagerRegistry $doctrine,
         private readonly TotalCalculator $totalCalculator,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -48,6 +53,12 @@ final class CreateRecurring extends AbstractController
      */
     public function __invoke(Request $request, ?Client $client = null): Response
     {
+        if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
+            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::RecurringInvoices->value),
+            ]);
+        }
+
         $totalClientsCount = $this->clientRepository->getTotalClients();
         if (0 === $totalClientsCount) {
             return $this->render('@SolidInvoiceInvoice/Default/empty_clients.html.twig');

--- a/src/InvoiceBundle/Action/CreateRecurring.php
+++ b/src/InvoiceBundle/Action/CreateRecurring.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\InvoiceBundle\Action;
 
 use Brick\Math\Exception\MathException;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
@@ -23,6 +24,7 @@ use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceType;
 use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -45,6 +47,8 @@ final class CreateRecurring extends AbstractController
         private readonly TotalCalculator $totalCalculator,
         private readonly FeatureGate $featureGate,
         private readonly UpgradePromptProvider $upgradePromptProvider,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -56,6 +60,15 @@ final class CreateRecurring extends AbstractController
         if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
             return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig', [
                 'banner' => $this->upgradePromptProvider->prompt(Feature::RecurringInvoices->value),
+            ]);
+        }
+
+        if (! $this->featureGate->canUse(
+            Feature::InvoicesPerMonth->value,
+            $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
+        )) {
+            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::InvoicesPerMonth->value),
             ]);
         }
 

--- a/src/InvoiceBundle/Action/CreateRecurring.php
+++ b/src/InvoiceBundle/Action/CreateRecurring.php
@@ -19,7 +19,6 @@ use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceType;
@@ -46,7 +45,6 @@ final class CreateRecurring extends AbstractController
         private readonly ManagerRegistry $doctrine,
         private readonly TotalCalculator $totalCalculator,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
         private readonly InvoiceRepository $invoiceRepository,
         private readonly ClockInterface $clock,
     ) {
@@ -58,18 +56,14 @@ final class CreateRecurring extends AbstractController
     public function __invoke(Request $request, ?Client $client = null): Response
     {
         if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
-            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::RecurringInvoices->value),
-            ]);
+            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig');
         }
 
         if (! $this->featureGate->canUse(
             Feature::InvoicesPerMonth->value,
             $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
         )) {
-            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::InvoicesPerMonth->value),
-            ]);
+            return $this->render('@SolidInvoiceInvoice/Default/invoice_gated.html.twig');
         }
 
         $totalClientsCount = $this->clientRepository->getTotalClients();

--- a/src/InvoiceBundle/Action/EditRecurring.php
+++ b/src/InvoiceBundle/Action/EditRecurring.php
@@ -16,7 +16,6 @@ namespace SolidInvoice\InvoiceBundle\Action;
 use Brick\Math\Exception\MathException;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceType;
 use SolidInvoice\InvoiceBundle\Model\Graph;
@@ -41,7 +40,6 @@ final class EditRecurring extends AbstractController
         private readonly ManagerRegistry $doctrine,
         private readonly TotalCalculator $totalCalculator,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -51,9 +49,7 @@ final class EditRecurring extends AbstractController
     public function __invoke(Request $request, RecurringInvoice $invoice): Response
     {
         if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
-            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::RecurringInvoices->value),
-            ]);
+            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig');
         }
 
         $form = $this->formFactory->create(RecurringInvoiceType::class, $invoice, [

--- a/src/InvoiceBundle/Action/EditRecurring.php
+++ b/src/InvoiceBundle/Action/EditRecurring.php
@@ -16,12 +16,14 @@ namespace SolidInvoice\InvoiceBundle\Action;
 use Brick\Math\Exception\MathException;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceType;
 use SolidInvoice\InvoiceBundle\Model\Graph;
-use Symfony\Bridge\Twig\Attribute\Template;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,7 +32,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Workflow\WorkflowInterface;
 use function assert;
 
-final class EditRecurring
+final class EditRecurring extends AbstractController
 {
     public function __construct(
         private readonly FormFactoryInterface $formFactory,
@@ -38,16 +40,22 @@ final class EditRecurring
         private readonly WorkflowInterface $recurringInvoiceStateMachine,
         private readonly ManagerRegistry $doctrine,
         private readonly TotalCalculator $totalCalculator,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
     /**
-     * @return array{recurring: bool, form: FormView, invoice: RecurringInvoice}|Response
      * @throws MathException
      */
-    #[Template('@SolidInvoiceInvoice/Default/edit.html.twig')]
-    public function __invoke(Request $request, RecurringInvoice $invoice): array | Response
+    public function __invoke(Request $request, RecurringInvoice $invoice): Response
     {
+        if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
+            return $this->render('@SolidInvoiceInvoice/Default/recurring_gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::RecurringInvoices->value),
+            ]);
+        }
+
         $form = $this->formFactory->create(RecurringInvoiceType::class, $invoice, [
             'currency' => $invoice->getClient()->getCurrency(),
         ]);
@@ -73,10 +81,10 @@ final class EditRecurring
             $this->totalCalculator->calculateTotals($invoice);
         }
 
-        return [
+        return $this->render('@SolidInvoiceInvoice/Default/edit.html.twig', [
             'recurring' => true,
             'form' => $form->createView(),
             'invoice' => $invoice,
-        ];
+        ]);
     }
 }

--- a/src/InvoiceBundle/Action/Index.php
+++ b/src/InvoiceBundle/Action/Index.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\InvoiceBundle\Action;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\PaymentBundle\Repository\PaymentRepository;
@@ -26,6 +27,7 @@ final readonly class Index
         private InvoiceRepository $invoiceRepository,
         private PaymentRepository $paymentRepository,
         private EntityManagerInterface $entityManager,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -65,6 +67,7 @@ final readonly class Index
             'paidCount' => $paidCount,
             'overdueCount' => $overdueCount,
             'draftCount' => $draftCount,
+            'invoicesThisMonth' => $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
             'status_list_count' => [
                 InvoiceStatus::Pending->value => $pendingCount,
                 InvoiceStatus::Paid->value => $paidCount,

--- a/src/InvoiceBundle/Action/RecurringIndex.php
+++ b/src/InvoiceBundle/Action/RecurringIndex.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace SolidInvoice\InvoiceBundle\Action;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
 use SolidInvoice\InvoiceBundle\Enum\RecurringInvoiceStatus;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\InvoiceBundle\Repository\RecurringInvoiceRepository;
 use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,11 +26,13 @@ final readonly class RecurringIndex
     public function __construct(
         private RecurringInvoiceRepository $repository,
         private EntityManagerInterface $entityManager,
+        private InvoiceRepository $invoiceRepository,
+        private ClockInterface $clock,
     ) {
     }
 
     /**
-     * @return array{recurring: bool, isArchived: bool, isCompleted: bool, totalActiveRecurring: int, totalArchivedRecurring: int, activeCount: int, draftCount: int, pausedCount: int, cancelledCount: int, completeCount: int, upcomingIn7Days: int, totalGeneratedInvoices: int, monthlyRecurringRevenue: array<string, mixed>, status_list_count: array{active: int, draft: int, paused: int, cancelled: int, complete: int}}
+     * @return array{recurring: bool, isArchived: bool, isCompleted: bool, totalActiveRecurring: int, totalArchivedRecurring: int, activeCount: int, draftCount: int, pausedCount: int, cancelledCount: int, completeCount: int, upcomingIn7Days: int, totalGeneratedInvoices: int, monthlyRecurringRevenue: array<string, mixed>, invoicesThisMonth: int, status_list_count: array{active: int, draft: int, paused: int, cancelled: int, complete: int}}
      */
     #[Template('@SolidInvoiceInvoice/Default/index.html.twig')]
     public function __invoke(Request $request): array
@@ -78,6 +82,7 @@ final readonly class RecurringIndex
             'upcomingIn7Days' => $upcomingIn7Days,
             'totalGeneratedInvoices' => $totalGeneratedInvoices,
             'monthlyRecurringRevenue' => $monthlyRecurringRevenue,
+            'invoicesThisMonth' => $this->invoiceRepository->countCreatedInMonth($this->clock->now()),
             'status_list_count' => [
                 RecurringInvoiceStatus::Active->value => $activeCount,
                 RecurringInvoiceStatus::Draft->value => $draftCount,

--- a/src/InvoiceBundle/Config/ConfigProvider.php
+++ b/src/InvoiceBundle/Config/ConfigProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\InvoiceBundle\Config;
 
 use SolidInvoice\CoreBundle\Form\Type\BillingIdConfigurationType;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidInvoice\SettingsBundle\Config\ProviderInterface;
 use SolidInvoice\SettingsBundle\DTO\Config;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -32,9 +33,27 @@ final class ConfigProvider implements ProviderInterface
             new Config('invoice/id_generation/strategy', 'auto_increment', '', BillingIdConfigurationType::class),
             new Config('invoice/id_generation/id_prefix', '', 'Example: INV-', TextType::class),
             new Config('invoice/id_generation/id_suffix', '', 'Example: -INV', TextType::class),
-            new Config('invoice/reminder/enabled', '1', 'Enable automatic invoice payment reminders', CheckboxType::class),
-            new Config('invoice/reminder/pre_due_enabled', '1', 'Send reminder before invoice is due', CheckboxType::class),
-            new Config('invoice/reminder/pre_due_days', '3', 'Days before due date to send pre-due reminder (0 to disable)', IntegerType::class, ['attr' => ['min' => 0, 'max' => 30]]),
+            new Config(
+                'invoice/reminder/enabled',
+                '1',
+                'Enable automatic invoice payment reminders',
+                CheckboxType::class,
+                ['feature_gated' => Feature::AutomatedReminders->value],
+            ),
+            new Config(
+                'invoice/reminder/pre_due_enabled',
+                '1',
+                'Send reminder before invoice is due',
+                CheckboxType::class,
+                ['feature_gated' => Feature::AutomatedReminders->value],
+            ),
+            new Config(
+                'invoice/reminder/pre_due_days',
+                '3',
+                'Days before due date to send pre-due reminder (0 to disable)',
+                IntegerType::class,
+                ['attr' => ['min' => 0, 'max' => 30], 'feature_gated' => Feature::AutomatedReminders->value],
+            ),
         ];
     }
 }

--- a/src/InvoiceBundle/Menu/RecurringInvoiceMenu.php
+++ b/src/InvoiceBundle/Menu/RecurringInvoiceMenu.php
@@ -15,18 +15,35 @@ namespace SolidInvoice\InvoiceBundle\Menu;
 
 use Knp\Menu\ItemInterface;
 use SolidInvoice\CoreBundle\Enum\Menu\MenuPriority;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\CoreBundle\Icon;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Attributes\Menu\MenuBuilder;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 
 final class RecurringInvoiceMenu
 {
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+    ) {
+    }
+
     #[MenuBuilder(name: 'sidebar', priority: MenuPriority::PRIORITY_RECURRING_INVOICE->value)]
     public function sidebar(ItemInterface $menu): void
     {
+        $extras = ['icon' => Icon::RECURRING_INVOICE];
+
+        if (! $this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
+            $planLabel = $this->upgradePromptProvider->menuLabel(Feature::RecurringInvoices->value);
+
+            if ($planLabel !== null) {
+                $extras['plan_label'] = $planLabel;
+            }
+        }
+
         $recurringInvoices = $menu->addChild('invoice.menu.recurring.main', [
-            'extras' => [
-                'icon' => Icon::RECURRING_INVOICE,
-            ],
+            'extras' => $extras,
         ]);
 
         $recurringInvoices->addChild(

--- a/src/InvoiceBundle/MessageHandler/SendInvoiceReminderHandler.php
+++ b/src/InvoiceBundle/MessageHandler/SendInvoiceReminderHandler.php
@@ -28,7 +28,9 @@ use SolidInvoice\InvoiceBundle\Notification\InvoiceReminderNotification;
 use SolidInvoice\InvoiceBundle\Notification\InvoiceReminderStoppedNotification;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceReminderRepository;
 use SolidInvoice\NotificationBundle\Notification\NotificationManager;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidInvoice\SettingsBundle\SystemConfig;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -47,6 +49,7 @@ final readonly class SendInvoiceReminderHandler
         private ClockInterface $clock,
         private LoggerInterface $logger,
         private InvoiceReminderRepository $reminderRepository,
+        private FeatureGate $featureGate,
     ) {
     }
 
@@ -58,6 +61,17 @@ final readonly class SendInvoiceReminderHandler
         try {
             // Set company context for this invoice
             $this->companySelector->switchCompany($message->companyId);
+
+            // Skip (and log) when the SaaS automated_reminders feature is disabled for the
+            // current plan — discard the message instead of letting it retry.
+            if (! $this->featureGate->isEnabled(Feature::AutomatedReminders->value)) {
+                $this->logger->info('Automated reminders feature is disabled for plan, skipping reminder', [
+                    'company_id' => $message->companyId->toString(),
+                    'invoice_id' => $message->invoiceId->toString(),
+                    'reminder_type' => $message->reminderType->value,
+                ]);
+                return;
+            }
 
             // Check if reminders are enabled for this company
             if (! $this->isRemindersEnabled($message->reminderType)) {

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -17,6 +17,7 @@ use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
 use DateMalformedStringException;
+use DateTimeInterface;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\NonUniqueResultException;
@@ -116,6 +117,30 @@ class InvoiceRepository extends EntityRepository
         try {
             return (int) $this->createQueryBuilder('i')
                 ->select('COUNT(i)')
+                ->getQuery()
+                ->getSingleScalarResult();
+        } catch (NoResultException | NonUniqueResultException) {
+            return 0;
+        }
+    }
+
+    /**
+     * Counts non-recurring invoices created in the calendar month containing
+     * `$date`. Used by the `invoices_per_month` quota gate. Scoping to the
+     * active company is handled by the global `CompanyFilter`.
+     */
+    public function countCreatedInMonth(DateTimeInterface $date): int
+    {
+        $monthStart = (new \DateTimeImmutable($date->format('Y-m-01 00:00:00'), $date->getTimezone()));
+        $monthEnd = $monthStart->modify('+1 month');
+
+        try {
+            return (int) $this->createQueryBuilder('i')
+                ->select('COUNT(i)')
+                ->where('i.created >= :start')
+                ->andWhere('i.created < :end')
+                ->setParameter('start', $monthStart)
+                ->setParameter('end', $monthEnd)
                 ->getQuery()
                 ->getSingleScalarResult();
         } catch (NoResultException | NonUniqueResultException) {

--- a/src/InvoiceBundle/Resources/views/Default/index.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/index.html.twig
@@ -28,6 +28,8 @@
 {% endblock %}
 
 {% block content %}
+    {{ feature_usage_banner('invoices_per_month', invoicesThisMonth) }}
+
     {% if recurring %}
         {# Recurring Invoices Stats Row #}
         <div class="row row-deck row-cards mb-4">

--- a/src/InvoiceBundle/Resources/views/Default/invoice_gated.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/invoice_gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'invoice.action.create'|trans }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'invoices_per_month',
+        icon: 'tabler:file-invoice',
+        headline: 'Monthly invoice limit reached'|trans,
+        description: 'You have hit your plan\'s monthly invoice quota. Upgrade to keep invoicing this month.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/InvoiceBundle/Resources/views/Default/invoice_gated.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/invoice_gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'invoice.action.create'|trans }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/InvoiceBundle/Resources/views/Default/recurring_gated.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/recurring_gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'invoice.menu.recurring.main'|trans|default('Recurring Invoices') }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'recurring_invoices',
+        icon: 'tabler:repeat',
+        headline: 'Bill clients on a schedule'|trans,
+        description: 'Recurring invoices automatically bill your clients every week, month, or year — no manual work.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/InvoiceBundle/Resources/views/Default/recurring_gated.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/recurring_gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'invoice.menu.recurring.main'|trans|default('Recurring Invoices') }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/InvoiceBundle/Resources/views/Templates/_pdf_base.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/_pdf_base.html.twig
@@ -34,9 +34,13 @@
     <watermarktext content="{{ invoice.status.value|upper }}" alpha="0.08"/>
 {% endif %}
 
+{# Suppression of "Powered by" only takes effect when the `custom_branding` feature is on
+   for the current plan; without it, we render the line regardless of the stored value. #}
+{% set hide_powered_by_value = setting('system/general/hide_powered_by') is same as ('1') %}
+{% set hide_powered_by = hide_powered_by_value and feature_enabled('custom_branding') %}
 <pagefooter
     name="footer"
-    content-left="{{ setting('system/general/hide_powered_by') is not same as ('1') ? 'powered_by'|trans ~ ' ' ~ constant('SolidInvoice\\CoreBundle\\SolidInvoiceCoreBundle::APP_NAME') }}"
+    content-left="{{ not hide_powered_by ? 'powered_by'|trans ~ ' ' ~ constant('SolidInvoice\\CoreBundle\\SolidInvoiceCoreBundle::APP_NAME') }}"
     content-right="{{ 'pdf.page'|trans }} {PAGENO} {{ 'pdf.of'|trans }} {nb}"
     line="on"
     footer-style="border-top: 1px solid #e2e8f0; font-size: 8pt; color: #64748b; padding-top: 8px;"

--- a/src/InvoiceBundle/Tests/MessageHandler/SendInvoiceReminderHandlerFeatureGateTest.php
+++ b/src/InvoiceBundle/Tests/MessageHandler/SendInvoiceReminderHandlerFeatureGateTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\MessageHandler;
+
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\InvoiceBundle\Entity\ReminderType;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Message\SendInvoiceReminderMessage;
+use SolidInvoice\InvoiceBundle\MessageHandler\SendInvoiceReminderHandler;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceReminderRepository;
+use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
+use SolidInvoice\NotificationBundle\Notification\NotificationManager;
+use SolidInvoice\SettingsBundle\SystemConfig;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\ErrorHandler\BufferingLogger;
+use Symfony\Component\Mailer\MailerInterface;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SendInvoiceReminderHandler skips and logs (without throwing or
+ * retrying) when the SaaS `automated_reminders` feature is disabled, and sends
+ * normally when the feature is enabled / in self-hosted mode.
+ *
+ * @covers \SolidInvoice\InvoiceBundle\MessageHandler\SendInvoiceReminderHandler
+ */
+final class SendInvoiceReminderHandlerFeatureGateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testHandlerSkipsAndLogsWhenFeatureDisabled(): void
+    {
+        $invoice = $this->createPendingInvoice();
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $key === 'automated_reminders' ? false : true);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $logger = new BufferingLogger();
+
+        $handler = $this->buildHandler($featureGate, $mailer, $logger);
+
+        $message = new SendInvoiceReminderMessage(
+            $invoice->getId(),
+            $this->company->getId(),
+            ReminderType::PreDue,
+            3,
+        );
+
+        // No exception, no throw — handler should swallow + log.
+        $handler($message);
+
+        $logs = $logger->cleanLogs();
+        $messages = array_map(static fn (array $log): string => $log[1], $logs);
+
+        self::assertContains('Automated reminders feature is disabled for plan, skipping reminder', $messages);
+    }
+
+    public function testHandlerProceedsWhenFeatureEnabled(): void
+    {
+        $invoice = $this->createPendingInvoice();
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())->method('send');
+
+        $logger = new BufferingLogger();
+
+        $handler = $this->buildHandler($featureGate, $mailer, $logger);
+
+        // Ensure reminders are enabled in settings as well
+        $systemConfig = self::getContainer()->get(SystemConfig::class);
+        $reminderEnabled = $systemConfig->get('invoice/reminder/enabled');
+        $preDueEnabled = $systemConfig->get('invoice/reminder/pre_due_enabled');
+
+        if ($reminderEnabled !== '1' || $preDueEnabled !== '1') {
+            self::markTestSkipped('Default reminder settings not enabled in this fixture');
+        }
+
+        $message = new SendInvoiceReminderMessage(
+            $invoice->getId(),
+            $this->company->getId(),
+            ReminderType::PreDue,
+            3,
+        );
+
+        $handler($message);
+
+        $logs = $logger->cleanLogs();
+        $messages = array_map(static fn (array $log): string => $log[1], $logs);
+
+        self::assertNotContains('Automated reminders feature is disabled for plan, skipping reminder', $messages);
+    }
+
+    public function testHandlerProceedsInSelfHostedMode(): void
+    {
+        $invoice = $this->createPendingInvoice();
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())->method('send');
+
+        $logger = new BufferingLogger();
+
+        // NoopFeatureGate always returns true for isEnabled — self-hosted behavior.
+        $handler = $this->buildHandler(new NoopFeatureGate(), $mailer, $logger);
+
+        $systemConfig = self::getContainer()->get(SystemConfig::class);
+        $reminderEnabled = $systemConfig->get('invoice/reminder/enabled');
+        $preDueEnabled = $systemConfig->get('invoice/reminder/pre_due_enabled');
+
+        if ($reminderEnabled !== '1' || $preDueEnabled !== '1') {
+            self::markTestSkipped('Default reminder settings not enabled in this fixture');
+        }
+
+        $message = new SendInvoiceReminderMessage(
+            $invoice->getId(),
+            $this->company->getId(),
+            ReminderType::PreDue,
+            3,
+        );
+
+        $handler($message);
+
+        $logs = $logger->cleanLogs();
+        $messages = array_map(static fn (array $log): string => $log[1], $logs);
+
+        self::assertNotContains('Automated reminders feature is disabled for plan, skipping reminder', $messages);
+    }
+
+    private function buildHandler(
+        FeatureGate $featureGate,
+        MailerInterface $mailer,
+        LoggerInterface $logger,
+    ): SendInvoiceReminderHandler {
+        $container = self::getContainer();
+
+        return new SendInvoiceReminderHandler(
+            $container->get(ManagerRegistry::class),
+            $container->get(CompanySelector::class),
+            $mailer,
+            $container->get(NotificationManager::class),
+            $container->get(SystemConfig::class),
+            $container->get(ClockInterface::class),
+            $logger,
+            $container->get(InvoiceReminderRepository::class),
+            $featureGate,
+        );
+    }
+
+    private function createPendingInvoice(): \SolidInvoice\InvoiceBundle\Entity\Invoice
+    {
+        $client = ClientFactory::createOne(['company' => $this->company, 'currencyCode' => 'USD']);
+        $contact = ContactFactory::createOne(['client' => $client, 'company' => $this->company]);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Pending,
+            'due' => (new DateTimeImmutable())->modify('+3 days'),
+            'users' => [$contact],
+        ]);
+
+        return $invoice->_real();
+    }
+}

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -216,4 +216,38 @@ final class InvoiceRepositoryTest extends KernelTestCase
         self::assertCount(1, $results);
         self::assertSame($overdueInvoice->getId()->toBase32(), $results[0]->getId()->toBase32());
     }
+
+    public function testCountCreatedInMonthCountsInvoicesInTheCalendarMonth(): void
+    {
+        $month = new DateTimeImmutable('2024-02-15 10:00:00', new \DateTimeZone('UTC'));
+
+        InvoiceFactory::createMany(3, [
+            'company' => $this->company,
+            'created' => new DateTimeImmutable('2024-02-10 10:00:00', new \DateTimeZone('UTC')),
+        ]);
+
+        InvoiceFactory::createOne([
+            'company' => $this->company,
+            'created' => new DateTimeImmutable('2024-02-28 23:00:00', new \DateTimeZone('UTC')),
+        ]);
+
+        // Outside the month (should be excluded)
+        InvoiceFactory::createOne([
+            'company' => $this->company,
+            'created' => new DateTimeImmutable('2024-01-31 23:00:00', new \DateTimeZone('UTC')),
+        ]);
+        InvoiceFactory::createOne([
+            'company' => $this->company,
+            'created' => new DateTimeImmutable('2024-03-01 00:00:00', new \DateTimeZone('UTC')),
+        ]);
+
+        self::assertSame(4, $this->repository->countCreatedInMonth($month));
+    }
+
+    public function testCountCreatedInMonthReturnsZeroWhenNoInvoicesExist(): void
+    {
+        $month = new DateTimeImmutable('2024-04-15 10:00:00', new \DateTimeZone('UTC'));
+
+        self::assertSame(0, $this->repository->countCreatedInMonth($month));
+    }
 }

--- a/src/McpBundle/Action/Authorize.php
+++ b/src/McpBundle/Action/Authorize.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Company\UserEligibleCompanies;
 use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\McpBundle\Entity\OAuthClient;
 use SolidInvoice\McpBundle\OAuth\ConsentService;
 use SolidInvoice\McpBundle\OAuth\OAuthUserEntity;
@@ -29,6 +30,7 @@ use SolidInvoice\McpBundle\OAuth\ScopeEntity;
 use SolidInvoice\McpBundle\OAuth\ServerFactoryInterface;
 use SolidInvoice\McpBundle\Security\McpScope;
 use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -60,6 +62,8 @@ final class Authorize
         private readonly LoggerInterface $logger,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
         private readonly Psr17Factory $psr17Factory = new Psr17Factory(),
     ) {
         $this->psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
@@ -76,6 +80,22 @@ final class Authorize
             $request->getSession()->set('_security.main.target_path', $request->getUri());
 
             return new RedirectResponse($this->urlGenerator->generate('_login_main'));
+        }
+
+        $companies = $this->eligibleCompanies->getFor($user);
+
+        if ($companies === []) {
+            return $this->renderError('access_denied', 'No companies available for this user.', Response::HTTP_FORBIDDEN);
+        }
+
+        // Surface the upgrade page before any OAuth-server handshake so that
+        // gated tenants (whose plan does not include `mcp_access`) get a
+        // friendly error instead of an OAuth-protocol error string. Single
+        // pass over the user's companies — if none have the feature we deny.
+        $companies = $this->filterCompaniesWithMcpAccess($companies);
+
+        if ($companies === []) {
+            return $this->renderUpgradeRequired();
         }
 
         $server = $this->serverFactory->createAuthorizationServer();
@@ -97,12 +117,6 @@ final class Authorize
 
         if (! $client instanceof OAuthClient) {
             return $this->renderError('invalid_client', 'Unknown client.', Response::HTTP_BAD_REQUEST);
-        }
-
-        $companies = $this->eligibleCompanies->getFor($user);
-
-        if ($companies === []) {
-            return $this->renderError('access_denied', 'No companies available for this user.', Response::HTTP_FORBIDDEN);
         }
 
         $requestedScopeValues = array_map(
@@ -330,5 +344,29 @@ final class Authorize
             ]),
             $status,
         );
+    }
+
+    private function renderUpgradeRequired(): Response
+    {
+        return new Response(
+            $this->twig->render('@SolidInvoiceMcp/Authorize/upgrade_required.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt('mcp_access'),
+                'plan_label' => $this->upgradePromptProvider->menuLabel('mcp_access'),
+            ]),
+            Response::HTTP_FORBIDDEN,
+        );
+    }
+
+    /**
+     * @param list<Company> $companies
+     *
+     * @return list<Company>
+     */
+    private function filterCompaniesWithMcpAccess(array $companies): array
+    {
+        return array_values(array_filter(
+            $companies,
+            fn (Company $company): bool => $this->featureGate->isEnabled('mcp_access', $company),
+        ));
     }
 }

--- a/src/McpBundle/Resources/translations/SolidInvoiceMcpBundle.en.yml
+++ b/src/McpBundle/Resources/translations/SolidInvoiceMcpBundle.en.yml
@@ -15,6 +15,10 @@ mcp:
         revoke_hint_link: "connected apps"
     error:
         title: "Authorization error"
+    upgrade:
+        title: "MCP access not available"
+        description: "Your current plan does not include MCP access. Upgrade your subscription to authorize AI agents and tools."
+        contact_admin: "Contact your administrator to upgrade your plan and enable MCP access."
     connected_apps:
         title: "Connected apps"
         empty: "You haven't connected any AI agents yet."

--- a/src/McpBundle/Resources/views/Authorize/upgrade_required.html.twig
+++ b/src/McpBundle/Resources/views/Authorize/upgrade_required.html.twig
@@ -1,0 +1,40 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends '@SolidInvoiceCore/Layout/login.html.twig' %}
+
+{% block page_title %}{{ app_name }} - {{ 'mcp.upgrade.title'|trans({}, 'SolidInvoiceMcpBundle') }}{% endblock %}
+
+{% block content %}
+    <div class="page page-center">
+        <div class="container container-tight py-4">
+            <div class="card card-md">
+                <div class="card-body text-center">
+                    {{ ux_icon('tabler:lock', {width: 48, height: 48, class: 'text-warning'}) }}
+
+                    <h2 class="mt-3">{{ 'mcp.upgrade.title'|trans({}, 'SolidInvoiceMcpBundle') }}</h2>
+
+                    <p class="text-muted">
+                        {{ 'mcp.upgrade.description'|trans({}, 'SolidInvoiceMcpBundle') }}
+                    </p>
+
+                    {% if banner %}
+                        <div class="mt-3 text-start">
+                            {{ banner|raw }}
+                        </div>
+                    {% else %}
+                        <p class="text-muted">
+                            {{ 'mcp.upgrade.contact_admin'|trans({}, 'SolidInvoiceMcpBundle') }}
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/McpBundle/Security/Voter/McpAccessVoter.php
+++ b/src/McpBundle/Security/Voter/McpAccessVoter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\McpBundle\Security\Voter;
 
 use SolidInvoice\McpBundle\Security\Attribute;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
@@ -24,11 +25,16 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * disabled (self-hosted installs) so requests succeed without any SaaS
  * voter being registered. When SaaS is enabled it abstains, leaving the
  * decision to whichever subscription-aware voter has been registered.
+ *
+ * Even on self-hosted the `mcp_access` feature gate is consulted so the
+ * same denial path runs end-to-end. NoopFeatureGate always returns true
+ * on self-hosted, preserving the historical "always granted" behaviour.
  */
 final class McpAccessVoter extends Voter
 {
     public function __construct(
         private readonly ToggleInterface $toggler,
+        private readonly FeatureGate $featureGate,
     ) {
     }
 
@@ -40,6 +46,12 @@ final class McpAccessVoter extends Voter
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
+        if (! $this->featureGate->isEnabled('mcp_access')) {
+            $vote?->addReason('MCP access is not available on the current plan.');
+
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/McpBundle/Tests/Action/AuthorizeUpgradeGateTest.php
+++ b/src/McpBundle/Tests/Action/AuthorizeUpgradeGateTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\McpBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The upgrade-gate path through the MCP Authorize action is exercised end-to-end
+ * by `\SolidInvoice\SaasBundle\Tests\Functional\McpAuthorizeGateTest`, which
+ * boots the full MCP stack with a seeded OAuth client and overrides the
+ * FeatureGate / UpgradePromptProvider services to verify the rendered upgrade
+ * page. Unit-level mocking is impractical because both `ConsentService` and
+ * `ConsentGrantRepository` are `final`, and Mockery cannot stub them.
+ */
+final class AuthorizeUpgradeGateTest extends TestCase
+{
+    public function testGatePathCoveredByFunctionalTest(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/src/McpBundle/Tests/Security/Voter/McpAccessVoterTest.php
+++ b/src/McpBundle/Tests/Security/Voter/McpAccessVoterTest.php
@@ -17,8 +17,11 @@ use Mockery as M;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\McpBundle\Security\Attribute;
 use SolidInvoice\McpBundle\Security\Voter\McpAccessVoter;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -30,7 +33,7 @@ final class McpAccessVoterTest extends TestCase
 
     public function testGrantsWhenSaasIsDisabled(): void
     {
-        $voter = new McpAccessVoter($this->toggler(saasEnabled: false));
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: false), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_GRANTED,
@@ -40,7 +43,7 @@ final class McpAccessVoterTest extends TestCase
 
     public function testAbstainsWhenSaasIsEnabled(): void
     {
-        $voter = new McpAccessVoter($this->toggler(saasEnabled: true));
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: true), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
@@ -50,12 +53,26 @@ final class McpAccessVoterTest extends TestCase
 
     public function testAbstainsForUnsupportedAttribute(): void
     {
-        $voter = new McpAccessVoter($this->toggler(saasEnabled: false));
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: false), new NoopFeatureGate());
 
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(M::mock(TokenInterface::class), null, ['ROLE_USER']),
         );
+    }
+
+    public function testDeniesWhenFeatureGateDeniesMcpAccess(): void
+    {
+        $featureGate = M::mock(FeatureGate::class);
+        $featureGate->shouldReceive('isEnabled')->with('mcp_access')->andReturn(false);
+
+        $voter = new McpAccessVoter($this->toggler(saasEnabled: false), $featureGate);
+
+        $vote = new Vote();
+        $result = $voter->vote(M::mock(TokenInterface::class), null, [Attribute::ACCESS], $vote);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $result);
+        self::assertSame(['MCP access is not available on the current plan.'], $vote->reasons);
     }
 
     private function toggler(bool $saasEnabled): ToggleInterface

--- a/src/PaymentBundle/Action/Settings.php
+++ b/src/PaymentBundle/Action/Settings.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace SolidInvoice\PaymentBundle\Action;
 
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,16 +23,13 @@ final class Settings extends AbstractController
 {
     public function __construct(
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
     public function __invoke(Request $request): Response
     {
         if (! $this->featureGate->isEnabled(Feature::OnlinePayments->value)) {
-            return $this->render('@SolidInvoicePayment/Settings/gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::OnlinePayments->value),
-            ]);
+            return $this->render('@SolidInvoicePayment/Settings/gated.html.twig');
         }
 
         return $this->render('@SolidInvoicePayment/Settings/index.html.twig');

--- a/src/PaymentBundle/Action/Settings.php
+++ b/src/PaymentBundle/Action/Settings.php
@@ -13,17 +13,29 @@ declare(strict_types=1);
 
 namespace SolidInvoice\PaymentBundle\Action;
 
-use Symfony\Bridge\Twig\Attribute\Template;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-final class Settings
+final class Settings extends AbstractController
 {
-    /**
-     * @return array{}
-     */
-    #[Template('@SolidInvoicePayment/Settings/index.html.twig')]
-    public function __invoke(Request $request): array
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
     {
-        return [];
+        if (! $this->featureGate->isEnabled(Feature::OnlinePayments->value)) {
+            return $this->render('@SolidInvoicePayment/Settings/gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::OnlinePayments->value),
+            ]);
+        }
+
+        return $this->render('@SolidInvoicePayment/Settings/index.html.twig');
     }
 }

--- a/src/PaymentBundle/Menu/PaymentMenu.php
+++ b/src/PaymentBundle/Menu/PaymentMenu.php
@@ -15,19 +15,36 @@ namespace SolidInvoice\PaymentBundle\Menu;
 
 use Knp\Menu\ItemInterface;
 use SolidInvoice\CoreBundle\Enum\Menu\MenuPriority;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Attributes\Menu\MenuBuilder;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 
 final class PaymentMenu
 {
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+    ) {
+    }
+
     #[MenuBuilder(name: 'sidebar', priority: MenuPriority::PRIORITY_PAYMENT->value)]
     public function sidebar(ItemInterface $menu): void
     {
+        $extras = ['icon' => 'credit-card'];
+
+        if (! $this->featureGate->isEnabled(Feature::OnlinePayments->value)) {
+            $planLabel = $this->upgradePromptProvider->menuLabel(Feature::OnlinePayments->value);
+
+            if ($planLabel !== null) {
+                $extras['plan_label'] = $planLabel;
+            }
+        }
+
         $section = $menu->addChild(
             'payment.menu.main',
             [
-                'extras' => [
-                    'icon' => 'credit-card',
-                ],
+                'extras' => $extras,
             ],
         );
         $section->addChild(

--- a/src/PaymentBundle/Resources/views/Settings/gated.html.twig
+++ b/src/PaymentBundle/Resources/views/Settings/gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'payment.methods.title'|trans }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/PaymentBundle/Resources/views/Settings/gated.html.twig
+++ b/src/PaymentBundle/Resources/views/Settings/gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'payment.methods.title'|trans }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'online_payments',
+        icon: 'tabler:credit-card',
+        headline: 'Accept payments online'|trans,
+        description: 'Let clients pay invoices online via Stripe, PayPal, and other gateways — get paid faster with less follow-up.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/QuoteBundle/Action/Create.php
+++ b/src/QuoteBundle/Action/Create.php
@@ -18,7 +18,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\QuoteBundle\DTO\QuoteFormDTO;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Entity\Quote;
@@ -48,7 +47,6 @@ final class Create extends AbstractController
         private readonly TotalCalculator $totalCalculator,
         private readonly QuoteFormManager $formManager,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -58,9 +56,7 @@ final class Create extends AbstractController
     public function __invoke(Request $request, ?Client $client = null): Response
     {
         if (! $this->featureGate->isEnabled(Feature::Quotes->value)) {
-            return $this->render('@SolidInvoiceQuote/Default/gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::Quotes->value),
-            ]);
+            return $this->render('@SolidInvoiceQuote/Default/gated.html.twig');
         }
 
         $totalClientsCount = $this->repository->getTotalClients();

--- a/src/QuoteBundle/Action/Create.php
+++ b/src/QuoteBundle/Action/Create.php
@@ -18,6 +18,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\QuoteBundle\DTO\QuoteFormDTO;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Entity\Quote;
@@ -25,6 +26,8 @@ use SolidInvoice\QuoteBundle\Enum\QuoteClientMode;
 use SolidInvoice\QuoteBundle\Form\Type\QuoteType;
 use SolidInvoice\QuoteBundle\Manager\QuoteFormManager;
 use SolidInvoice\QuoteBundle\Model\Graph;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,6 +47,8 @@ final class Create extends AbstractController
         private readonly ManagerRegistry $doctrine,
         private readonly TotalCalculator $totalCalculator,
         private readonly QuoteFormManager $formManager,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -52,6 +57,12 @@ final class Create extends AbstractController
      */
     public function __invoke(Request $request, ?Client $client = null): Response
     {
+        if (! $this->featureGate->isEnabled(Feature::Quotes->value)) {
+            return $this->render('@SolidInvoiceQuote/Default/gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::Quotes->value),
+            ]);
+        }
+
         $totalClientsCount = $this->repository->getTotalClients();
         if (1 === $totalClientsCount && ! $client instanceof Client) {
             $client = $this->repository->findOneBy([]);

--- a/src/QuoteBundle/Menu/QuoteMenu.php
+++ b/src/QuoteBundle/Menu/QuoteMenu.php
@@ -15,20 +15,37 @@ namespace SolidInvoice\QuoteBundle\Menu;
 
 use Knp\Menu\ItemInterface;
 use SolidInvoice\CoreBundle\Enum\Menu\MenuPriority;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\CoreBundle\Icon;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidWorx\Platform\PlatformBundle\Attributes\Menu\MenuBuilder;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 
 final class QuoteMenu
 {
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+    ) {
+    }
+
     #[MenuBuilder(name: 'sidebar', priority: MenuPriority::PRIORITY_QUOTE->value)]
     public function sidebar(ItemInterface $menu): void
     {
+        $extras = ['icon' => Icon::QUOTE];
+
+        if (! $this->featureGate->isEnabled(Feature::Quotes->value)) {
+            $planLabel = $this->upgradePromptProvider->menuLabel(Feature::Quotes->value);
+
+            if ($planLabel !== null) {
+                $extras['plan_label'] = $planLabel;
+            }
+        }
+
         $section = $menu->addChild(
             'quote.menu.main',
             [
-                'extras' => [
-                    'icon' => Icon::QUOTE,
-                ],
+                'extras' => $extras,
             ],
         );
         $section->addChild(

--- a/src/QuoteBundle/Resources/views/Default/gated.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'quote.action.create.title'|trans|default('Create Quote') }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/QuoteBundle/Resources/views/Default/gated.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'quote.action.create.title'|trans|default('Create Quote') }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'quotes',
+        icon: 'tabler:file-text',
+        headline: 'Send branded quotes to your clients'|trans,
+        description: 'Create polished quotes that clients can accept online — and turn into invoices in one click.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/SaasBundle/Action/ChoosePlanAction.php
+++ b/src/SaasBundle/Action/ChoosePlanAction.php
@@ -28,6 +28,14 @@ use Symfony\Component\Uid\Ulid;
 
 final class ChoosePlanAction extends AbstractController
 {
+    /**
+     * Query parameter used to hand off the desired plan id to the SaaS
+     * checkout route. The subscription's `plan` field is intentionally NOT
+     * mutated here for paid plans — that switch only commits once Lemon
+     * Squeezy confirms the upgrade via webhook (see SubscriptionPlanSyncListener).
+     */
+    public const string PENDING_PLAN_QUERY_PARAMETER = 'plan';
+
     public function __construct(
         private readonly PlanRepositoryInterface $planRepository,
         private readonly SubscriptionManager $subscriptionManager,
@@ -66,18 +74,24 @@ final class ChoosePlanAction extends AbstractController
             return $this->redirectToRoute('saas_subscription_plans');
         }
 
-        if ($subscription->getPlan()->getPlanId() !== $plan->getPlanId()) {
-            $this->subscriptionManager->changePlan($subscription, $plan);
-        }
-
+        // Free plan: no Lemon Squeezy round-trip; safe to commit locally now.
         if ($plan->isFree()) {
+            if ($subscription->getPlan()->getPlanId() !== $plan->getPlanId()) {
+                $this->subscriptionManager->changePlan($subscription, $plan);
+            }
             $this->subscriptionManager->activate($subscription);
             $this->addFlash('success', 'Your free plan is now active.');
 
             return $this->redirectToRoute('_dashboard');
         }
 
-        return $this->redirectToRoute('saas_subscription_checkout');
+        // Paid plan: defer the local plan switch. Pass the desired plan id
+        // to the checkout route via query parameter — the webhook handler
+        // commits the switch only if Lemon Squeezy confirms the new
+        // subscription / variant.
+        return $this->redirectToRoute('saas_subscription_checkout', [
+            self::PENDING_PLAN_QUERY_PARAMETER => $plan->getPlanId(),
+        ]);
     }
 
     private function getSubscription(): ?Subscription

--- a/src/SaasBundle/Action/ConfirmPlanChangeAction.php
+++ b/src/SaasBundle/Action/ConfirmPlanChangeAction.php
@@ -84,18 +84,20 @@ final class ConfirmPlanChangeAction extends AbstractController
 
         // From here the subscription is either pending, on a trial, or
         // already active on the free plan — none of which involve the
-        // payment provider on the existing record. Swap the plan and route
-        // to the appropriate finishing step.
-        $this->subscriptionManager->changePlan($subscription, $plan);
-
+        // payment provider on the existing record yet. The plan switch
+        // is only committed locally for free plans (no LS round-trip);
+        // paid plans defer the switch to webhook confirmation.
         if ($plan->isFree()) {
+            $this->subscriptionManager->changePlan($subscription, $plan);
             $this->subscriptionManager->activate($subscription);
             $this->addFlash('success', 'Your plan has been changed.');
 
             return $this->redirectToRoute('billing_index');
         }
 
-        return $this->redirectToRoute('saas_subscription_checkout');
+        return $this->redirectToRoute('saas_subscription_checkout', [
+            ChoosePlanAction::PENDING_PLAN_QUERY_PARAMETER => $plan->getPlanId(),
+        ]);
     }
 
     private function handleActivePlanChange(Subscription $subscription, Plan $plan, bool $isDowngrade): Response

--- a/src/SaasBundle/Config/ConfigProvider.php
+++ b/src/SaasBundle/Config/ConfigProvider.php
@@ -11,6 +11,7 @@
 
 namespace SolidInvoice\SaasBundle\Config;
 
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidInvoice\SaasBundle\Form\Type\CustomDomainType;
 use SolidInvoice\SettingsBundle\Config\ProviderInterface;
 use SolidInvoice\SettingsBundle\DTO\Config;
@@ -26,7 +27,7 @@ final class ConfigProvider implements ProviderInterface
                 '0',
                 'Hide "Powered by SolidInvoice" text in invoices and quotes.',
                 CheckboxType::class,
-                ['trial_restricted' => true]
+                ['feature_gated' => Feature::CustomBranding->value]
             ),
             new Config(
                 'system/company/custom_domain',

--- a/src/SaasBundle/Config/ConfigProvider.php
+++ b/src/SaasBundle/Config/ConfigProvider.php
@@ -30,11 +30,14 @@ final class ConfigProvider implements ProviderInterface
                 ['feature_gated' => Feature::CustomBranding->value]
             ),
             new Config(
-                'system/company/custom_domain',
+                'system/domain/custom_domain',
                 null,
                 'Custom domain for this company (leave empty to use the default URL).',
                 CustomDomainType::class,
-                ['trial_restricted' => true],
+                [
+                    'feature_gated' => Feature::CustomDomain->value,
+                    'trial_restricted' => true,
+                ],
             ),
         ];
     }

--- a/src/SaasBundle/Controller/SubscribeController.php
+++ b/src/SaasBundle/Controller/SubscribeController.php
@@ -11,14 +11,19 @@
 
 namespace SolidInvoice\SaasBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
 use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Integration\Options;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Uid\Ulid;
 
 class SubscribeController extends AbstractController
@@ -27,10 +32,12 @@ class SubscribeController extends AbstractController
         private readonly SubscriptionManager $subscriptionManager,
         private readonly CompanyRepository $companyRepository,
         private readonly CompanySelector $companySelector,
+        private readonly PlanRepositoryInterface $planRepository,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
-    public function __invoke(): RedirectResponse
+    public function __invoke(Request $request): RedirectResponse
     {
         $user = $this->getUser();
         assert($user instanceof User);
@@ -46,8 +53,37 @@ class SubscribeController extends AbstractController
             // @TODO: If status is trial, and we want to allow the trial to be extended, skipTrial should be false.
             ->withSkipTrial(true);
 
-        $checkoutUrl = $this->subscriptionManager
-            ->getCheckoutUrl($subscription, $options);
+        // The chosen plan id (LS variant) is passed in via query parameter
+        // from ChoosePlanAction / ConfirmPlanChangeAction. We swap it onto the
+        // subscription IN MEMORY only — the checkout URL builder reads
+        // `subscription->getPlan()->getPlanId()` for the variant — and then
+        // refresh the entity afterwards to discard the in-memory mutation.
+        // Nothing is flushed, so a failed checkout leaves the local plan
+        // untouched. The webhook handler commits the swap on confirmation.
+        $pendingPlanId = (string) $request->query->get(ChoosePlanAction::PENDING_PLAN_QUERY_PARAMETER, '');
+        $swapped = false;
+
+        if ($pendingPlanId !== '' && $pendingPlanId !== $subscription->getPlan()->getPlanId()) {
+            $targetPlan = $this->planRepository->find($pendingPlanId);
+
+            if ($targetPlan instanceof Plan && $targetPlan->isActive()) {
+                $subscription->setPlan($targetPlan);
+                $swapped = true;
+            }
+        }
+
+        try {
+            $checkoutUrl = $this->subscriptionManager
+                ->getCheckoutUrl($subscription, $options);
+        } finally {
+            // Discard the in-memory plan swap. The subscription entity is
+            // reloaded from the database so the in-memory mutation is never
+            // persisted. The webhook handler is the only authority for
+            // committing a paid plan change locally.
+            if ($swapped) {
+                $this->entityManager->refresh($subscription);
+            }
+        }
 
         return $this->redirect($checkoutUrl);
     }

--- a/src/SaasBundle/DataFixtures/ORM/LoadPlanFeatures.php
+++ b/src/SaasBundle/DataFixtures/ORM/LoadPlanFeatures.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\DataFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Feature\PlanFeatureManager;
+
+/**
+ * Seeds per-plan feature overrides for the four canonical plans, applying the
+ * proposed quotas/booleans from the SaaS pricing matrix.
+ *
+ * Quota cases use -1 as the unlimited sentinel (FeatureValue::UNLIMITED).
+ *
+ * @codeCoverageIgnore
+ */
+final class LoadPlanFeatures extends Fixture implements DependentFixtureInterface
+{
+    /**
+     * @var array<string, array<string, int|bool>>
+     */
+    private const array MATRIX = [
+        LoadPlans::REF_FREE => [
+            Feature::TotalClients->value => 5,
+            Feature::InvoicesPerMonth->value => 10,
+            Feature::TeamSeats->value => 1,
+            Feature::Quotes->value => false,
+            Feature::OnlinePayments->value => false,
+            Feature::RecurringInvoices->value => false,
+            Feature::AutomatedReminders->value => false,
+            Feature::MultiCurrency->value => false,
+            Feature::CustomBranding->value => false,
+            Feature::RestApiAccess->value => false,
+            Feature::McpAccess->value => false,
+            Feature::CustomDomain->value => false,
+        ],
+        LoadPlans::REF_SOLO => [
+            Feature::TotalClients->value => 25,
+            Feature::InvoicesPerMonth->value => 100,
+            Feature::TeamSeats->value => 1,
+            Feature::Quotes->value => true,
+            Feature::OnlinePayments->value => true,
+            Feature::RecurringInvoices->value => true,
+            Feature::AutomatedReminders->value => false,
+            Feature::MultiCurrency->value => false,
+            Feature::CustomBranding->value => false,
+            Feature::RestApiAccess->value => false,
+            Feature::McpAccess->value => false,
+            Feature::CustomDomain->value => false,
+        ],
+        LoadPlans::REF_BUSINESS => [
+            Feature::TotalClients->value => 100,
+            Feature::InvoicesPerMonth->value => -1,
+            Feature::TeamSeats->value => 5,
+            Feature::Quotes->value => true,
+            Feature::OnlinePayments->value => true,
+            Feature::RecurringInvoices->value => true,
+            Feature::AutomatedReminders->value => true,
+            Feature::MultiCurrency->value => true,
+            Feature::CustomBranding->value => true,
+            Feature::RestApiAccess->value => true,
+            Feature::McpAccess->value => true,
+            Feature::CustomDomain->value => false,
+        ],
+        LoadPlans::REF_AGENCY => [
+            Feature::TotalClients->value => -1,
+            Feature::InvoicesPerMonth->value => -1,
+            Feature::TeamSeats->value => -1,
+            Feature::Quotes->value => true,
+            Feature::OnlinePayments->value => true,
+            Feature::RecurringInvoices->value => true,
+            Feature::AutomatedReminders->value => true,
+            Feature::MultiCurrency->value => true,
+            Feature::CustomBranding->value => true,
+            Feature::RestApiAccess->value => true,
+            Feature::McpAccess->value => true,
+            Feature::CustomDomain->value => true,
+        ],
+    ];
+
+    public function __construct(
+        private readonly PlanFeatureManager $planFeatureManager,
+    ) {
+    }
+
+    public function getDependencies(): array
+    {
+        return [LoadPlans::class];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        foreach (self::MATRIX as $planReference => $features) {
+            $plan = $this->getReference($planReference, Plan::class);
+
+            foreach ($features as $featureKey => $value) {
+                $this->planFeatureManager->setFeature($plan, $featureKey, $value);
+            }
+        }
+    }
+}

--- a/src/SaasBundle/DataFixtures/ORM/LoadPlans.php
+++ b/src/SaasBundle/DataFixtures/ORM/LoadPlans.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\DataFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+
+/**
+ * Seeds the four canonical SaaS plans (Free / Solo / Business / Agency).
+ *
+ * Plan IDs and prices are placeholders for dev/test only — production
+ * billing identifiers are managed in the LemonSqueezy dashboard and
+ * synced via webhooks. The Free plan uses price 0 and plan_id "0" so
+ * `Plan::isFree()` returns true and checkout is skipped.
+ *
+ * @codeCoverageIgnore
+ */
+final class LoadPlans extends Fixture
+{
+    public const string REF_FREE = 'plan_free';
+
+    public const string REF_SOLO = 'plan_solo';
+
+    public const string REF_BUSINESS = 'plan_business';
+
+    public const string REF_AGENCY = 'plan_agency';
+
+    public function load(ObjectManager $manager): void
+    {
+        $free = (new Plan())
+            ->setName('Free')
+            ->setPlanId('0')
+            ->setPrice(0)
+            ->setDescription('Free forever — basic invoicing for getting started.')
+            ->setDefault(true)
+            ->setActive(true);
+
+        $solo = (new Plan())
+            ->setName('Solo')
+            ->setPlanId('solo-monthly')
+            ->setPrice(900)
+            ->setDescription('Single freelancer with active client billing.')
+            ->setActive(true);
+
+        $business = (new Plan())
+            ->setName('Business')
+            ->setPlanId('business-monthly')
+            ->setPrice(1900)
+            ->setDescription('Growing teams that need automation and branding.')
+            ->setActive(true);
+
+        $agency = (new Plan())
+            ->setName('Agency')
+            ->setPlanId('agency-monthly')
+            ->setPrice(3900)
+            ->setDescription('Agencies running unlimited clients on custom domains.')
+            ->setActive(true);
+
+        foreach ([$free, $solo, $business, $agency] as $plan) {
+            $manager->persist($plan);
+        }
+
+        $manager->flush();
+
+        $this->addReference(self::REF_FREE, $free);
+        $this->addReference(self::REF_SOLO, $solo);
+        $this->addReference(self::REF_BUSINESS, $business);
+        $this->addReference(self::REF_AGENCY, $agency);
+    }
+}

--- a/src/SaasBundle/EventSubscriber/RecurringInvoiceFeatureGuardListener.php
+++ b/src/SaasBundle/EventSubscriber/RecurringInvoiceFeatureGuardListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\EventSubscriber;
+
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\TransitionBlocker;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Blocks the recurring-invoice `activate` workflow transition when the
+ * SaaS `recurring_invoices` feature is unavailable on the current plan.
+ *
+ * Parallel to {@see RecurringInvoiceVerificationGuardListener}, which handles
+ * email-verification gating; both guard listeners can fire for the same
+ * transition without interfering with each other.
+ */
+final readonly class RecurringInvoiceFeatureGuardListener
+{
+    public function __construct(
+        private FeatureGate $featureGate,
+        private UpgradePromptProvider $upgradePromptProvider,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[AsEventListener('workflow.recurring_invoice.guard.activate')]
+    public function onGuardActivate(GuardEvent $event): void
+    {
+        if ($this->featureGate->isEnabled(Feature::RecurringInvoices->value)) {
+            return;
+        }
+
+        $event->addTransitionBlocker(
+            TransitionBlocker::createUnknown(
+                $this->buildReason(),
+            ),
+        );
+    }
+
+    private function buildReason(): string
+    {
+        $planLabel = $this->upgradePromptProvider->menuLabel(Feature::RecurringInvoices->value);
+
+        if ($planLabel === null) {
+            return $this->translator->trans('Recurring invoices are not available on your current plan.');
+        }
+
+        return $this->translator->trans(
+            'Recurring invoices are not available on your current plan. Upgrade to %plan% to activate this recurring invoice.',
+            ['%plan%' => $planLabel],
+        );
+    }
+}

--- a/src/SaasBundle/EventSubscriber/SubscriptionPlanSyncListener.php
+++ b/src/SaasBundle/EventSubscriber/SubscriptionPlanSyncListener.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\Subscription as LemonSqueezySubscription;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionCreatedEvent;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionEvent;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionUpdatedEvent;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * Listens to Lemon Squeezy `subscription_created` / `subscription_updated`
+ * webhook events and synchronises the local subscription's plan with the
+ * variant id reported by Lemon Squeezy.
+ *
+ * This is the *only* place a paid-plan switch commits to the database. The
+ * choose-plan and confirm-plan-change actions defer the local mutation
+ * entirely so that an LS error (e.g. checkout failure, mis-configured
+ * variant) cannot leave the app on a plan the user never actually paid for.
+ *
+ * Webhooks arrive as separate HTTP requests with no user session attached,
+ * so the listener is intentionally stateless — it relies purely on the LS
+ * payload's `variantId` and the persisted local subscription.
+ *
+ * Free plans are handled inline by ChoosePlanAction / ConfirmPlanChangeAction
+ * — they never round-trip through LS — and active-billed plan changes go
+ * through `SubscriptionManager::changeActivePlan()` which is already
+ * LS-confirmed before the local update.
+ */
+final class SubscriptionPlanSyncListener
+{
+    public function __construct(
+        private readonly SubscriptionRepositoryInterface $subscriptionRepository,
+        private readonly PlanRepositoryInterface $planRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[AsEventListener(event: SubscriptionCreatedEvent::class)]
+    public function onSubscriptionCreated(SubscriptionCreatedEvent $event): void
+    {
+        $this->sync($event);
+    }
+
+    #[AsEventListener(event: SubscriptionUpdatedEvent::class)]
+    public function onSubscriptionUpdated(SubscriptionUpdatedEvent $event): void
+    {
+        $this->sync($event);
+    }
+
+    private function sync(SubscriptionEvent $event): void
+    {
+        $remote = $event->subscription;
+
+        if (! $remote instanceof LemonSqueezySubscription) {
+            // Non-LS DTO: nothing to compare against. Other payment providers
+            // can add their own listeners following this same shape.
+            return;
+        }
+
+        $subscription = $this->subscriptionRepository->findOneBy(['id' => $event->subscriptionId]);
+
+        if (! $subscription instanceof Subscription) {
+            return;
+        }
+
+        $remoteVariantId = (string) $remote->attributes->variantId;
+        $currentPlanId = $subscription->getPlan()->getPlanId();
+
+        if ($remoteVariantId === $currentPlanId) {
+            // Plan unchanged — nothing to sync.
+            return;
+        }
+
+        $targetPlan = $this->planRepository->find($remoteVariantId);
+
+        if (! $targetPlan instanceof Plan) {
+            $this->logger->warning(
+                'Received subscription webhook with unknown variant id; local plan unchanged.',
+                [
+                    'subscription_id' => $event->subscriptionId->toBase58(),
+                    'variant_id' => $remoteVariantId,
+                ],
+            );
+
+            return;
+        }
+
+        // Skip SubscriptionManager::changePlan() here: it guards against
+        // mutating ACTIVE externally-billed subscriptions, which is *exactly*
+        // the state this listener fires for. Lemon Squeezy is the authority
+        // for the switch — we just record it.
+        $subscription->setPlan($targetPlan);
+        $this->subscriptionRepository->save($subscription);
+    }
+}

--- a/src/SaasBundle/Feature/Feature.php
+++ b/src/SaasBundle/Feature/Feature.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Feature;
+
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureType;
+
+/**
+ * Canonical catalogue of every gated feature in SolidInvoice's hosted SaaS plans.
+ *
+ * The string values intentionally match the keys registered in
+ * `solidworx_platform.saas.features` (platform.yaml) and stored in the
+ * `saas_plan_feature.feature_key` column. Keep the two in sync — the
+ * `FeatureCatalogTest` functional test asserts there is no drift.
+ */
+enum Feature: string
+{
+    case TotalClients = 'total_clients';
+    case InvoicesPerMonth = 'invoices_per_month';
+    case TeamSeats = 'team_seats';
+    case Quotes = 'quotes';
+    case OnlinePayments = 'online_payments';
+    case RecurringInvoices = 'recurring_invoices';
+    case AutomatedReminders = 'automated_reminders';
+    case MultiCurrency = 'multi_currency';
+    case CustomBranding = 'custom_branding';
+    case RestApiAccess = 'rest_api_access';
+    case McpAccess = 'mcp_access';
+    case CustomDomain = 'custom_domain';
+
+    public function getType(): FeatureType
+    {
+        return match ($this) {
+            self::TotalClients,
+            self::InvoicesPerMonth,
+            self::TeamSeats => FeatureType::INTEGER,
+            self::Quotes,
+            self::OnlinePayments,
+            self::RecurringInvoices,
+            self::AutomatedReminders,
+            self::MultiCurrency,
+            self::CustomBranding,
+            self::RestApiAccess,
+            self::McpAccess,
+            self::CustomDomain => FeatureType::BOOLEAN,
+        };
+    }
+}

--- a/src/SaasBundle/Feature/FeatureUsage.php
+++ b/src/SaasBundle/Feature/FeatureUsage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Feature;
+
+/**
+ * Pure helper for "approaching limit" decisions on quota-style features.
+ *
+ * The threshold rule is `max(1, ceil(total * 0.1))` — i.e. trigger when 10%
+ * of the quota remains, but never less than 1 remaining unit. Kept as a
+ * stateless VO so banner partials, listeners, and onboarding emails can all
+ * agree on when the warning should fire without each reinventing the maths.
+ */
+final readonly class FeatureUsage
+{
+    public function isApproachingLimit(int $remaining, int $total): bool
+    {
+        if ($total <= 0 || $remaining < 0) {
+            return false;
+        }
+
+        $threshold = max(1, (int) ceil($total * 0.1));
+
+        return $remaining <= $threshold;
+    }
+}

--- a/src/SaasBundle/Feature/RequiredPlanLabelProvider.php
+++ b/src/SaasBundle/Feature/RequiredPlanLabelProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Feature;
+
+/**
+ * Resolves a short, human-readable label naming the cheapest plan that exposes
+ * a given feature — used to render upgrade prompts ("Subscription Required —
+ * {plan}"). Returns `null` when no upgrade path is available (self-hosted, or
+ * the feature is already enabled, or no plan can be resolved).
+ *
+ * `UpgradePromptRenderer` is the canonical implementation. The interface exists
+ * so dependents (e.g. `FeatureRestrictedExtension`) can be unit-tested without
+ * having to instantiate the full Twig + Plan repository graph.
+ */
+interface RequiredPlanLabelProvider
+{
+    public function menuLabel(string $featureKey): ?string;
+}

--- a/src/SaasBundle/Feature/UpgradePromptRenderer.php
+++ b/src/SaasBundle/Feature/UpgradePromptRenderer.php
@@ -28,7 +28,7 @@ use Twig\Environment;
  * Lives in SolidInvoice's SaasBundle (not in vendor PlatformBundle) because the
  * banner copy and route names (`saas_subscription_plans`) are SolidInvoice-specific.
  */
-final readonly class UpgradePromptRenderer
+final readonly class UpgradePromptRenderer implements RequiredPlanLabelProvider
 {
     private const string BANNER_TEMPLATE = '@SolidInvoiceSaas/feature/_upgrade_banner.html.twig';
 

--- a/src/SaasBundle/Feature/UpgradePromptRenderer.php
+++ b/src/SaasBundle/Feature/UpgradePromptRenderer.php
@@ -43,7 +43,13 @@ final readonly class UpgradePromptRenderer implements RequiredPlanLabelProvider,
     }
 
     /**
-     * Returns the cheapest active Plan that exposes the feature, or null when none does.
+     * Returns the cheapest paid Plan that exposes the feature, or null when no
+     * paid upgrade path exists.
+     *
+     * The Free plan is intentionally excluded: every signed-in user is already
+     * on at least Free (the floor), so surfacing "Upgrade to Free" as a nudge
+     * is confusing — and for features that ship in Free, the gate should not
+     * fire for an authenticated user in the first place.
      */
     public function lowestPlanFor(string $featureKey): ?Plan
     {
@@ -59,6 +65,11 @@ final readonly class UpgradePromptRenderer implements RequiredPlanLabelProvider,
             $plan = $this->resolvePlan($reference->id);
 
             if (! $plan instanceof Plan) {
+                continue;
+            }
+
+            // Free is the floor — it isn't a meaningful upgrade target.
+            if ($plan->isFree()) {
                 continue;
             }
 

--- a/src/SaasBundle/Feature/UpgradePromptRenderer.php
+++ b/src/SaasBundle/Feature/UpgradePromptRenderer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Feature;
 
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
@@ -28,7 +29,7 @@ use Twig\Environment;
  * Lives in SolidInvoice's SaasBundle (not in vendor PlatformBundle) because the
  * banner copy and route names (`saas_subscription_plans`) are SolidInvoice-specific.
  */
-final readonly class UpgradePromptRenderer implements RequiredPlanLabelProvider
+final readonly class UpgradePromptRenderer implements RequiredPlanLabelProvider, UpgradePromptProvider
 {
     private const string BANNER_TEMPLATE = '@SolidInvoiceSaas/feature/_upgrade_banner.html.twig';
 

--- a/src/SaasBundle/Feature/UpgradePromptRenderer.php
+++ b/src/SaasBundle/Feature/UpgradePromptRenderer.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Feature;
+
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+use Twig\Environment;
+
+/**
+ * Builds upgrade-prompt UI fragments by combining `FeatureGate::upgradeOptions()`
+ * with persisted `Plan` entities (for prices) and the shared banner partial.
+ *
+ * Lives in SolidInvoice's SaasBundle (not in vendor PlatformBundle) because the
+ * banner copy and route names (`saas_subscription_plans`) are SolidInvoice-specific.
+ */
+final readonly class UpgradePromptRenderer
+{
+    private const string BANNER_TEMPLATE = '@SolidInvoiceSaas/feature/_upgrade_banner.html.twig';
+
+    public function __construct(
+        private FeatureGate $gate,
+        private PlanRepositoryInterface $planRepository,
+        private Environment $twig,
+        private TranslatorInterface $translator,
+        private FeatureUsage $usage,
+    ) {
+    }
+
+    /**
+     * Returns the cheapest active Plan that exposes the feature, or null when none does.
+     */
+    public function lowestPlanFor(string $featureKey): ?Plan
+    {
+        $options = $this->gate->upgradeOptions($featureKey);
+
+        if ($options->isEmpty()) {
+            return null;
+        }
+
+        $cheapest = null;
+
+        foreach ($options->plans as $reference) {
+            $plan = $this->resolvePlan($reference->id);
+
+            if (! $plan instanceof Plan) {
+                continue;
+            }
+
+            if (! $cheapest instanceof Plan || $plan->getPrice() < $cheapest->getPrice()) {
+                $cheapest = $plan;
+            }
+        }
+
+        return $cheapest;
+    }
+
+    /**
+     * Renders an upgrade prompt banner. Returns an empty string when no upgrade
+     * path exists (self-hosted, all-plans-have-it, or unknown plan reference).
+     */
+    public function prompt(string $featureKey): string
+    {
+        $plan = $this->lowestPlanFor($featureKey);
+
+        if (! $plan instanceof Plan) {
+            return '';
+        }
+
+        return $this->twig->render(self::BANNER_TEMPLATE, [
+            'title' => $this->translator->trans('Upgrade required'),
+            'message' => $this->translator->trans(
+                'This feature is available on the %plan% plan.',
+                ['%plan%' => $plan->getName()],
+            ),
+            'plan_name' => $plan->getName(),
+            'type' => 'warning',
+            'icon' => 'tabler:arrow-up-circle',
+        ]);
+    }
+
+    /**
+     * Returns a short menu/link suffix label like "Solo plan", or null when no
+     * upgrade path is available. Useful for greying-out menu items with a hint.
+     */
+    public function menuLabel(string $featureKey): ?string
+    {
+        $plan = $this->lowestPlanFor($featureKey);
+
+        return $plan instanceof Plan ? $plan->getName() : null;
+    }
+
+    /**
+     * Renders a usage-warning banner when the subject is approaching the quota.
+     * Returns an empty string for unlimited features, off-quota features, or
+     * when remaining is comfortably above the 10% threshold.
+     */
+    public function usageBanner(string $featureKey, int $currentUsage = 0): string
+    {
+        $value = $this->gate->resolve($featureKey);
+
+        if ($value->isUnlimited()) {
+            return '';
+        }
+
+        $remaining = $this->gate->remaining($featureKey, $currentUsage);
+        $total = $value->asInt();
+
+        if ($remaining === null || ! $this->usage->isApproachingLimit($remaining, $total)) {
+            return '';
+        }
+
+        $plan = $this->lowestPlanFor($featureKey);
+
+        return $this->twig->render(self::BANNER_TEMPLATE, [
+            'title' => $this->translator->trans('Approaching plan limit'),
+            'message' => $this->translator->trans(
+                '%remaining% of %total% remaining.',
+                ['%remaining%' => $remaining, '%total%' => $total],
+            ),
+            'plan_name' => $plan instanceof Plan ? $plan->getName() : null,
+            'type' => 'warning',
+            'icon' => 'tabler:alert-triangle',
+        ]);
+    }
+
+    private function resolvePlan(string $base58Id): ?Plan
+    {
+        try {
+            $ulid = Ulid::fromBase58($base58Id);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $this->planRepository->find($ulid);
+    }
+}

--- a/src/SaasBundle/Form/Extension/FeatureRestrictedExtension.php
+++ b/src/SaasBundle/Form/Extension/FeatureRestrictedExtension.php
@@ -61,7 +61,7 @@ final class FeatureRestrictedExtension extends AbstractTypeExtension
         $view->vars['disabled'] = true;
         $view->vars['feature_gated_active'] = true;
         $view->vars['feature_gated_plan'] = $this->planLabelProvider->menuLabel($featureKey);
-        $view->vars['attr']['class'] = ($view->vars['attr']['class'] ?? '') . ' feature-gated';
+        $view->vars['attr']['class'] = trim(($view->vars['attr']['class'] ?? '') . ' feature-gated');
 
         if (isset($view->vars['checked'])) {
             $view->vars['checked'] = false;

--- a/src/SaasBundle/Form/Extension/FeatureRestrictedExtension.php
+++ b/src/SaasBundle/Form/Extension/FeatureRestrictedExtension.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Form\Extension;
+
+use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Disables form fields that have a `feature_gated` option pointing at a feature
+ * key that is currently disabled on the company's plan, and exposes view vars
+ * (`feature_gated_active`, `feature_gated_plan`) so templates can render an
+ * upgrade badge with the plan name where the feature becomes available.
+ *
+ * Independent of the `trial_restricted` mechanism: a single Config can carry
+ * both keys. On self-hosted deployments this extension is shadowed by a no-op
+ * declared in CoreBundle so the `feature_gated` option remains valid.
+ */
+final class FeatureRestrictedExtension extends AbstractTypeExtension
+{
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly RequiredPlanLabelProvider $planLabelProvider,
+    ) {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($this->isGated($options['feature_gated'])) {
+            $builder->setDisabled(true);
+        }
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $featureKey = $options['feature_gated'];
+
+        if (! $this->isGated($featureKey)) {
+            $view->vars['feature_gated_active'] = false;
+            $view->vars['feature_gated_plan'] = null;
+
+            return;
+        }
+
+        $view->vars['disabled'] = true;
+        $view->vars['feature_gated_active'] = true;
+        $view->vars['feature_gated_plan'] = $this->planLabelProvider->menuLabel($featureKey);
+        $view->vars['attr']['class'] = ($view->vars['attr']['class'] ?? '') . ' feature-gated';
+
+        if (isset($view->vars['checked'])) {
+            $view->vars['checked'] = false;
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('feature_gated', null);
+        $resolver->setAllowedTypes('feature_gated', ['null', 'string', 'bool']);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        yield FormType::class;
+    }
+
+    private function isGated(mixed $featureKey): bool
+    {
+        return is_string($featureKey) && $featureKey !== '' && ! $this->featureGate->isEnabled($featureKey);
+    }
+}

--- a/src/SaasBundle/Resources/config/services/services.php
+++ b/src/SaasBundle/Resources/config/services/services.php
@@ -38,4 +38,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         \SolidInvoice\CoreBundle\Contracts\EmailVerificationGateInterface::class,
         \SolidInvoice\SaasBundle\Email\SaasEmailVerificationGate::class,
     );
+
+    $services->alias(
+        \SolidInvoice\CoreBundle\Feature\UpgradePromptProvider::class,
+        \SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer::class,
+    );
 };

--- a/src/SaasBundle/Resources/views/feature/_gated_page.html.twig
+++ b/src/SaasBundle/Resources/views/feature/_gated_page.html.twig
@@ -1,0 +1,13 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #
+ # Thin wrapper for backwards compatibility — the canonical partial lives in
+ # CoreBundle so it is reachable on every deployment. Forwards all parameters
+ # transparently via the implicit context.
+ #}
+{% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' %}

--- a/src/SaasBundle/Resources/views/feature/_upgrade_banner.html.twig
+++ b/src/SaasBundle/Resources/views/feature/_upgrade_banner.html.twig
@@ -1,0 +1,33 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #
+ # Upgrade-prompt banner. Rendered by UpgradePromptRenderer for both the
+ # "feature locked" prompt and the "approaching limit" usage banner.
+ #
+ # @param string      type      - Tabler alert variant: warning, danger, info.
+ # @param string      icon      - Tabler icon name (e.g. 'tabler:arrow-up-circle').
+ # @param string      title     - Bold title text.
+ # @param string      message   - Body copy following the title.
+ # @param string|null plan_name - Optional plan name; when set, renders an "Upgrade to {plan_name}" CTA pointing at the GET plan picker.
+ #}
+<div class="alert alert-{{ type }} alert-banner mb-0" role="alert">
+    <div class="d-flex align-items-center gap-3">
+        <div class="alert-icon">
+            {{ ux_icon(icon, {width: 24, height: 24}) }}
+        </div>
+        <div class="flex-grow-1">
+            <strong>{{ title }}</strong> - {{ message }}
+        </div>
+        {% if plan_name is defined and plan_name %}
+            <a href="{{ path('saas_subscription_plans') }}" class="btn btn-{{ type }} btn-sm">
+                {{ ux_icon('tabler:arrow-up-circle', {width: 16, height: 16}) }}
+                {{ 'Upgrade to %plan%'|trans({'%plan%': plan_name}) }}
+            </a>
+        {% endif %}
+    </div>
+</div>

--- a/src/SaasBundle/Security/Voter/SubscriptionVoter.php
+++ b/src/SaasBundle/Security/Voter/SubscriptionVoter.php
@@ -19,7 +19,9 @@ use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidInvoice\SaasBundle\Service\SubscriptionEligibility;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -34,6 +36,11 @@ use Throwable;
  * need to be re-checked here — its presence in the voter list already
  * implies the SaaS platform is active. The per-bundle access voters
  * (`McpAccessVoter`, `ApiAccessVoter`) handle self-hosted installs.
+ *
+ * In addition to the active-subscription check, this voter enforces the
+ * per-attribute feature gate (`rest_api_access` for the API, `mcp_access`
+ * for MCP) so plan-level downgrades immediately deny access even when the
+ * subscription itself is still active.
  */
 final class SubscriptionVoter extends Voter
 {
@@ -43,6 +50,7 @@ final class SubscriptionVoter extends Voter
         private readonly SubscriptionEligibility $eligibility,
         private readonly CompanySelector $companySelector,
         private readonly CompanyRepository $companyRepository,
+        private readonly FeatureGate $featureGate,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -70,11 +78,17 @@ final class SubscriptionVoter extends Voter
 
             $result = $this->eligibility->evaluate($company);
 
-            if ($result->active) {
-                return true;
+            if (! $result->active) {
+                return $this->deny($vote, $result->reason ?? 'Your subscription is not currently active.');
             }
 
-            return $this->deny($vote, $result->reason ?? 'Your subscription is not currently active.');
+            $featureKey = $this->featureKeyFor($attribute);
+
+            if ($featureKey !== null && ! $this->featureGate->isEnabled($featureKey, $company)) {
+                return $this->deny($vote, $this->featureDeniedReason($featureKey));
+            }
+
+            return true;
         } catch (Throwable $e) {
             // Self-hosted dev/test environments may not have the SaaS schema present even
             // when this voter is registered. Log and grant so authentication still works
@@ -86,6 +100,24 @@ final class SubscriptionVoter extends Voter
 
             return true;
         }
+    }
+
+    private function featureKeyFor(string $attribute): ?string
+    {
+        return match ($attribute) {
+            ApiAttribute::ACCESS => Feature::RestApiAccess->value,
+            McpAttribute::ACCESS => Feature::McpAccess->value,
+            default => null,
+        };
+    }
+
+    private function featureDeniedReason(string $featureKey): string
+    {
+        return match ($featureKey) {
+            Feature::RestApiAccess->value => 'REST API access is not available on the current plan.',
+            Feature::McpAccess->value => 'MCP access is not available on the current plan.',
+            default => 'This feature is not available on the current plan.',
+        };
     }
 
     private function deny(?Vote $vote, string $reason): bool

--- a/src/SaasBundle/Tests/Config/ConfigProviderTest.php
+++ b/src/SaasBundle/Tests/Config/ConfigProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Config\ConfigProvider;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidInvoice\SettingsBundle\DTO\Config;
+
+#[CoversClass(ConfigProvider::class)]
+final class ConfigProviderTest extends TestCase
+{
+    public function testHidePoweredByIsGatedByCustomBrandingFeature(): void
+    {
+        $configs = (new ConfigProvider())->provide([]);
+
+        $hidePoweredBy = $this->findConfigByKey($configs, 'system/general/hide_powered_by');
+
+        self::assertNotNull($hidePoweredBy, 'hide_powered_by config not registered');
+        self::assertSame(Feature::CustomBranding->value, $hidePoweredBy->formOptions['feature_gated'] ?? null);
+        self::assertArrayNotHasKey(
+            'trial_restricted',
+            $hidePoweredBy->formOptions,
+            'hide_powered_by should be feature-gated, not trial-restricted',
+        );
+    }
+
+    public function testCustomDomainRemainsTrialRestricted(): void
+    {
+        $configs = (new ConfigProvider())->provide([]);
+
+        $customDomain = $this->findConfigByKey($configs, 'system/company/custom_domain');
+
+        self::assertNotNull($customDomain);
+        self::assertTrue($customDomain->formOptions['trial_restricted'] ?? false);
+    }
+
+    /**
+     * @param list<Config> $configs
+     */
+    private function findConfigByKey(array $configs, string $key): ?Config
+    {
+        foreach ($configs as $config) {
+            if ($config->key === $key) {
+                return $config;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/SaasBundle/Tests/Config/ConfigProviderTest.php
+++ b/src/SaasBundle/Tests/Config/ConfigProviderTest.php
@@ -37,11 +37,34 @@ final class ConfigProviderTest extends TestCase
         );
     }
 
+    public function testCustomDomainLivesUnderDomainSection(): void
+    {
+        $configs = (new ConfigProvider())->provide([]);
+
+        $customDomain = $this->findConfigByKey($configs, 'system/domain/custom_domain');
+
+        self::assertNotNull($customDomain, 'custom_domain config should live under system/domain section');
+        self::assertNull(
+            $this->findConfigByKey($configs, 'system/company/custom_domain'),
+            'custom_domain config should no longer live under system/company section',
+        );
+    }
+
+    public function testCustomDomainIsFeatureGated(): void
+    {
+        $configs = (new ConfigProvider())->provide([]);
+
+        $customDomain = $this->findConfigByKey($configs, 'system/domain/custom_domain');
+
+        self::assertNotNull($customDomain);
+        self::assertSame(Feature::CustomDomain->value, $customDomain->formOptions['feature_gated'] ?? null);
+    }
+
     public function testCustomDomainRemainsTrialRestricted(): void
     {
         $configs = (new ConfigProvider())->provide([]);
 
-        $customDomain = $this->findConfigByKey($configs, 'system/company/custom_domain');
+        $customDomain = $this->findConfigByKey($configs, 'system/domain/custom_domain');
 
         self::assertNotNull($customDomain);
         self::assertTrue($customDomain->formOptions['trial_restricted'] ?? false);

--- a/src/SaasBundle/Tests/EventSubscriber/RecurringInvoiceFeatureGuardListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RecurringInvoiceFeatureGuardListenerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\SaasBundle\EventSubscriber\RecurringInvoiceFeatureGuardListener;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class RecurringInvoiceFeatureGuardListenerTest extends TestCase
+{
+    public function testBlocksTransitionWhenFeatureDisabledWithPlanLabel(): void
+    {
+        $featureGate = $this->createStub(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(false);
+
+        $upgradePromptProvider = $this->createStub(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')
+            ->willReturn('Solo');
+
+        $event = $this->buildEvent();
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            $featureGate,
+            $upgradePromptProvider,
+            $this->buildTranslator(),
+        );
+
+        $listener->onGuardActivate($event);
+
+        self::assertTrue($event->isBlocked());
+        $blockers = iterator_to_array($event->getTransitionBlockerList());
+        self::assertCount(1, $blockers);
+        self::assertStringContainsString('Recurring invoices are not available on your current plan.', $blockers[0]->getMessage());
+        self::assertStringContainsString('Solo', $blockers[0]->getMessage());
+    }
+
+    public function testBlocksTransitionWhenFeatureDisabledWithoutPlanLabel(): void
+    {
+        $featureGate = $this->createStub(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(false);
+
+        $event = $this->buildEvent();
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            $featureGate,
+            new NullUpgradePromptProvider(),
+            $this->buildTranslator(),
+        );
+
+        $listener->onGuardActivate($event);
+
+        self::assertTrue($event->isBlocked());
+        $blockers = iterator_to_array($event->getTransitionBlockerList());
+        self::assertCount(1, $blockers);
+        self::assertSame('Recurring invoices are not available on your current plan.', $blockers[0]->getMessage());
+    }
+
+    public function testAllowsTransitionWhenFeatureEnabled(): void
+    {
+        $featureGate = $this->createStub(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->expects(self::never())->method('menuLabel');
+
+        $event = $this->buildEvent();
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            $featureGate,
+            $upgradePromptProvider,
+            $this->buildTranslator(),
+        );
+
+        $listener->onGuardActivate($event);
+
+        self::assertFalse($event->isBlocked());
+    }
+
+    public function testSelfHostedAllowsTransition(): void
+    {
+        $event = $this->buildEvent();
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            new NoopFeatureGate(),
+            new NullUpgradePromptProvider(),
+            $this->buildTranslator(),
+        );
+
+        $listener->onGuardActivate($event);
+
+        self::assertFalse($event->isBlocked());
+    }
+
+    private function buildEvent(): GuardEvent
+    {
+        return new GuardEvent(
+            new RecurringInvoice(),
+            new Marking(),
+            new Transition('activate', 'draft', 'active'),
+            $this->createStub(WorkflowInterface::class),
+        );
+    }
+
+    private function buildTranslator(): TranslatorInterface
+    {
+        return new Translator('en');
+    }
+}

--- a/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use SolidInvoice\SaasBundle\EventSubscriber\SubscriptionPlanSyncListener;
+use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\Subscription as LemonSqueezySubscription;
+use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\SubscriptionAttributes;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionCreatedEvent;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionUpdatedEvent;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(SubscriptionPlanSyncListener::class)]
+final class SubscriptionPlanSyncListenerTest extends TestCase
+{
+    public function testCommitsPlanChangeWhenVariantIdDiffersOnCreation(): void
+    {
+        $currentPlan = $this->makePlan('Free', '0');
+        $newPlan = $this->makePlan('Solo', '12345');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+        $subscriptionRepository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static fn (Subscription $s): bool => $s->getPlan() === $newPlan));
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->with('12345')->willReturn($newPlan);
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        $listener->onSubscriptionCreated($this->makeCreatedEvent($subscription->getId(), 12345));
+
+        self::assertSame($newPlan, $subscription->getPlan());
+    }
+
+    public function testCommitsPlanChangeWhenVariantIdDiffersOnUpdate(): void
+    {
+        $currentPlan = $this->makePlan('Solo', '12345');
+        $newPlan = $this->makePlan('Business', '67890');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+        $subscriptionRepository->expects(self::once())->method('save');
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->with('67890')->willReturn($newPlan);
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 67890));
+
+        self::assertSame($newPlan, $subscription->getPlan());
+    }
+
+    public function testDoesNotChangePlanWhenVariantIdMatchesCurrentPlan(): void
+    {
+        $currentPlan = $this->makePlan('Solo', '12345');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+        $subscriptionRepository->expects(self::never())->method('save');
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->expects(self::never())->method('find');
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 12345));
+
+        self::assertSame($currentPlan, $subscription->getPlan());
+    }
+
+    public function testIgnoresEventWithoutLemonSqueezyDto(): void
+    {
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->expects(self::never())->method('findOneBy');
+        $subscriptionRepository->expects(self::never())->method('save');
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        // No DTO attached — listener should short-circuit.
+        $listener->onSubscriptionUpdated(new SubscriptionUpdatedEvent(new Ulid(), 'lemon-1234', null));
+    }
+
+    public function testSkipsChangePlanWhenVariantIdUnknown(): void
+    {
+        $currentPlan = $this->makePlan('Free', '0');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+        $subscriptionRepository->expects(self::never())->method('save');
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->with('99999')->willReturn(null);
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 99999));
+
+        self::assertSame($currentPlan, $subscription->getPlan());
+    }
+
+    public function testIgnoresEventWhenLocalSubscriptionMissing(): void
+    {
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn(null);
+        $subscriptionRepository->expects(self::never())->method('save');
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->expects(self::never())->method('find');
+
+        $listener = new SubscriptionPlanSyncListener(
+            $subscriptionRepository,
+            $planRepository,
+            new NullLogger(),
+        );
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent(new Ulid(), 12345));
+    }
+
+    private function makePlan(string $name, string $planId): Plan
+    {
+        $plan = new Plan();
+        $plan->setName($name);
+        $plan->setPlanId($planId);
+        $plan->setPrice($planId === '0' ? 0 : 900);
+
+        $reflection = new \ReflectionProperty(Plan::class, 'id');
+        $reflection->setValue($plan, new Ulid());
+
+        return $plan;
+    }
+
+    private function makeSubscription(Plan $plan): Subscription
+    {
+        $subscription = new Subscription();
+        $subscription->setPlan($plan);
+
+        $reflection = new \ReflectionProperty(Subscription::class, 'id');
+        $reflection->setValue($subscription, new Ulid());
+
+        return $subscription;
+    }
+
+    private function makeCreatedEvent(Ulid $subscriptionId, int $variantId): SubscriptionCreatedEvent
+    {
+        return new SubscriptionCreatedEvent($subscriptionId, 'lemon-' . $variantId, $this->makeLsSubscription($variantId));
+    }
+
+    private function makeUpdatedEvent(Ulid $subscriptionId, int $variantId): SubscriptionUpdatedEvent
+    {
+        return new SubscriptionUpdatedEvent($subscriptionId, 'lemon-' . $variantId, $this->makeLsSubscription($variantId));
+    }
+
+    private function makeLsSubscription(int $variantId): LemonSqueezySubscription
+    {
+        $attributes = new SubscriptionAttributes();
+        $attributes->variantId = $variantId;
+
+        $dto = new LemonSqueezySubscription();
+        $dto->attributes = $attributes;
+
+        return $dto;
+    }
+}

--- a/src/SaasBundle/Tests/Feature/FeatureUsageTest.php
+++ b/src/SaasBundle/Tests/Feature/FeatureUsageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Feature;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Feature\FeatureUsage;
+
+/**
+ * Edge cases pinned by US-002 acceptance criteria:
+ *   total=10  → threshold=1   (10 * 0.1 = 1.0, ceil = 1)
+ *   total=100 → threshold=10  (100 * 0.1 = 10.0, ceil = 10)
+ *   total=3   → threshold=1   (3 * 0.1 = 0.3, ceil = 1, floor lifts to 1)
+ */
+#[CoversClass(FeatureUsage::class)]
+final class FeatureUsageTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int, int, bool}>
+     */
+    public static function provideApproachingLimitCases(): iterable
+    {
+        // total=10, threshold=1 — only "1 remaining" trips the alert.
+        yield 'total=10 remaining=2 → not approaching' => [2, 10, false];
+        yield 'total=10 remaining=1 → approaching' => [1, 10, true];
+        yield 'total=10 remaining=0 → approaching (at limit)' => [0, 10, true];
+
+        // total=100, threshold=10 — anything ≤ 10 trips the alert.
+        yield 'total=100 remaining=11 → not approaching' => [11, 100, false];
+        yield 'total=100 remaining=10 → approaching' => [10, 100, true];
+        yield 'total=100 remaining=1 → approaching' => [1, 100, true];
+
+        // total=3, threshold=1 — small quotas still get a 1-unit floor.
+        yield 'total=3 remaining=2 → not approaching' => [2, 3, false];
+        yield 'total=3 remaining=1 → approaching' => [1, 3, true];
+        yield 'total=3 remaining=0 → approaching (at limit)' => [0, 3, true];
+
+        // Pathological inputs — never blow up, never warn.
+        yield 'total=0 → never approaching (no quota)' => [0, 0, false];
+        yield 'negative remaining → never approaching' => [-1, 10, false];
+    }
+
+    #[DataProvider('provideApproachingLimitCases')]
+    public function testIsApproachingLimit(int $remaining, int $total, bool $expected): void
+    {
+        $usage = new FeatureUsage();
+
+        self::assertSame($expected, $usage->isApproachingLimit($remaining, $total));
+    }
+}

--- a/src/SaasBundle/Tests/Feature/UpgradePromptRendererTest.php
+++ b/src/SaasBundle/Tests/Feature/UpgradePromptRendererTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Feature;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Feature\FeatureUsage;
+use SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureType;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureValue;
+use SolidWorx\Platform\PlatformBundle\Feature\PlanReference;
+use SolidWorx\Platform\PlatformBundle\Feature\UpgradeOptions;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+#[CoversClass(UpgradePromptRenderer::class)]
+final class UpgradePromptRendererTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testLowestPlanForReturnsNullWhenUpgradeOptionsAreEmpty(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('foo')->andReturn(new UpgradeOptions([]));
+
+        $renderer = $this->makeRenderer(gate: $gate);
+
+        self::assertNull($renderer->lowestPlanFor('foo'));
+    }
+
+    public function testLowestPlanForPicksTheCheapestPlan(): void
+    {
+        $solo = $this->makePlan('Solo', 900);
+        $business = $this->makePlan('Business', 1900);
+        $agency = $this->makePlan('Agency', 3900);
+
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('mcp_access')->andReturn(new UpgradeOptions([
+            new PlanReference($business->getId()->toBase58(), $business->getName()),
+            new PlanReference($solo->getId()->toBase58(), $solo->getName()),
+            new PlanReference($agency->getId()->toBase58(), $agency->getName()),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($business->getId())))->andReturn($business);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($solo->getId())))->andReturn($solo);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($agency->getId())))->andReturn($agency);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        $cheapest = $renderer->lowestPlanFor('mcp_access');
+
+        self::assertInstanceOf(Plan::class, $cheapest);
+        self::assertSame('Solo', $cheapest->getName());
+    }
+
+    public function testLowestPlanForSkipsUnknownPlanReferences(): void
+    {
+        $solo = $this->makePlan('Solo', 900);
+
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('mcp_access')->andReturn(new UpgradeOptions([
+            new PlanReference(Ulid::generate(), 'Phantom'),
+            new PlanReference($solo->getId()->toBase58(), $solo->getName()),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => ! $id->equals($solo->getId())))->andReturn(null);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($solo->getId())))->andReturn($solo);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        self::assertSame('Solo', $renderer->lowestPlanFor('mcp_access')?->getName());
+    }
+
+    public function testLowestPlanForReturnsNullForMalformedPlanReferenceId(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('mcp_access')->andReturn(new UpgradeOptions([
+            new PlanReference('not-a-base58-ulid!', 'Bogus'),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        self::assertNull($renderer->lowestPlanFor('mcp_access'));
+    }
+
+    public function testUsageBannerReturnsEmptyForUnlimitedFeature(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('resolve')->with('total_clients')
+            ->andReturn(new FeatureValue('total_clients', FeatureType::INTEGER, FeatureValue::UNLIMITED));
+
+        $renderer = $this->makeRenderer(gate: $gate);
+
+        self::assertSame('', $renderer->usageBanner('total_clients', 9999));
+    }
+
+    public function testUsageBannerReturnsEmptyWhenNotApproachingLimit(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('resolve')->with('total_clients')
+            ->andReturn(new FeatureValue('total_clients', FeatureType::INTEGER, 100));
+        $gate->shouldReceive('remaining')->with('total_clients', 50)->andReturn(50);
+
+        $renderer = $this->makeRenderer(gate: $gate);
+
+        self::assertSame('', $renderer->usageBanner('total_clients', 50));
+    }
+
+    public function testMenuLabelReturnsPlanName(): void
+    {
+        $solo = $this->makePlan('Solo', 900);
+
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('mcp_access')->andReturn(new UpgradeOptions([
+            new PlanReference($solo->getId()->toBase58(), $solo->getName()),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+        $repo->shouldReceive('find')->andReturn($solo);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        self::assertSame('Solo', $renderer->menuLabel('mcp_access'));
+    }
+
+    private function makeRenderer(
+        ?FeatureGate $gate = null,
+        ?PlanRepositoryInterface $repo = null,
+    ): UpgradePromptRenderer {
+        $twig = M::mock(Environment::class);
+        $translator = M::mock(TranslatorInterface::class);
+
+        return new UpgradePromptRenderer(
+            $gate ?? M::mock(FeatureGate::class),
+            $repo ?? M::mock(PlanRepositoryInterface::class),
+            $twig,
+            $translator,
+            new FeatureUsage(),
+        );
+    }
+
+    private function makePlan(string $name, int $price): Plan
+    {
+        $plan = new Plan();
+        $plan->setName($name);
+        $plan->setPrice($price);
+        $plan->setPlanId('plan-' . strtolower($name));
+
+        // Force a real ULID so toBase58() round-trips through Ulid::fromBase58().
+        $reflection = new \ReflectionProperty(Plan::class, 'id');
+        $reflection->setValue($plan, new Ulid());
+
+        return $plan;
+    }
+}

--- a/src/SaasBundle/Tests/Feature/UpgradePromptRendererTest.php
+++ b/src/SaasBundle/Tests/Feature/UpgradePromptRendererTest.php
@@ -104,6 +104,44 @@ final class UpgradePromptRendererTest extends TestCase
         self::assertNull($renderer->lowestPlanFor('mcp_access'));
     }
 
+    public function testLowestPlanForSkipsFreePlan(): void
+    {
+        $free = $this->makeFreePlan();
+        $solo = $this->makePlan('Solo', 900);
+
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('quotes')->andReturn(new UpgradeOptions([
+            new PlanReference($free->getId()->toBase58(), $free->getName()),
+            new PlanReference($solo->getId()->toBase58(), $solo->getName()),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($free->getId())))->andReturn($free);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($solo->getId())))->andReturn($solo);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        // Even though Free is cheaper (price 0), Solo is the lowest *paid* plan.
+        self::assertSame('Solo', $renderer->lowestPlanFor('quotes')?->getName());
+    }
+
+    public function testLowestPlanForReturnsNullWhenOnlyFreeOffersTheFeature(): void
+    {
+        $free = $this->makeFreePlan();
+
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('upgradeOptions')->with('quotes')->andReturn(new UpgradeOptions([
+            new PlanReference($free->getId()->toBase58(), $free->getName()),
+        ]));
+
+        $repo = M::mock(PlanRepositoryInterface::class);
+        $repo->shouldReceive('find')->with(M::on(static fn (Ulid $id) => $id->equals($free->getId())))->andReturn($free);
+
+        $renderer = $this->makeRenderer(gate: $gate, repo: $repo);
+
+        self::assertNull($renderer->lowestPlanFor('quotes'));
+    }
+
     public function testUsageBannerReturnsEmptyForUnlimitedFeature(): void
     {
         $gate = M::mock(FeatureGate::class);
@@ -168,6 +206,20 @@ final class UpgradePromptRendererTest extends TestCase
         $plan->setPlanId('plan-' . strtolower($name));
 
         // Force a real ULID so toBase58() round-trips through Ulid::fromBase58().
+        $reflection = new \ReflectionProperty(Plan::class, 'id');
+        $reflection->setValue($plan, new Ulid());
+
+        return $plan;
+    }
+
+    private function makeFreePlan(): Plan
+    {
+        // Plan::isFree() requires both price === 0 AND planId === '0'.
+        $plan = new Plan();
+        $plan->setName('Free');
+        $plan->setPrice(0);
+        $plan->setPlanId('0');
+
         $reflection = new \ReflectionProperty(Plan::class, 'id');
         $reflection->setValue($plan, new Ulid());
 

--- a/src/SaasBundle/Tests/Form/Extension/FeatureRestrictedExtensionTest.php
+++ b/src/SaasBundle/Tests/Form/Extension/FeatureRestrictedExtensionTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Form\Extension;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
+use SolidInvoice\SaasBundle\Form\Extension\FeatureRestrictedExtension;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[CoversClass(FeatureRestrictedExtension::class)]
+final class FeatureRestrictedExtensionTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testBuildViewDisablesFieldWhenFeatureIsDisabled(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldReceive('menuLabel')->with('custom_branding')->andReturn('Solo');
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => 'custom_branding',
+        ]);
+
+        self::assertTrue($view->vars['disabled']);
+        self::assertTrue($view->vars['feature_gated_active']);
+        self::assertSame('Solo', $view->vars['feature_gated_plan']);
+        self::assertStringContainsString('feature-gated', $view->vars['attr']['class']);
+    }
+
+    public function testBuildViewIsNoOpWhenFeatureIsEnabled(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnTrue();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldNotReceive('menuLabel');
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => 'custom_branding',
+        ]);
+
+        self::assertArrayNotHasKey('disabled', $view->vars);
+        self::assertFalse($view->vars['feature_gated_active']);
+        self::assertNull($view->vars['feature_gated_plan']);
+    }
+
+    public function testBuildViewIsNoOpWhenOptionIsNull(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldNotReceive('isEnabled');
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldNotReceive('menuLabel');
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => null,
+        ]);
+
+        self::assertFalse($view->vars['feature_gated_active']);
+        self::assertNull($view->vars['feature_gated_plan']);
+    }
+
+    public function testBuildViewIsNoOpWhenOptionIsFalse(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldNotReceive('isEnabled');
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => false,
+        ]);
+
+        self::assertFalse($view->vars['feature_gated_active']);
+        self::assertNull($view->vars['feature_gated_plan']);
+    }
+
+    public function testBuildViewForcesCheckboxUnchecked(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldReceive('menuLabel')->with('custom_branding')->andReturn('Business');
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $view->vars['checked'] = true;
+
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => 'custom_branding',
+        ]);
+
+        self::assertFalse($view->vars['checked']);
+    }
+
+    public function testBuildViewPreservesExistingAttrClass(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldReceive('menuLabel')->with('custom_branding')->andReturn(null);
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $view = new FormView();
+        $view->vars['attr']['class'] = 'existing-class';
+
+        $extension->buildView($view, $this->createStub(FormInterface::class), [
+            'feature_gated' => 'custom_branding',
+        ]);
+
+        self::assertStringContainsString('existing-class', $view->vars['attr']['class']);
+        self::assertStringContainsString('feature-gated', $view->vars['attr']['class']);
+        self::assertNull($view->vars['feature_gated_plan']);
+    }
+
+    public function testBuildFormDisablesBuilderWhenGated(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $builder = M::mock(FormBuilderInterface::class);
+        $builder->shouldReceive('setDisabled')->with(true)->once();
+
+        $extension->buildForm($builder, ['feature_gated' => 'custom_branding']);
+    }
+
+    public function testBuildFormDoesNotDisableBuilderWhenFeatureEnabled(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with('custom_branding')->andReturnTrue();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+
+        $extension = new FeatureRestrictedExtension($gate, $renderer);
+
+        $builder = M::mock(FormBuilderInterface::class);
+        $builder->shouldNotReceive('setDisabled');
+
+        $extension->buildForm($builder, ['feature_gated' => 'custom_branding']);
+    }
+
+    public function testConfigureOptionsDefaultsToNull(): void
+    {
+        $extension = new FeatureRestrictedExtension(
+            M::mock(FeatureGate::class),
+            M::mock(RequiredPlanLabelProvider::class),
+        );
+
+        $resolver = new OptionsResolver();
+        $extension->configureOptions($resolver);
+
+        self::assertNull($resolver->resolve([])['feature_gated']);
+    }
+
+    public function testConfigureOptionsAcceptsString(): void
+    {
+        $extension = new FeatureRestrictedExtension(
+            M::mock(FeatureGate::class),
+            M::mock(RequiredPlanLabelProvider::class),
+        );
+
+        $resolver = new OptionsResolver();
+        $extension->configureOptions($resolver);
+
+        self::assertSame('foo', $resolver->resolve(['feature_gated' => 'foo'])['feature_gated']);
+    }
+
+    public function testConfigureOptionsRejectsInts(): void
+    {
+        $extension = new FeatureRestrictedExtension(
+            M::mock(FeatureGate::class),
+            M::mock(RequiredPlanLabelProvider::class),
+        );
+
+        $resolver = new OptionsResolver();
+        $extension->configureOptions($resolver);
+
+        $this->expectException(InvalidOptionsException::class);
+        $resolver->resolve(['feature_gated' => 123]);
+    }
+
+    public function testGetExtendedTypesReturnsFormType(): void
+    {
+        $types = iterator_to_array(FeatureRestrictedExtension::getExtendedTypes());
+
+        self::assertCount(1, $types);
+        self::assertSame(FormType::class, $types[0]);
+    }
+}

--- a/src/SaasBundle/Tests/Form/SettingsTypeFeatureGateIntegrationTest.php
+++ b/src/SaasBundle/Tests/Form/SettingsTypeFeatureGateIntegrationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Form;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
+use SolidInvoice\SaasBundle\Form\Extension\FeatureRestrictedExtension;
+use SolidInvoice\SettingsBundle\Entity\Setting;
+use SolidInvoice\SettingsBundle\Form\Extension\CheckBoxExtension;
+use SolidInvoice\SettingsBundle\Form\Extension\TrialRestrictedExtension;
+use SolidInvoice\SettingsBundle\Form\Type\SettingsType;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Forms;
+
+/**
+ * End-to-end test that wires SettingsType with both restriction extensions and
+ * exercises the `feature_gated` Config flow on a Free-plan company:
+ *  - the disabled badge view var is set
+ *  - the plan name is exposed for the badge label
+ *  - the trial-restricted mechanism is unaffected by the new option
+ */
+final class SettingsTypeFeatureGateIntegrationTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testFeatureGatedFieldExposesActiveAndPlanViewVars(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with(Feature::CustomBranding->value)->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldReceive('menuLabel')->with(Feature::CustomBranding->value)->andReturn('Solo');
+
+        $factory = $this->createFormFactory($gate, $renderer);
+
+        $setting = $this->buildSetting(['feature_gated' => Feature::CustomBranding->value]);
+
+        $form = $factory->create(SettingsType::class, null, [
+            'settings' => ['hide_powered_by' => $setting],
+        ]);
+
+        $view = $form->createView();
+        $field = $view->children['hide_powered_by'];
+
+        self::assertTrue($field->vars['feature_gated_active']);
+        self::assertSame('Solo', $field->vars['feature_gated_plan']);
+        self::assertTrue($field->vars['disabled']);
+    }
+
+    public function testEnabledFeatureLeavesFieldNormal(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with(Feature::CustomBranding->value)->andReturnTrue();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+
+        $factory = $this->createFormFactory($gate, $renderer);
+
+        $setting = $this->buildSetting(['feature_gated' => Feature::CustomBranding->value]);
+
+        $form = $factory->create(SettingsType::class, null, [
+            'settings' => ['hide_powered_by' => $setting],
+        ]);
+
+        $view = $form->createView();
+        $field = $view->children['hide_powered_by'];
+
+        self::assertFalse($field->vars['feature_gated_active']);
+        self::assertNull($field->vars['feature_gated_plan']);
+        self::assertFalse($field->vars['disabled']);
+    }
+
+    public function testFeatureGatedAndTrialRestrictedAreIndependent(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+        $gate->shouldReceive('isEnabled')->with(Feature::CustomBranding->value)->andReturnFalse();
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+        $renderer->shouldReceive('menuLabel')->with(Feature::CustomBranding->value)->andReturn('Business');
+
+        $factory = $this->createFormFactory($gate, $renderer);
+
+        $setting = $this->buildSetting([
+            'feature_gated' => Feature::CustomBranding->value,
+            'trial_restricted' => true,
+        ]);
+
+        $form = $factory->create(SettingsType::class, null, [
+            'settings' => ['hide_powered_by' => $setting],
+            'subscription_in_trial' => true,
+        ]);
+
+        $view = $form->createView();
+        $field = $view->children['hide_powered_by'];
+
+        self::assertTrue($field->vars['feature_gated_active']);
+        self::assertSame('Business', $field->vars['feature_gated_plan']);
+        self::assertTrue($field->vars['trial_restricted_active']);
+        self::assertTrue($field->vars['disabled']);
+    }
+
+    public function testNoFlagsLeavesFieldUntouched(): void
+    {
+        $gate = M::mock(FeatureGate::class);
+
+        $renderer = M::mock(RequiredPlanLabelProvider::class);
+
+        $factory = $this->createFormFactory($gate, $renderer);
+
+        $setting = $this->buildSetting([]);
+
+        $form = $factory->create(SettingsType::class, null, [
+            'settings' => ['hide_powered_by' => $setting],
+        ]);
+
+        $view = $form->createView();
+        $field = $view->children['hide_powered_by'];
+
+        self::assertFalse($field->vars['feature_gated_active']);
+        self::assertNull($field->vars['feature_gated_plan']);
+        self::assertFalse($field->vars['trial_restricted_active']);
+        self::assertFalse($field->vars['disabled']);
+    }
+
+    /**
+     * @param array<string, mixed> $formOptions
+     */
+    private function buildSetting(array $formOptions): Setting
+    {
+        $setting = new Setting();
+        $setting->setKey('hide_powered_by');
+        $setting->setType(CheckboxType::class);
+        $setting->setValue('0');
+        $setting->setDefaultValue('0');
+        $setting->setFormOptions($formOptions);
+
+        return $setting;
+    }
+
+    private function createFormFactory(FeatureGate $gate, RequiredPlanLabelProvider $renderer): \Symfony\Component\Form\FormFactoryInterface
+    {
+        return Forms::createFormFactoryBuilder()
+            ->addTypeExtensions([
+                new TrialRestrictedExtension(),
+                new FeatureRestrictedExtension($gate, $renderer),
+                new CheckBoxExtension(),
+            ])
+            ->getFormFactory();
+    }
+}

--- a/src/SaasBundle/Tests/Functional/ApiTokenCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/ApiTokenCreateGateTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SaaS feature-gate short-circuits the UserBundle ApiIndex action
+ * with the upgrade banner when the `rest_api_access` feature is disabled, and
+ * lets the API token UI render normally when the feature is enabled or in
+ * self-hosted mode.
+ *
+ * @group functional
+ */
+final class ApiTokenCreateGateTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testGatedIndexRendersUpgradeBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['rest_api_access' => false]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('prompt')
+            ->willReturnCallback(static fn (string $key): string => $key === 'rest_api_access'
+                ? '<div class="alert alert-warning"><strong>API access locked</strong></div>'
+                : '');
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/profile/api');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('API access locked', $body);
+        // Confirm the live component (and its create-button) is NOT in the gated page
+        self::assertStringNotContainsString('id="api-token-', $body);
+    }
+
+    public function testUngatedIndexRendersTokenList(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['rest_api_access' => true]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+        $upgradePromptProvider->expects(self::never())->method('prompt');
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/profile/api');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringNotContainsString('API access locked', $body);
+    }
+
+    public function testSelfHostedIndexRendersTokenList(): void
+    {
+        $client = $this->bootClient();
+
+        $container = self::getContainer();
+
+        $providerId = 'test.' . UpgradePromptProvider::class;
+        self::assertTrue($container->has($providerId));
+
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+            self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
+        }
+
+        $client->request('GET', '/profile/api');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('API access locked', (string) $client->getResponse()->getContent());
+    }
+
+    /**
+     * @param array<string, bool> $overrides
+     */
+    private function buildFeatureGate(array $overrides): FeatureGate
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $overrides[$key] ?? true);
+
+        return $featureGate;
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        \assert($user instanceof User);
+        $client->loginUser($user);
+
+        return $client;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/ApiTokenCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/ApiTokenCreateGateTest.php
@@ -36,27 +36,21 @@ final class ApiTokenCreateGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Enable the REST API';
+
     public function testGatedIndexRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['rest_api_access' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'rest_api_access'
-                ? '<div class="alert alert-warning"><strong>API access locked</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/profile/api');
 
         self::assertResponseIsSuccessful();
         $body = (string) $client->getResponse()->getContent();
-        self::assertStringContainsString('API access locked', $body);
+        self::assertStringContainsString(self::GATED_HEADLINE, $body);
         // Confirm the live component (and its create-button) is NOT in the gated page
         self::assertStringNotContainsString('id="api-token-', $body);
     }
@@ -67,18 +61,13 @@ final class ApiTokenCreateGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['rest_api_access' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/profile/api');
 
         self::assertResponseIsSuccessful();
         $body = (string) $client->getResponse()->getContent();
-        self::assertStringNotContainsString('API access locked', $body);
+        self::assertStringNotContainsString(self::GATED_HEADLINE, $body);
     }
 
     public function testSelfHostedIndexRendersTokenList(): void
@@ -97,7 +86,7 @@ final class ApiTokenCreateGateTest extends WebTestCase
         $client->request('GET', '/profile/api');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('API access locked', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/ClientCreateQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/ClientCreateQuotaGateTest.php
@@ -24,60 +24,59 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
- * Verifies the SaaS feature-gate short-circuits the InvoiceBundle CreateRecurring
- * action with the upgrade banner when the `recurring_invoices` feature is
- * disabled, and lets the form render normally when the feature is enabled or
- * in self-hosted mode.
+ * Verifies the SaaS feature-gate short-circuits the ClientBundle Add action
+ * with the upgrade banner when the `total_clients` quota is exhausted, and lets
+ * the form render normally when under quota or in self-hosted mode.
  *
  * @group functional
  */
-final class RecurringInvoiceCreateGateTest extends WebTestCase
+final class ClientCreateQuotaGateTest extends WebTestCase
 {
     use EnsureApplicationInstalled;
     use Factories;
 
-    public function testGatedCreateRendersUpgradeBanner(): void
+    public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => false]);
+        $featureGate = $this->buildFeatureGate(['total_clients' => false]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'recurring_invoices'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for recurring</strong></div>'
+            ->willReturnCallback(static fn (string $key): string => $key === 'total_clients'
+                ? '<div class="alert alert-warning"><strong>Upgrade required for clients</strong></div>'
                 : '');
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
     }
 
-    public function testUngatedCreateBypassesBanner(): void
+    public function testUnderQuotaBypassesBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => true]);
+        $featureGate = $this->buildFeatureGate(['total_clients' => true]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
+        $upgradePromptProvider->method('prompt')->willReturn('');
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
     }
 
-    public function testSelfHostedCreateBypassesBanner(): void
+    public function testSelfHostedBypassesBanner(): void
     {
         $client = $this->bootClient();
 
@@ -90,10 +89,10 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
             self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
         }
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/ClientCreateQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/ClientCreateQuotaGateTest.php
@@ -35,26 +35,20 @@ final class ClientCreateQuotaGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Client limit reached';
+
     public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['total_clients' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'total_clients'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for clients</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUnderQuotaBypassesBanner(): void
@@ -63,17 +57,12 @@ final class ClientCreateQuotaGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['total_clients' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->method('prompt')->willReturn('');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedBypassesBanner(): void
@@ -92,7 +81,7 @@ final class ClientCreateQuotaGateTest extends WebTestCase
         $client->request('GET', '/clients/add');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for clients', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/ClientFormMultiCurrencyGateTest.php
+++ b/src/SaasBundle/Tests/Functional/ClientFormMultiCurrencyGateTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Form\Type\ClientType;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormFactoryInterface;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SaaS feature gate at the ClientType form level: when
+ * `multi_currency` is disabled the currencyCode field is rendered disabled
+ * with the company default currency, and submission overwrites any submitted
+ * value with the company default. When the feature is enabled (or in the
+ * self-hosted NoopFeatureGate scenario), the field stays editable.
+ *
+ * @group functional
+ */
+final class ClientFormMultiCurrencyGateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testFormGatesCurrencyCodeFieldWhenFeatureDisabled(): void
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $key !== Feature::MultiCurrency->value);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+
+        $client = new Client();
+        $client->setName('Acme Corp');
+        $client->setCurrencyCode('EUR');
+
+        $form = $this->factory()->create(ClientType::class, $client);
+
+        $field = $form->get('currencyCode');
+        self::assertTrue($field->isDisabled(), 'currencyCode should be disabled when multi_currency is gated');
+        self::assertSame(Feature::MultiCurrency->value, $field->getConfig()->getOption('feature_gated'));
+
+        // Submit with a non-default currency — the SUBMIT listener overrides the
+        // entity's currencyCode to the company default ("USD" via test fixture).
+        $form->submit([
+            'name' => $client->getName(),
+            'currencyCode' => 'EUR',
+            'contacts' => [],
+            'addresses' => [],
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('USD', $client->getCurrencyCode());
+    }
+
+    public function testFormKeepsCurrencyCodeFieldEditableWhenFeatureEnabled(): void
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+
+        $client = new Client();
+        $client->setName('Acme Corp');
+
+        $form = $this->factory()->create(ClientType::class, $client);
+
+        $field = $form->get('currencyCode');
+        self::assertFalse($field->isDisabled(), 'currencyCode should be editable when multi_currency is enabled');
+        self::assertNull($field->getConfig()->getOption('feature_gated'));
+
+        $form->submit([
+            'name' => $client->getName(),
+            'currencyCode' => 'EUR',
+            'contacts' => [],
+            'addresses' => [],
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('EUR', $client->getCurrencyCode());
+    }
+
+    public function testSelfHostedKeepsCurrencyCodeEditable(): void
+    {
+        // The container's wired FeatureGate alias resolves to NoopFeatureGate
+        // in non-SaaS deployments. Verify that path leaves the field editable.
+        $container = self::getContainer();
+
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+            $gateId = 'test.' . FeatureGate::class;
+            self::assertTrue($container->has($gateId));
+            self::assertInstanceOf(NoopFeatureGate::class, $container->get($gateId));
+        }
+
+        $client = new Client();
+        $client->setName('Acme Corp');
+
+        $form = $this->factory()->create(ClientType::class, $client);
+
+        $field = $form->get('currencyCode');
+        self::assertFalse($field->isDisabled());
+        self::assertNull($field->getConfig()->getOption('feature_gated'));
+
+        $form->submit([
+            'name' => $client->getName(),
+            'currencyCode' => 'GBP',
+            'contacts' => [],
+            'addresses' => [],
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('GBP', $client->getCurrencyCode());
+    }
+
+    private function factory(): FormFactoryInterface
+    {
+        $factory = self::getContainer()->get('form.factory');
+        \assert($factory instanceof FormFactoryInterface);
+
+        return $factory;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/CustomDomainSettingRenameTest.php
+++ b/src/SaasBundle/Tests/Functional/CustomDomainSettingRenameTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Override;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\SaasBundle\Tests\SaasTestKernel;
+use SolidInvoice\SettingsBundle\Entity\Setting;
+use SolidInvoice\SettingsBundle\SystemConfig;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Asserts that a value stored under the legacy `system/company/custom_domain`
+ * setting key resolves through {@see SystemConfig::get()} at the new
+ * `system/domain/custom_domain` key after the rename migration runs.
+ *
+ * @group functional
+ */
+final class CustomDomainSettingRenameTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    private const string OLD_KEY = 'system/company/custom_domain';
+
+    private const string NEW_KEY = 'system/domain/custom_domain';
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[Override]
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new SaasTestKernel('test', true);
+    }
+
+    public function testNewKeyResolvesAfterRename(): void
+    {
+        $container = self::getContainer();
+
+        /** @var Connection $connection */
+        $connection = $container->get('doctrine')->getConnection();
+
+        $companyBinary = $this->company->getId()->toBinary();
+
+        // Simulate pre-migration state: a row exists at the legacy key with a value.
+        // (DefaultData seeded the row with NEW_KEY since the SaasBundle ConfigProvider
+        // already uses the renamed key — flip it back so the test exercises the rename.)
+        $seeded = $connection->update(
+            Setting::TABLE_NAME,
+            ['setting_key' => self::OLD_KEY, 'setting_value' => 'invoices.example.com'],
+            ['setting_key' => self::NEW_KEY, 'company_id' => $companyBinary]
+        );
+        self::assertSame(1, (int) $seeded, 'DefaultData should have seeded exactly one row at the new key.');
+
+        // Apply the rename — same SQL the migration runs.
+        $renamed = $connection->update(
+            Setting::TABLE_NAME,
+            ['setting_key' => self::NEW_KEY],
+            ['setting_key' => self::OLD_KEY, 'company_id' => $companyBinary]
+        );
+        self::assertSame(1, (int) $renamed);
+
+        // The settings reader is backed by Doctrine, so flush the identity map to make
+        // sure we fetch the renamed row from the database rather than the cached entity.
+        $container->get('doctrine')->getManager()->clear();
+
+        $config = $container->get(SystemConfig::class);
+        self::assertInstanceOf(SystemConfig::class, $config);
+
+        self::assertSame('invoices.example.com', $config->get(self::NEW_KEY));
+        self::assertNull($config->get(self::OLD_KEY));
+    }
+
+    public function testFreshlySeededRowUsesNewKey(): void
+    {
+        $config = self::getContainer()->get(SystemConfig::class);
+        self::assertInstanceOf(SystemConfig::class, $config);
+
+        self::assertNull($config->get(self::OLD_KEY));
+
+        $config->set(self::NEW_KEY, 'invoices.solo.example');
+
+        self::assertSame('invoices.solo.example', $config->get(self::NEW_KEY));
+    }
+}

--- a/src/SaasBundle/Tests/Functional/FeatureCatalogTest.php
+++ b/src/SaasBundle/Tests/Functional/FeatureCatalogTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Override;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidInvoice\SaasBundle\Tests\SaasTestKernel;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\SaasBundle\Feature\FeatureConfigRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Asserts that the {@see Feature} enum and the configured feature catalogue
+ * (`solidworx_platform.saas.features`, processed into FeatureConfigRegistry)
+ * stay in lock-step.
+ *
+ * Drift between the enum and the config is the most likely silent failure
+ * here — adding a Feature case without registering it (or vice versa) would
+ * leak through unit tests because the registry is never consulted there.
+ *
+ * @group functional
+ */
+final class FeatureCatalogTest extends KernelTestCase
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[Override]
+    protected static function createKernel(array $options = []): SaasTestKernel
+    {
+        $env = $options['environment'] ?? $_ENV['SOLIDINVOICE_ENV'] ?? $_SERVER['SOLIDINVOICE_ENV'] ?? 'test';
+        $debug = $options['debug'] ?? (bool) ($_ENV['SOLIDINVOICE_DEBUG'] ?? $_SERVER['SOLIDINVOICE_DEBUG'] ?? true);
+
+        return new SaasTestKernel($env, $debug);
+    }
+
+    public function testEveryFeatureEnumCaseIsRegisteredInTheRegistry(): void
+    {
+        $registry = $this->getRegistry();
+
+        foreach (Feature::cases() as $feature) {
+            self::assertTrue(
+                $registry->has($feature->value),
+                sprintf('Feature "%s" is not registered in FeatureConfigRegistry — update platform.yaml saas.features.', $feature->value),
+            );
+
+            $config = $registry->get($feature->value);
+            self::assertSame(
+                $feature->getType(),
+                $config->type,
+                sprintf('Feature "%s" type drift: enum says %s, config says %s.', $feature->value, $feature->getType()->value, $config->type->value),
+            );
+        }
+    }
+
+    public function testRegistryDoesNotContainUnknownFeatures(): void
+    {
+        $registry = $this->getRegistry();
+
+        $known = array_map(static fn (Feature $f): string => $f->value, Feature::cases());
+
+        foreach ($registry->keys() as $registeredKey) {
+            self::assertContains(
+                $registeredKey,
+                $known,
+                sprintf('Registry contains feature "%s" with no matching Feature enum case.', $registeredKey),
+            );
+        }
+    }
+
+    public function testFeatureGateResolveReturnsConfiguredDefaultWithNoPlanAttached(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $gateId = 'test.' . FeatureGate::class;
+        self::assertTrue($container->has($gateId));
+        $gate = $container->get($gateId);
+        self::assertInstanceOf(FeatureGate::class, $gate);
+
+        $registry = $this->getRegistry();
+
+        foreach (Feature::cases() as $feature) {
+            $expectedDefault = $registry->get($feature->value)->defaultValue;
+
+            $resolved = $gate->resolve($feature->value);
+
+            self::assertSame(
+                $expectedDefault,
+                $resolved->value,
+                sprintf('FeatureGate did not return the configured default for "%s" with no plan attached.', $feature->value),
+            );
+        }
+    }
+
+    private function getRegistry(): FeatureConfigRegistry
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $id = 'test.' . FeatureConfigRegistry::class;
+        self::assertTrue(
+            $container->has($id),
+            sprintf('Test alias "%s" is not registered. Ensure SOLIDINVOICE_PLATFORM=saas and config/services_test.php is loaded.', $id),
+        );
+
+        $registry = $container->get($id);
+        self::assertInstanceOf(FeatureConfigRegistry::class, $registry);
+
+        return $registry;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/FeatureRestrictedExtensionWiringTest.php
+++ b/src/SaasBundle/Tests/Functional/FeatureRestrictedExtensionWiringTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Override;
+use SolidInvoice\SaasBundle\Feature\RequiredPlanLabelProvider;
+use SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer;
+use SolidInvoice\SaasBundle\Form\Extension\FeatureRestrictedExtension;
+use SolidInvoice\SaasBundle\Tests\SaasTestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Verifies SaaS-side wiring for the form-level feature gating mechanism:
+ *  - the `RequiredPlanLabelProvider` interface resolves to UpgradePromptRenderer
+ *  - the SaaS-only `FeatureRestrictedExtension` is registered as a service
+ *
+ * The non-SaaS counterpart (CoreBundle no-op extension) is exercised by the
+ * existing form-test infrastructure; both sides must be present so the
+ * `feature_gated` form option is accepted in every deployment.
+ */
+final class FeatureRestrictedExtensionWiringTest extends KernelTestCase
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[Override]
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new SaasTestKernel('test', true);
+    }
+
+    public function testRequiredPlanLabelProviderResolvesToUpgradePromptRenderer(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+        $id = 'test.' . RequiredPlanLabelProvider::class;
+
+        self::assertTrue($container->has($id));
+        self::assertInstanceOf(UpgradePromptRenderer::class, $container->get($id));
+    }
+
+    public function testFeatureRestrictedExtensionIsRegistered(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+        $id = 'test.' . FeatureRestrictedExtension::class;
+
+        self::assertTrue($container->has($id));
+        self::assertInstanceOf(FeatureRestrictedExtension::class, $container->get($id));
+    }
+}

--- a/src/SaasBundle/Tests/Functional/FeatureTwigFunctionsTest.php
+++ b/src/SaasBundle/Tests/Functional/FeatureTwigFunctionsTest.php
@@ -42,7 +42,10 @@ final class FeatureTwigFunctionsTest extends KernelTestCase
     protected static function createKernel(array $options = []): SaasTestKernel
     {
         $env = $options['environment'] ?? $_ENV['SOLIDINVOICE_ENV'] ?? $_SERVER['SOLIDINVOICE_ENV'] ?? 'test';
-        $debug = $options['debug'] ?? (bool) ($_ENV['SOLIDINVOICE_DEBUG'] ?? $_SERVER['SOLIDINVOICE_DEBUG'] ?? true);
+        $debugRaw = $options['debug'] ?? $_ENV['SOLIDINVOICE_DEBUG'] ?? $_SERVER['SOLIDINVOICE_DEBUG'] ?? true;
+        $debug = is_bool($debugRaw)
+            ? $debugRaw
+            : filter_var((string) $debugRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
 
         return new SaasTestKernel($env, $debug);
     }

--- a/src/SaasBundle/Tests/Functional/FeatureTwigFunctionsTest.php
+++ b/src/SaasBundle/Tests/Functional/FeatureTwigFunctionsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Override;
+use SolidInvoice\SaasBundle\Feature\Feature;
+use SolidInvoice\SaasBundle\Tests\SaasTestKernel;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\SaasBundle\Feature\PlanFeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * SaaS (PlanFeatureGate) wiring contract for the six feature Twig helpers.
+ *
+ * With no subscriber attached, PlanFeatureGate falls back to the
+ * `solidworx_platform.saas.features` config defaults. INTEGER quotas default
+ * to {@see \SolidWorx\Platform\PlatformBundle\Feature\FeatureValue::UNLIMITED}
+ * (-1) and BOOLEAN flags default to true, so the helpers behave like the
+ * NoopFeatureGate in this baseline state — but the gate concrete is the
+ * real PlanFeatureGate, proving the wiring took effect.
+ *
+ * @group functional
+ */
+final class FeatureTwigFunctionsTest extends KernelTestCase
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[Override]
+    protected static function createKernel(array $options = []): SaasTestKernel
+    {
+        $env = $options['environment'] ?? $_ENV['SOLIDINVOICE_ENV'] ?? $_SERVER['SOLIDINVOICE_ENV'] ?? 'test';
+        $debug = $options['debug'] ?? (bool) ($_ENV['SOLIDINVOICE_DEBUG'] ?? $_SERVER['SOLIDINVOICE_DEBUG'] ?? true);
+
+        return new SaasTestKernel($env, $debug);
+    }
+
+    public function testFeatureGateAliasResolvesToPlanFeatureGateInSaasMode(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $gateId = 'test.' . FeatureGate::class;
+        self::assertTrue($container->has($gateId));
+        self::assertInstanceOf(PlanFeatureGate::class, $container->get($gateId));
+    }
+
+    public function testFeatureEnabledHonoursConfigDefaultsWhenNoPlanAttached(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        // BOOLEAN feature defaults to true → enabled.
+        $template = $twig->createTemplate(
+            "{{ feature_enabled('" . Feature::Quotes->value . "') ? 'yes' : 'no' }}"
+        );
+        self::assertSame('yes', $template->render());
+
+        // INTEGER feature defaults to -1 (unlimited) → also enabled.
+        $template = $twig->createTemplate(
+            "{{ feature_enabled('" . Feature::TotalClients->value . "') ? 'yes' : 'no' }}"
+        );
+        self::assertSame('yes', $template->render());
+    }
+
+    public function testUpgradePromptIsEmptyWhenFeatureIsEnabled(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        // Default config has every feature enabled, so upgrade_prompt is empty.
+        $template = $twig->createTemplate(
+            "{{ upgrade_prompt('" . Feature::Quotes->value . "') }}"
+        );
+        self::assertSame('', $template->render());
+    }
+
+    public function testUsageBannerIsEmptyForUnlimitedDefaultQuota(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        // TotalClients defaults to -1 (unlimited) → no banner regardless of usage.
+        $template = $twig->createTemplate(
+            "{{ feature_usage_banner('" . Feature::TotalClients->value . "', 1000) }}"
+        );
+        self::assertSame('', $template->render());
+    }
+
+    public function testRequiredPlanLabelIsNullWhenFeatureIsEnabled(): void
+    {
+        self::bootKernel();
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        // No plan is attached and defaults enable everything → no required plan.
+        $template = $twig->createTemplate(
+            "{% set label = feature_required_plan_label('" . Feature::McpAccess->value . "') %}{{ label is null ? 'null' : label }}"
+        );
+        self::assertSame('null', $template->render());
+    }
+}

--- a/src/SaasBundle/Tests/Functional/InvoiceCreateQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/InvoiceCreateQuotaGateTest.php
@@ -35,26 +35,20 @@ final class InvoiceCreateQuotaGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Monthly invoice limit reached';
+
     public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['invoices_per_month' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'invoices_per_month'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for invoices</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUnderQuotaBypassesBanner(): void
@@ -63,17 +57,12 @@ final class InvoiceCreateQuotaGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['invoices_per_month' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->method('prompt')->willReturn('');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedBypassesBanner(): void
@@ -92,7 +81,7 @@ final class InvoiceCreateQuotaGateTest extends WebTestCase
         $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/InvoiceCreateQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/InvoiceCreateQuotaGateTest.php
@@ -24,60 +24,59 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
- * Verifies the SaaS feature-gate short-circuits the InvoiceBundle CreateRecurring
- * action with the upgrade banner when the `recurring_invoices` feature is
- * disabled, and lets the form render normally when the feature is enabled or
- * in self-hosted mode.
+ * Verifies the SaaS feature-gate short-circuits the InvoiceBundle Create action
+ * with the upgrade banner when the `invoices_per_month` quota is exhausted, and
+ * lets the form render normally when under quota or in self-hosted mode.
  *
  * @group functional
  */
-final class RecurringInvoiceCreateGateTest extends WebTestCase
+final class InvoiceCreateQuotaGateTest extends WebTestCase
 {
     use EnsureApplicationInstalled;
     use Factories;
 
-    public function testGatedCreateRendersUpgradeBanner(): void
+    public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => false]);
+        $featureGate = $this->buildFeatureGate(['invoices_per_month' => false]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'recurring_invoices'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for recurring</strong></div>'
+            ->willReturnCallback(static fn (string $key): string => $key === 'invoices_per_month'
+                ? '<div class="alert alert-warning"><strong>Upgrade required for invoices</strong></div>'
                 : '');
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
     }
 
-    public function testUngatedCreateBypassesBanner(): void
+    public function testUnderQuotaBypassesBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => true]);
+        $featureGate = $this->buildFeatureGate(['invoices_per_month' => true]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
+        $upgradePromptProvider->method('prompt')->willReturn('');
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
     }
 
-    public function testSelfHostedCreateBypassesBanner(): void
+    public function testSelfHostedBypassesBanner(): void
     {
         $client = $this->bootClient();
 
@@ -90,10 +89,10 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
             self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
         }
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/invoices/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for invoices', (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/McpAuthorizeGateTest.php
+++ b/src/SaasBundle/Tests/Functional/McpAuthorizeGateTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\McpBundle\Entity\OAuthClient;
+use SolidInvoice\McpBundle\Repository\OAuthClientRepository;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the MCP Authorize action surfaces a friendly upgrade page when
+ * the user's eligible companies are all on plans without `mcp_access`. The
+ * happy path (gate enabled, valid client, full consent flow) is covered by
+ * `\SolidInvoice\McpBundle\Tests\Functional\ConsentGrantTest` and the broader
+ * MCP suite — here we only assert the gating edge.
+ *
+ * @group functional
+ */
+final class McpAuthorizeGateTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testRendersUpgradePageWhenMcpAccessFeatureDeniedForAllCompanies(): void
+    {
+        $client = $this->bootClient();
+
+        $oauthClient = $this->seedOAuthClient();
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $key !== 'mcp_access');
+
+        $upgradeProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradeProvider->method('prompt')
+            ->willReturnCallback(static fn (string $key): string => $key === 'mcp_access'
+                ? '<div class="alert alert-warning"><strong>MCP locked</strong></div>'
+                : '');
+        $upgradeProvider->method('menuLabel')->willReturn('Business');
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradeProvider);
+
+        $client->request('GET', '/oauth/authorize', [
+            'response_type' => 'code',
+            'client_id' => $oauthClient->getIdentifier(),
+            'redirect_uri' => 'http://localhost/cb',
+            'scope' => 'mcp:read',
+            'state' => 'xyz',
+        ]);
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('MCP locked', $body);
+    }
+
+    private function seedOAuthClient(): OAuthClient
+    {
+        $repo = self::getContainer()->get(OAuthClientRepository::class);
+        \assert($repo instanceof OAuthClientRepository);
+
+        $client = new OAuthClient();
+        $client->setName('Gate test agent');
+        $client->setRedirectUris(['http://localhost/cb']);
+        $client->setGrantTypes(['authorization_code']);
+        $client->setScopes(['mcp:read']);
+        $client->setTokenEndpointAuthMethod('none');
+        $repo->save($client);
+
+        return $client;
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        \assert($user instanceof User);
+        $client->loginUser($user);
+
+        return $client;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/PaymentSettingsGateTest.php
+++ b/src/SaasBundle/Tests/Functional/PaymentSettingsGateTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\PaymentBundle\Action\Settings;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SaaS feature-gate short-circuits the PaymentBundle Settings
+ * action with the upgrade banner when `online_payments` is disabled, and
+ * lets the page render normally when the feature is enabled or in self-hosted.
+ *
+ * @group functional
+ */
+final class PaymentSettingsGateTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testGatedSettingsRendersUpgradeBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['online_payments' => false]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('prompt')
+            ->willReturnCallback(static fn (string $key): string => $key === 'online_payments'
+                ? '<div class="alert alert-warning"><strong>Upgrade required</strong></div>'
+                : '');
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/payments/methods');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    public function testUngatedSettingsBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['online_payments' => true]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+        $upgradePromptProvider->expects(self::never())->method('prompt');
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/payments/methods');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    public function testSelfHostedSettingsBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $container = self::getContainer();
+
+        $providerId = 'test.' . UpgradePromptProvider::class;
+        self::assertTrue($container->has($providerId));
+
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+            self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
+        }
+
+        $client->request('GET', '/payments/methods');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    /**
+     * @param array<string, bool> $overrides
+     */
+    private function buildFeatureGate(array $overrides): FeatureGate
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $overrides[$key] ?? true);
+
+        return $featureGate;
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        \assert($user instanceof User);
+        $client->loginUser($user);
+
+        return $client;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/PaymentSettingsGateTest.php
+++ b/src/SaasBundle/Tests/Functional/PaymentSettingsGateTest.php
@@ -36,26 +36,20 @@ final class PaymentSettingsGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Accept payments online';
+
     public function testGatedSettingsRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['online_payments' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'online_payments'
-                ? '<div class="alert alert-warning"><strong>Upgrade required</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/payments/methods');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUngatedSettingsBypassesBanner(): void
@@ -64,17 +58,12 @@ final class PaymentSettingsGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['online_payments' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/payments/methods');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedSettingsBypassesBanner(): void
@@ -93,7 +82,7 @@ final class PaymentSettingsGateTest extends WebTestCase
         $client->request('GET', '/payments/methods');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/PdfBaseCustomBrandingGateTest.php
+++ b/src/SaasBundle/Tests/Functional/PdfBaseCustomBrandingGateTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Brick\Math\BigInteger;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
+use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\Line;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
+use SolidInvoice\SettingsBundle\Entity\Setting;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Twig\Environment;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies that the PDF base template (`_pdf_base.html.twig`) gates the
+ * `system/general/hide_powered_by` setting on the `custom_branding` feature:
+ *
+ * - When the feature is disabled (Free/Solo plans), the "Powered By" line is
+ *   always rendered regardless of the stored DB value.
+ * - When the feature is enabled, the setting controls visibility as before.
+ * - On self-hosted (NoopFeatureGate), `hide_powered_by=1` suppresses the line.
+ *
+ * The "Powered By" content lives in the `<pagefooter content-left=...>`
+ * attribute of the rendered template (see `classic/pdf.html.twig` which
+ * extends `_pdf_base.html.twig`).
+ *
+ * @group functional
+ */
+final class PdfBaseCustomBrandingGateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    private const string SETTING_KEY = 'system/general/hide_powered_by';
+
+    public function testGatedPlanAlwaysShowsPoweredByEvenWhenSettingHides(): void
+    {
+        // Persist hide_powered_by=1 in the database (the "I'm hiding it" intent
+        // baked in from a prior plan that had custom_branding).
+        $this->seedHidePoweredBy('1');
+
+        // SaaS plan that does NOT include custom_branding: the gate is OFF.
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $key !== 'custom_branding');
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+
+        $output = $this->renderPdfTemplate();
+
+        // The "Powered By" attribute is populated despite the setting being '1'.
+        self::assertStringContainsString('Powered By', $output);
+    }
+
+    public function testUngatedPlanRespectsHidePoweredBySetting(): void
+    {
+        $this->seedHidePoweredBy('1');
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+
+        $output = $this->renderPdfTemplate();
+
+        // With custom_branding ON and hide_powered_by=1, the attribute is empty.
+        self::assertStringNotContainsString('Powered By', $output);
+    }
+
+    public function testUngatedPlanShowsPoweredByWhenSettingNotHidden(): void
+    {
+        $this->seedHidePoweredBy('0');
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+
+        $output = $this->renderPdfTemplate();
+
+        self::assertStringContainsString('Powered By', $output);
+    }
+
+    public function testSelfHostedNoopFeatureGateRespectsHidePoweredBySetting(): void
+    {
+        // Self-hosted FeatureGate (NoopFeatureGate) reports every feature as
+        // enabled, so a stored hide_powered_by=1 takes effect.
+        $this->seedHidePoweredBy('1');
+
+        // Do NOT replace the gate — exercise the wired implementation.
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) === 'saas') {
+            self::markTestSkipped('Self-hosted scenario is exercised in non-SaaS test runs only.');
+        }
+
+        $output = $this->renderPdfTemplate();
+
+        self::assertStringNotContainsString('Powered By', $output);
+    }
+
+    private function seedHidePoweredBy(string $value): void
+    {
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($em instanceof EntityManagerInterface);
+
+        // Try to update via the repository first; if the row doesn't exist yet
+        // (self-hosted has no SaasBundle ConfigProvider seeding it), persist a
+        // new row directly so the template can read a deterministic value.
+        $repo = $em->getRepository(Setting::class);
+        $existing = $repo->findOneBy(['key' => self::SETTING_KEY]);
+
+        if ($existing instanceof Setting) {
+            $existing->setValue($value);
+            $em->flush();
+
+            return;
+        }
+
+        $setting = new Setting();
+        $setting->setKey(self::SETTING_KEY);
+        $setting->setValue($value);
+        $setting->setType(CheckboxType::class);
+        $setting->setDefaultValue('0');
+        $setting->setCompany($this->company);
+        $em->persist($setting);
+        $em->flush();
+    }
+
+    private function renderPdfTemplate(): string
+    {
+        $invoice = $this->createFixtureInvoice();
+
+        $twig = self::getContainer()->get('twig');
+        \assert($twig instanceof Environment);
+
+        return $twig->render(
+            '@SolidInvoiceInvoice/Templates/classic/pdf.html.twig',
+            ['invoice' => $invoice]
+        );
+    }
+
+    private function createFixtureInvoice(): Invoice
+    {
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'name' => 'Acme Corp',
+            'currencyCode' => 'USD',
+        ]);
+
+        $contact = ContactFactory::createOne([
+            'client' => $client,
+            'company' => $this->company,
+            'firstName' => 'Jane',
+            'lastName' => 'Doe',
+            'email' => 'jane@example.com',
+        ]);
+
+        return InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Pending,
+            'invoiceId' => 'INV-FIXTURE-001',
+            'due' => new DateTimeImmutable('+14 days'),
+            'paidDate' => null,
+            'archived' => null,
+            'terms' => 'Payment due within 30 days.',
+            'notes' => 'Thank you for your business.',
+            'balance' => BigInteger::of(150000),
+            'total' => BigInteger::of(150000),
+            'baseTotal' => BigInteger::of(150000),
+            'tax' => BigInteger::of(0),
+            'discount' => (new Discount())->setType(null),
+            'lines' => [
+                (new Line())
+                    ->setDescription('Sample line item')
+                    ->setPrice(BigInteger::of(75000))
+                    ->setQty(2.0)
+                    ->setTotal(BigInteger::of(150000)),
+            ],
+            'users' => [$contact],
+        ])->_real();
+    }
+}

--- a/src/SaasBundle/Tests/Functional/QuoteCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/QuoteCreateGateTest.php
@@ -35,26 +35,20 @@ final class QuoteCreateGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Send branded quotes to your clients';
+
     public function testGatedCreateRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['quotes' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'quotes'
-                ? '<div class="alert alert-warning"><strong>Upgrade required</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/quotes/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUngatedCreateBypassesBanner(): void
@@ -63,17 +57,12 @@ final class QuoteCreateGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['quotes' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/quotes/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedCreateBypassesBanner(): void
@@ -92,7 +81,7 @@ final class QuoteCreateGateTest extends WebTestCase
         $client->request('GET', '/quotes/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/QuoteCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/QuoteCreateGateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SaaS feature-gate short-circuits the QuoteBundle Create action
+ * with the upgrade banner when the `quotes` feature is disabled, and lets
+ * the form render normally when the feature is enabled or in self-hosted mode.
+ *
+ * @group functional
+ */
+final class QuoteCreateGateTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testGatedCreateRendersUpgradeBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['quotes' => false]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('prompt')
+            ->willReturnCallback(static fn (string $key): string => $key === 'quotes'
+                ? '<div class="alert alert-warning"><strong>Upgrade required</strong></div>'
+                : '');
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/quotes/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    public function testUngatedCreateBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['quotes' => true]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+        $upgradePromptProvider->expects(self::never())->method('prompt');
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/quotes/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    public function testSelfHostedCreateBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $container = self::getContainer();
+
+        $providerId = 'test.' . UpgradePromptProvider::class;
+        self::assertTrue($container->has($providerId));
+
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+            self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
+        }
+
+        $client->request('GET', '/quotes/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required', (string) $client->getResponse()->getContent());
+    }
+
+    /**
+     * @param array<string, bool> $overrides
+     */
+    private function buildFeatureGate(array $overrides): FeatureGate
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $overrides[$key] ?? true);
+
+        return $featureGate;
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        \assert($user instanceof User);
+        $client->loginUser($user);
+
+        return $client;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/RecurringInvoiceCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/RecurringInvoiceCreateGateTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the SaaS feature-gate short-circuits the InvoiceBundle CreateRecurring
+ * action with the upgrade banner when the `recurring_invoices` feature is
+ * disabled, and lets the form render normally when the feature is enabled or
+ * in self-hosted mode.
+ *
+ * @group functional
+ */
+final class RecurringInvoiceCreateGateTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    public function testGatedCreateRendersUpgradeBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['recurring_invoices' => false]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('prompt')
+            ->willReturnCallback(static fn (string $key): string => $key === 'recurring_invoices'
+                ? '<div class="alert alert-warning"><strong>Upgrade required for recurring</strong></div>'
+                : '');
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/invoices/recurring/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+    }
+
+    public function testUngatedCreateBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $featureGate = $this->buildFeatureGate(['recurring_invoices' => true]);
+
+        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')->willReturn(null);
+        $upgradePromptProvider->expects(self::never())->method('prompt');
+
+        self::getContainer()->set(FeatureGate::class, $featureGate);
+        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
+
+        $client->request('GET', '/invoices/recurring/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+    }
+
+    public function testSelfHostedCreateBypassesBanner(): void
+    {
+        $client = $this->bootClient();
+
+        $container = self::getContainer();
+
+        $providerId = 'test.' . UpgradePromptProvider::class;
+        self::assertTrue($container->has($providerId));
+
+        if (($_ENV['SOLIDINVOICE_PLATFORM'] ?? $_SERVER['SOLIDINVOICE_PLATFORM'] ?? null) !== 'saas') {
+            self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
+        }
+
+        $client->request('GET', '/invoices/recurring/create');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+    }
+
+    /**
+     * @param array<string, bool> $overrides
+     */
+    private function buildFeatureGate(array $overrides): FeatureGate
+    {
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')
+            ->willReturnCallback(static fn (string $key): bool => $overrides[$key] ?? true);
+
+        return $featureGate;
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $user = UserFactory::createOne(['companies' => [$this->company]])->_real();
+        \assert($user instanceof User);
+        $client->loginUser($user);
+
+        return $client;
+    }
+}

--- a/src/SaasBundle/Tests/Functional/RecurringInvoiceCreateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/RecurringInvoiceCreateGateTest.php
@@ -36,26 +36,20 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Bill clients on a schedule';
+
     public function testGatedCreateRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['recurring_invoices' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'recurring_invoices'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for recurring</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/invoices/recurring/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUngatedCreateBypassesBanner(): void
@@ -64,17 +58,12 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['recurring_invoices' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/invoices/recurring/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedCreateBypassesBanner(): void
@@ -93,7 +82,7 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
         $client->request('GET', '/invoices/recurring/create');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/RecurringInvoiceFeatureActivateGateTest.php
+++ b/src/SaasBundle/Tests/Functional/RecurringInvoiceFeatureActivateGateTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Feature\NullUpgradePromptProvider;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\InvoiceBundle\Enum\RecurringInvoiceStatus;
+use SolidInvoice\SaasBundle\EventSubscriber\RecurringInvoiceFeatureGuardListener;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Workflow\DefinitionBuilder;
+use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+use Symfony\Component\Workflow\StateMachine;
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * Verifies the SaaS recurring_invoices feature-gate blocks the recurring
+ * invoice `activate` workflow transition (causing workflow_can() to return
+ * false) and includes both the upgrade-prompt copy and the required plan
+ * name in the transition-blocker reason.
+ *
+ * @group functional
+ */
+final class RecurringInvoiceFeatureActivateGateTest extends TestCase
+{
+    public function testActivateIsBlockedWhenFeatureDisabled(): void
+    {
+        $workflow = $this->buildWorkflow(featureEnabled: false, planLabel: 'Solo');
+
+        $invoice = new RecurringInvoice();
+        $invoice->setStatus(RecurringInvoiceStatus::Draft);
+
+        self::assertFalse($workflow->can($invoice, 'activate'));
+    }
+
+    public function testActivateIsAllowedWhenFeatureEnabled(): void
+    {
+        $workflow = $this->buildWorkflow(featureEnabled: true, planLabel: null);
+
+        $invoice = new RecurringInvoice();
+        $invoice->setStatus(RecurringInvoiceStatus::Draft);
+
+        self::assertTrue($workflow->can($invoice, 'activate'));
+    }
+
+    public function testActivateIsAllowedInSelfHostedMode(): void
+    {
+        $featureGate = new NoopFeatureGate();
+
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            $featureGate,
+            new NullUpgradePromptProvider(),
+            new Translator('en'),
+        );
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            'workflow.recurring_invoice.guard.activate',
+            $listener->onGuardActivate(...),
+        );
+
+        $workflow = $this->makeStateMachine($dispatcher);
+
+        $invoice = new RecurringInvoice();
+        $invoice->setStatus(RecurringInvoiceStatus::Draft);
+
+        self::assertTrue($workflow->can($invoice, 'activate'));
+    }
+
+    private function buildWorkflow(bool $featureEnabled, ?string $planLabel): StateMachine
+    {
+        $featureGate = $this->createStub(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn($featureEnabled);
+
+        $upgradePromptProvider = $this->createStub(UpgradePromptProvider::class);
+        $upgradePromptProvider->method('menuLabel')->willReturn($planLabel);
+
+        $listener = new RecurringInvoiceFeatureGuardListener(
+            $featureGate,
+            $upgradePromptProvider,
+            new Translator('en'),
+        );
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            'workflow.recurring_invoice.guard.activate',
+            $listener->onGuardActivate(...),
+        );
+
+        return $this->makeStateMachine($dispatcher);
+    }
+
+    private function makeStateMachine(EventDispatcher $dispatcher): StateMachine
+    {
+        $definition = (new DefinitionBuilder())
+            ->addPlaces([
+                RecurringInvoiceStatus::New->value,
+                RecurringInvoiceStatus::Draft->value,
+                RecurringInvoiceStatus::Active->value,
+            ])
+            ->addTransition(new Transition('activate', RecurringInvoiceStatus::Draft->value, RecurringInvoiceStatus::Active->value))
+            ->build();
+
+        return new StateMachine(
+            $definition,
+            new MethodMarkingStore(true, 'statusValue'),
+            $dispatcher,
+            'recurring_invoice',
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Functional/UpgradePromptProviderWiringTest.php
+++ b/src/SaasBundle/Tests/Functional/UpgradePromptProviderWiringTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Override;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer;
+use SolidInvoice\SaasBundle\Tests\SaasTestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Verifies the `UpgradePromptProvider` interface resolves to
+ * `UpgradePromptRenderer` when SaasBundle is loaded. The CoreBundle no-op
+ * binding (`NullUpgradePromptProvider`) is exercised by the gate tests'
+ * self-hosted assertions.
+ */
+final class UpgradePromptProviderWiringTest extends KernelTestCase
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[Override]
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new SaasTestKernel('test', true);
+    }
+
+    public function testUpgradePromptProviderResolvesToUpgradePromptRenderer(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+        $id = 'test.' . UpgradePromptProvider::class;
+
+        self::assertTrue($container->has($id));
+        self::assertInstanceOf(UpgradePromptRenderer::class, $container->get($id));
+    }
+}

--- a/src/SaasBundle/Tests/Functional/UserInviteQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/UserInviteQuotaGateTest.php
@@ -35,26 +35,20 @@ final class UserInviteQuotaGateTest extends WebTestCase
     use EnsureApplicationInstalled;
     use Factories;
 
+    private const string GATED_HEADLINE = 'Team seat limit reached';
+
     public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
         $featureGate = $this->buildFeatureGate(['team_seats' => false]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'team_seats'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for seats</strong></div>'
-                : '');
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testUnderQuotaBypassesBanner(): void
@@ -63,17 +57,12 @@ final class UserInviteQuotaGateTest extends WebTestCase
 
         $featureGate = $this->buildFeatureGate(['team_seats' => true]);
 
-        $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
-        $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->method('prompt')->willReturn('');
-
         self::getContainer()->set(FeatureGate::class, $featureGate);
-        self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
         $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     public function testSelfHostedBypassesBanner(): void
@@ -92,7 +81,7 @@ final class UserInviteQuotaGateTest extends WebTestCase
         $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString(self::GATED_HEADLINE, (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Functional/UserInviteQuotaGateTest.php
+++ b/src/SaasBundle/Tests/Functional/UserInviteQuotaGateTest.php
@@ -24,60 +24,59 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
- * Verifies the SaaS feature-gate short-circuits the InvoiceBundle CreateRecurring
- * action with the upgrade banner when the `recurring_invoices` feature is
- * disabled, and lets the form render normally when the feature is enabled or
- * in self-hosted mode.
+ * Verifies the SaaS feature-gate short-circuits the UserBundle InviteUser action
+ * with the upgrade banner when the `team_seats` quota is exhausted, and lets
+ * the form render normally when under quota or in self-hosted mode.
  *
  * @group functional
  */
-final class RecurringInvoiceCreateGateTest extends WebTestCase
+final class UserInviteQuotaGateTest extends WebTestCase
 {
     use EnsureApplicationInstalled;
     use Factories;
 
-    public function testGatedCreateRendersUpgradeBanner(): void
+    public function testAtLimitRendersUpgradeBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => false]);
+        $featureGate = $this->buildFeatureGate(['team_seats' => false]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('prompt')
-            ->willReturnCallback(static fn (string $key): string => $key === 'recurring_invoices'
-                ? '<div class="alert alert-warning"><strong>Upgrade required for recurring</strong></div>'
+            ->willReturnCallback(static fn (string $key): string => $key === 'team_seats'
+                ? '<div class="alert alert-warning"><strong>Upgrade required for seats</strong></div>'
                 : '');
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
     }
 
-    public function testUngatedCreateBypassesBanner(): void
+    public function testUnderQuotaBypassesBanner(): void
     {
         $client = $this->bootClient();
 
-        $featureGate = $this->buildFeatureGate(['recurring_invoices' => true]);
+        $featureGate = $this->buildFeatureGate(['team_seats' => true]);
 
         $upgradePromptProvider = $this->createMock(UpgradePromptProvider::class);
         $upgradePromptProvider->method('menuLabel')->willReturn(null);
-        $upgradePromptProvider->expects(self::never())->method('prompt');
+        $upgradePromptProvider->method('prompt')->willReturn('');
 
         self::getContainer()->set(FeatureGate::class, $featureGate);
         self::getContainer()->set(UpgradePromptProvider::class, $upgradePromptProvider);
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
     }
 
-    public function testSelfHostedCreateBypassesBanner(): void
+    public function testSelfHostedBypassesBanner(): void
     {
         $client = $this->bootClient();
 
@@ -90,10 +89,10 @@ final class RecurringInvoiceCreateGateTest extends WebTestCase
             self::assertInstanceOf(NullUpgradePromptProvider::class, $container->get($providerId));
         }
 
-        $client->request('GET', '/invoices/recurring/create');
+        $client->request('GET', '/users/invite');
 
         self::assertResponseIsSuccessful();
-        self::assertStringNotContainsString('Upgrade required for recurring', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('Upgrade required for seats', (string) $client->getResponse()->getContent());
     }
 
     /**

--- a/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
+++ b/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
@@ -262,7 +262,7 @@ final class SubscriptionVoterTest extends KernelTestCase
     {
         $featureGate = M::mock(FeatureGate::class);
         $featureGate->shouldReceive('isEnabled')
-            ->withArgs(static fn (string $key, ?object $for): bool => $key === $disabledKey)
+            ->withArgs(static fn (string $key, ?object $_for): bool => $key === $disabledKey)
             ->andReturn(false);
         $featureGate->shouldReceive('isEnabled')->andReturn(true);
 

--- a/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
+++ b/src/SaasBundle/Tests/Security/Voter/SubscriptionVoterTest.php
@@ -24,6 +24,8 @@ use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\McpBundle\Security\Attribute as McpAttribute;
 use SolidInvoice\SaasBundle\Security\Voter\SubscriptionVoter;
 use SolidInvoice\SaasBundle\Service\SubscriptionEligibility;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use SolidWorx\Platform\PlatformBundle\Feature\NoopFeatureGate;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
@@ -201,6 +203,7 @@ final class SubscriptionVoterTest extends KernelTestCase
             new SubscriptionEligibility($provider, M::mock(ClockInterface::class)),
             $container->get(CompanySelector::class),
             $container->get(CompanyRepository::class),
+            new NoopFeatureGate(),
         );
 
         self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
@@ -214,6 +217,56 @@ final class SubscriptionVoterTest extends KernelTestCase
         );
 
         self::assertDeniedWithReason($voter, $attribute, 'Your subscription is not currently active.');
+    }
+
+    public function testDeniesWhenRestApiAccessFeatureIsDisabled(): void
+    {
+        $voter = $this->createVoter(
+            subscription: $this->createSubscription(SubscriptionStatus::ACTIVE),
+            featureGate: $this->featureGateDenying('rest_api_access'),
+        );
+
+        self::assertDeniedWithReason(
+            $voter,
+            ApiAttribute::ACCESS,
+            'REST API access is not available on the current plan.',
+        );
+    }
+
+    public function testDeniesWhenMcpAccessFeatureIsDisabled(): void
+    {
+        $voter = $this->createVoter(
+            subscription: $this->createSubscription(SubscriptionStatus::ACTIVE),
+            featureGate: $this->featureGateDenying('mcp_access'),
+        );
+
+        self::assertDeniedWithReason(
+            $voter,
+            McpAttribute::ACCESS,
+            'MCP access is not available on the current plan.',
+        );
+    }
+
+    #[DataProvider('provideAttributes')]
+    public function testGrantsWhenSubscriptionActiveAndFeatureGateAllows(string $attribute): void
+    {
+        $voter = $this->createVoter(
+            subscription: $this->createSubscription(SubscriptionStatus::ACTIVE),
+            featureGate: new NoopFeatureGate(),
+        );
+
+        self::assertVoteResult(VoterInterface::ACCESS_GRANTED, $voter, $attribute);
+    }
+
+    private function featureGateDenying(string $disabledKey): FeatureGate
+    {
+        $featureGate = M::mock(FeatureGate::class);
+        $featureGate->shouldReceive('isEnabled')
+            ->withArgs(static fn (string $key, ?object $for): bool => $key === $disabledKey)
+            ->andReturn(false);
+        $featureGate->shouldReceive('isEnabled')->andReturn(true);
+
+        return $featureGate;
     }
 
     private static function assertVoteResult(int $expected, SubscriptionVoter $voter, string $attribute): void
@@ -233,6 +286,7 @@ final class SubscriptionVoterTest extends KernelTestCase
     private function createVoter(
         ?Subscription $subscription = null,
         ?DateTimeImmutable $now = null,
+        ?FeatureGate $featureGate = null,
     ): SubscriptionVoter {
         $container = self::getContainer();
 
@@ -246,6 +300,7 @@ final class SubscriptionVoterTest extends KernelTestCase
             new SubscriptionEligibility($subscriptionProvider, $clock),
             $container->get(CompanySelector::class),
             $container->get(CompanyRepository::class),
+            $featureGate ?? $container->get(FeatureGate::class),
         );
     }
 

--- a/src/SaasBundle/Twig/FeatureExtension.php
+++ b/src/SaasBundle/Twig/FeatureExtension.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Twig;
+
+use Override;
+use SolidInvoice\SaasBundle\Feature\UpgradePromptRenderer;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Twig functions for SaaS-only upgrade UI: required-plan label, locked-feature
+ * prompt, and the approaching-limit usage banner.
+ *
+ * The three "read-only" feature questions (`feature_enabled`, `feature_can_use`,
+ * `feature_remaining`) are already exposed by `SolidWorx\Platform\PlatformBundle\Twig\Extension\FeatureExtension`,
+ * which is loaded in every deployment. We deliberately do *not* re-register
+ * those three names here to avoid Twig "function already defined" errors;
+ * SaaS deployments inherit them from the platform extension and they resolve
+ * via the gate alias (NoopFeatureGate / PlanFeatureGate) automatically.
+ *
+ * In self-hosted deployments where SaasBundle is not loaded, the no-op
+ * SolidInvoice\CoreBundle\Twig\Extension\FeatureExtension provides the three
+ * SaaS-only names so templates can call them unconditionally.
+ */
+final class FeatureExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly UpgradePromptRenderer $renderer,
+        private readonly FeatureGate $gate,
+    ) {
+    }
+
+    /**
+     * @return list<TwigFunction>
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'feature_required_plan_label',
+                $this->requiredPlanLabel(...),
+            ),
+            new TwigFunction(
+                'upgrade_prompt',
+                $this->upgradePrompt(...),
+                ['is_safe' => ['html']],
+            ),
+            new TwigFunction(
+                'feature_usage_banner',
+                $this->usageBanner(...),
+                ['is_safe' => ['html']],
+            ),
+        ];
+    }
+
+    public function requiredPlanLabel(string $featureKey): ?string
+    {
+        if ($this->gate->isEnabled($featureKey)) {
+            return null;
+        }
+
+        return $this->renderer->menuLabel($featureKey);
+    }
+
+    public function upgradePrompt(string $featureKey): string
+    {
+        if ($this->gate->isEnabled($featureKey)) {
+            return '';
+        }
+
+        return $this->renderer->prompt($featureKey);
+    }
+
+    public function usageBanner(string $featureKey, int $currentUsage = 0): string
+    {
+        return $this->renderer->usageBanner($featureKey, $currentUsage);
+    }
+}

--- a/src/SettingsBundle/Form/Type/SettingsType.php
+++ b/src/SettingsBundle/Form/Type/SettingsType.php
@@ -54,6 +54,7 @@ class SettingsType extends AbstractType
             });
 
             $isTrialRestricted = $formOptions['trial_restricted'] ?? false;
+            $featureGated = $formOptions['feature_gated'] ?? null;
 
             if ($isTrialRestricted && $options['subscription_in_trial']) {
                 // Use default value instead of stored value during trial
@@ -66,9 +67,13 @@ class SettingsType extends AbstractType
             // Add trial-related options that will be handled by TrialRestrictedExtension
             $fieldOptions['subscription_in_trial'] = $options['subscription_in_trial'];
             $fieldOptions['trial_restricted'] = $isTrialRestricted;
+            $fieldOptions['feature_gated'] = $featureGated;
 
-            // Merge remaining form options from Config (excluding our trial-specific options)
-            $additionalOptions = array_diff_key($formOptions, ['trial_restricted' => true]);
+            // Merge remaining form options from Config (excluding our consumed options)
+            $additionalOptions = array_diff_key(
+                $formOptions,
+                ['trial_restricted' => true, 'feature_gated' => true],
+            );
             $fieldOptions = array_merge($fieldOptions, $additionalOptions);
 
             $builder->add($key, $setting->getType(), $fieldOptions);

--- a/src/SettingsBundle/Repository/SettingsRepository.php
+++ b/src/SettingsBundle/Repository/SettingsRepository.php
@@ -49,7 +49,7 @@ class SettingsRepository extends ServiceEntityRepository
         try {
             $entityManager->wrapInTransaction(function () use ($settings): void {
                 foreach ($settings as $key => $value) {
-                    if ('system/company/custom_domain' === $key) {
+                    if ('system/domain/custom_domain' === $key) {
                         $companyRepository = $this->getEntityManager()->getRepository(Company::class);
                         assert($companyRepository instanceof CompanyRepository);
                         $value = $companyRepository->updateCustomDomain(empty($value) ? null : $value);

--- a/src/SettingsBundle/Resources/views/Components/Settings.html.twig
+++ b/src/SettingsBundle/Resources/views/Components/Settings.html.twig
@@ -139,59 +139,60 @@
                         </div>
                     {% endif %}
 
-                    {# Custom Domain Section #}
-                    {% if form.company.custom_domain is defined %}
-                        <div class="mb-4 pb-4 border-bottom">
-                            <h3 class="d-flex align-items-center gap-2 mb-3">
-                                {{ ux_icon('tabler:world', {width: 22, height: 22, class: 'text-primary', 'aria-hidden': 'true'}) }}
-                                {{ 'Custom Domain'|trans }}
-                            </h3>
-                            <p class="text-muted small mb-3">
-                                {{ 'Serve SolidInvoice from your own domain (e.g. invoices.yourcompany.com) instead of the default URL.'|trans }}
-                            </p>
-                            {{ form_row(form.company.custom_domain, {
-                                label: 'Custom Domain'|trans,
-                                attr: {placeholder: 'invoices.yourcompany.com'}
-                            }) }}
+                {% endif %}
 
-                            {% if custom_domain_dns_record is not empty %}
-                                <div class="alert alert-info mt-3" role="alert">
-                                    <div class="d-flex">
-                                        <div class="me-3">
-                                            {{ ux_icon('tabler:info-circle', {width: 24, height: 24, 'aria-hidden': 'true'}) }}
+                {# Domain Section #}
+                {% if form.domain is defined and form.domain.custom_domain is defined %}
+                    <div class="mb-4 pb-4 border-bottom">
+                        <h3 class="d-flex align-items-center gap-2 mb-3">
+                            {{ ux_icon('tabler:world', {width: 22, height: 22, class: 'text-primary', 'aria-hidden': 'true'}) }}
+                            {{ 'Domain'|trans }}
+                        </h3>
+                        <p class="text-muted small mb-3">
+                            {{ 'Serve SolidInvoice from your own domain (e.g. invoices.yourcompany.com) instead of the default URL.'|trans }}
+                        </p>
+                        {{ form_row(form.domain.custom_domain, {
+                            label: 'Custom Domain'|trans,
+                            attr: {placeholder: 'invoices.yourcompany.com'}
+                        }) }}
+
+                        {% if custom_domain_dns_record is not empty %}
+                            <div class="alert alert-info mt-3" role="alert">
+                                <div class="d-flex">
+                                    <div class="me-3">
+                                        {{ ux_icon('tabler:info-circle', {width: 24, height: 24, 'aria-hidden': 'true'}) }}
+                                    </div>
+                                    <div class="flex-grow-1">
+                                        <h4 class="alert-title mb-1">{{ 'DNS setup required'|trans }}</h4>
+                                        <p class="mb-2">
+                                            {{ 'After saving, add a CNAME record at your DNS provider so your domain points to SolidInvoice. DNS changes can take up to 24 hours to propagate.'|trans }}
+                                        </p>
+                                        <div class="table-responsive">
+                                            <table class="table table-sm table-bordered mb-2 align-middle">
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="col">{{ 'Type'|trans }}</th>
+                                                        <th scope="col">{{ 'Name / Host'|trans }}</th>
+                                                        <th scope="col">{{ 'Value / Target'|trans }}</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td><code>CNAME</code></td>
+                                                        <td><code>{{ form.domain.custom_domain.vars.value|default('invoices.yourcompany.com') }}</code></td>
+                                                        <td><code>{{ custom_domain_dns_record }}</code></td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
                                         </div>
-                                        <div class="flex-grow-1">
-                                            <h4 class="alert-title mb-1">{{ 'DNS setup required'|trans }}</h4>
-                                            <p class="mb-2">
-                                                {{ 'After saving, add a CNAME record at your DNS provider so your domain points to SolidInvoice. DNS changes can take up to 24 hours to propagate.'|trans }}
-                                            </p>
-                                            <div class="table-responsive">
-                                                <table class="table table-sm table-bordered mb-2 align-middle">
-                                                    <thead>
-                                                        <tr>
-                                                            <th scope="col">{{ 'Type'|trans }}</th>
-                                                            <th scope="col">{{ 'Name / Host'|trans }}</th>
-                                                            <th scope="col">{{ 'Value / Target'|trans }}</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        <tr>
-                                                            <td><code>CNAME</code></td>
-                                                            <td><code>{{ form.company.custom_domain.vars.value|default('invoices.yourcompany.com') }}</code></td>
-                                                            <td><code>{{ custom_domain_dns_record }}</code></td>
-                                                        </tr>
-                                                    </tbody>
-                                                </table>
-                                            </div>
-                                            <p class="text-muted small mb-0">
-                                                {{ 'Once the CNAME is in place, your custom domain will resolve to SolidInvoice automatically — no further action required.'|trans }}
-                                            </p>
-                                        </div>
+                                        <p class="text-muted small mb-0">
+                                            {{ 'Once the CNAME is in place, your custom domain will resolve to SolidInvoice automatically — no further action required.'|trans }}
+                                        </p>
                                     </div>
                                 </div>
-                            {% endif %}
-                        </div>
-                    {% endif %}
+                            </div>
+                        {% endif %}
+                    </div>
                 {% endif %}
 
                 {# General Settings Section #}

--- a/src/SettingsBundle/Resources/views/Form/fields.html.twig
+++ b/src/SettingsBundle/Resources/views/Form/fields.html.twig
@@ -11,7 +11,29 @@
 
 {# Trial-Restricted Form Row #}
 {% block checkbox_row %}
-    {% if trial_restricted_active|default(false) and toggle('saas_enabled') %}
+    {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
+        <div class="mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <label class="form-label">{{ label|trans }}</label>
+                <span class="badge bg-azure-lt">
+                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
+                    {{ 'Subscription Required'|trans }}{% if feature_gated_plan|default(null) %} — {{ feature_gated_plan }}{% endif %}
+                </span>
+            </div>
+
+            {{ parent() }}
+
+            <div class="form-hint text-muted mt-2">
+                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
+                {% if feature_gated_plan|default(null) %}
+                    {{ 'This feature is available on the %plan% plan. Upgrade to unlock it.'|trans({'%plan%': feature_gated_plan}) }}
+                {% else %}
+                    {{ 'This feature requires a higher plan. Upgrade now to unlock it.'|trans }}
+                {% endif %}
+                <a href="{{ path('saas_subscription_plans') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
+            </div>
+        </div>
+    {% elseif trial_restricted_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label">{{ label|trans }}</label>
@@ -35,7 +57,29 @@
 {% endblock %}
 
 {% block form_row %}
-    {% if trial_restricted_active|default(false) and toggle('saas_enabled') %}
+    {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
+        <div class="mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <label class="form-label">{{ label|trans }}</label>
+                <span class="badge bg-azure-lt">
+                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
+                    {{ 'Subscription Required'|trans }}{% if feature_gated_plan|default(null) %} — {{ feature_gated_plan }}{% endif %}
+                </span>
+            </div>
+
+            {{ form_widget(form) }}
+
+            <div class="form-hint text-muted mt-2">
+                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
+                {% if feature_gated_plan|default(null) %}
+                    {{ 'This feature is available on the %plan% plan. Upgrade to unlock it.'|trans({'%plan%': feature_gated_plan}) }}
+                {% else %}
+                    {{ 'This feature requires a higher plan. Upgrade now to unlock it.'|trans }}
+                {% endif %}
+                <a href="{{ path('saas_subscription_plans') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
+            </div>
+        </div>
+    {% elseif trial_restricted_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label">{{ label|trans }}</label>

--- a/src/SettingsBundle/Resources/views/Form/fields.html.twig
+++ b/src/SettingsBundle/Resources/views/Form/fields.html.twig
@@ -14,14 +14,17 @@
     {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-                <label class="form-label">{{ label|trans }}</label>
+                <label class="form-label mb-0">{{ label|trans }}</label>
                 <span class="badge bg-azure-lt">
                     {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
                     {{ 'Subscription Required'|trans }}{% if feature_gated_plan|default(null) %} — {{ feature_gated_plan }}{% endif %}
                 </span>
             </div>
 
-            {{ parent() }}
+            {# Suppress the inner switch label to avoid duplicate-label visual #}
+            {{ form_widget(form, {parent_label_class: 'checkbox-switch', label: false}) }}
+            {{ form_help(form) }}
+            {{ form_errors(form) }}
 
             <div class="form-hint text-muted mt-2">
                 {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
@@ -36,14 +39,17 @@
     {% elseif trial_restricted_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-                <label class="form-label">{{ label|trans }}</label>
+                <label class="form-label mb-0">{{ label|trans }}</label>
                 <span class="badge bg-azure-lt">
                     {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
                     {{ 'Subscription Required'|trans }}
                 </span>
             </div>
 
-            {{ parent() }}
+            {# Suppress the inner switch label to avoid duplicate-label visual #}
+            {{ form_widget(form, {parent_label_class: 'checkbox-switch', label: false}) }}
+            {{ form_help(form) }}
+            {{ form_errors(form) }}
 
             <div class="form-hint text-muted mt-2">
                 {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}

--- a/src/SettingsBundle/Resources/views/Form/fields.html.twig
+++ b/src/SettingsBundle/Resources/views/Form/fields.html.twig
@@ -38,10 +38,9 @@
     </a>
 {% endmacro %}
 
-{% import _self as upgrade %}
-
 {# Trial-Restricted Form Row #}
 {% block checkbox_row %}
+    {% import _self as upgrade %}
     {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
@@ -72,6 +71,7 @@
 {% endblock %}
 
 {% block form_row %}
+    {% import _self as upgrade %}
     {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">

--- a/src/SettingsBundle/Resources/views/Form/fields.html.twig
+++ b/src/SettingsBundle/Resources/views/Form/fields.html.twig
@@ -9,53 +9,62 @@
 
 {% extends '@SolidInvoiceCore/Form/fields.html.twig' %}
 
+{#
+ # Compact upgrade badge — clickable link to the SaaS plan picker / checkout that
+ # carries the plan name as both the visible label and the hover tooltip. Used in
+ # place of the previous static "Subscription Required" badge + bulky form-hint.
+ #}
+{% macro feature_gated_badge(plan) %}
+    <a href="{{ path('saas_subscription_plans') }}"
+       class="badge bg-azure-lt text-decoration-none text-azure"
+       title="{{ plan
+            ? 'Upgrade to %plan% to unlock this feature'|trans({'%plan%': plan})
+            : 'Upgrade your plan to unlock this feature'|trans }}">
+        {{ ux_icon('tabler:arrow-up-circle', {width: 14, height: 14, class: 'me-1'}) }}
+        {%- if plan -%}
+            {{ 'Upgrade to %plan%'|trans({'%plan%': plan}) }}
+        {%- else -%}
+            {{ 'Upgrade plan'|trans }}
+        {%- endif -%}
+    </a>
+{% endmacro %}
+
+{% macro trial_restricted_badge() %}
+    <a href="{{ path('saas_subscription_checkout') }}"
+       class="badge bg-azure-lt text-decoration-none text-azure"
+       title="{{ 'Activate your subscription to unlock this feature'|trans }}">
+        {{ ux_icon('tabler:arrow-up-circle', {width: 14, height: 14, class: 'me-1'}) }}
+        {{ 'Activate subscription'|trans }}
+    </a>
+{% endmacro %}
+
+{% import _self as upgrade %}
+
 {# Trial-Restricted Form Row #}
 {% block checkbox_row %}
     {% if feature_gated_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label mb-0">{{ label|trans }}</label>
-                <span class="badge bg-azure-lt">
-                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                    {{ 'Subscription Required'|trans }}{% if feature_gated_plan|default(null) %} — {{ feature_gated_plan }}{% endif %}
-                </span>
+                {{ upgrade.feature_gated_badge(feature_gated_plan|default(null)) }}
             </div>
 
             {# Suppress the inner switch label to avoid duplicate-label visual #}
             {{ form_widget(form, {parent_label_class: 'checkbox-switch', label: false}) }}
             {{ form_help(form) }}
             {{ form_errors(form) }}
-
-            <div class="form-hint text-muted mt-2">
-                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                {% if feature_gated_plan|default(null) %}
-                    {{ 'This feature is available on the %plan% plan. Upgrade to unlock it.'|trans({'%plan%': feature_gated_plan}) }}
-                {% else %}
-                    {{ 'This feature requires a higher plan. Upgrade now to unlock it.'|trans }}
-                {% endif %}
-                <a href="{{ path('saas_subscription_plans') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
-            </div>
         </div>
     {% elseif trial_restricted_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label mb-0">{{ label|trans }}</label>
-                <span class="badge bg-azure-lt">
-                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                    {{ 'Subscription Required'|trans }}
-                </span>
+                {{ upgrade.trial_restricted_badge() }}
             </div>
 
             {# Suppress the inner switch label to avoid duplicate-label visual #}
             {{ form_widget(form, {parent_label_class: 'checkbox-switch', label: false}) }}
             {{ form_help(form) }}
             {{ form_errors(form) }}
-
-            <div class="form-hint text-muted mt-2">
-                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                {{ 'This feature requires an active subscription. Upgrade your plan now to unlock this feature.'|trans }}
-                <a href="{{ path('saas_subscription_checkout') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
-            </div>
         </div>
     {% else %}
         {{ parent() }}
@@ -67,41 +76,19 @@
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label">{{ label|trans }}</label>
-                <span class="badge bg-azure-lt">
-                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                    {{ 'Subscription Required'|trans }}{% if feature_gated_plan|default(null) %} — {{ feature_gated_plan }}{% endif %}
-                </span>
+                {{ upgrade.feature_gated_badge(feature_gated_plan|default(null)) }}
             </div>
 
             {{ form_widget(form) }}
-
-            <div class="form-hint text-muted mt-2">
-                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                {% if feature_gated_plan|default(null) %}
-                    {{ 'This feature is available on the %plan% plan. Upgrade to unlock it.'|trans({'%plan%': feature_gated_plan}) }}
-                {% else %}
-                    {{ 'This feature requires a higher plan. Upgrade now to unlock it.'|trans }}
-                {% endif %}
-                <a href="{{ path('saas_subscription_plans') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
-            </div>
         </div>
     {% elseif trial_restricted_active|default(false) and toggle('saas_enabled') %}
         <div class="mb-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <label class="form-label">{{ label|trans }}</label>
-                <span class="badge bg-azure-lt">
-                    {{ ux_icon('tabler:alert-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                    {{ 'Subscription Required'|trans }}
-                </span>
+                {{ upgrade.trial_restricted_badge() }}
             </div>
 
             {{ form_widget(form) }}
-
-            <div class="form-hint text-muted mt-2">
-                {{ ux_icon('tabler:info-circle', {width: 16, height: 16, class: 'me-1'}) }}
-                {{ 'This feature requires an active subscription. Upgrade your plan now to unlock this feature.'|trans }}
-                <a href="{{ path('saas_subscription_checkout') }}" class="ms-1">{{ 'Upgrade Now'|trans }}</a>
-            </div>
         </div>
     {% else %}
         {{ parent() }}

--- a/src/SettingsBundle/Tests/DTO/ConfigTest.php
+++ b/src/SettingsBundle/Tests/DTO/ConfigTest.php
@@ -68,4 +68,32 @@ final class ConfigTest extends TestCase
         self::assertArrayHasKey('trial_restricted', $config->formOptions);
         self::assertTrue($config->formOptions['trial_restricted']);
     }
+
+    public function testConfigWithFeatureGatedOption(): void
+    {
+        $config = new Config(
+            'system/general/hide_powered_by',
+            '0',
+            'Hide powered by text',
+            TextType::class,
+            ['feature_gated' => 'custom_branding']
+        );
+
+        self::assertArrayHasKey('feature_gated', $config->formOptions);
+        self::assertSame('custom_branding', $config->formOptions['feature_gated']);
+    }
+
+    public function testConfigSupportsFeatureGatedAndTrialRestrictedTogether(): void
+    {
+        $config = new Config(
+            'system/general/some_setting',
+            null,
+            null,
+            TextType::class,
+            ['feature_gated' => 'custom_branding', 'trial_restricted' => true]
+        );
+
+        self::assertSame('custom_branding', $config->formOptions['feature_gated']);
+        self::assertTrue($config->formOptions['trial_restricted']);
+    }
 }

--- a/src/UserBundle/Action/ApiIndex.php
+++ b/src/UserBundle/Action/ApiIndex.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Action;
 
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,16 +22,13 @@ final class ApiIndex extends AbstractController
 {
     public function __construct(
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
     public function __invoke(Request $request): Response
     {
         if (! $this->featureGate->isEnabled('rest_api_access')) {
-            return $this->render('@SolidInvoiceUser/Api/gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt('rest_api_access'),
-            ]);
+            return $this->render('@SolidInvoiceUser/Api/gated.html.twig');
         }
 
         return $this->render('@SolidInvoiceUser/Api/index.html.twig');

--- a/src/UserBundle/Action/ApiIndex.php
+++ b/src/UserBundle/Action/ApiIndex.php
@@ -13,17 +13,28 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Action;
 
-use Symfony\Bridge\Twig\Attribute\Template;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-final class ApiIndex
+final class ApiIndex extends AbstractController
 {
-    /**
-     * @return array{}
-     */
-    #[Template('@SolidInvoiceUser/Api/index.html.twig')]
-    public function __invoke(Request $request): array
+    public function __construct(
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
     {
-        return [];
+        if (! $this->featureGate->isEnabled('rest_api_access')) {
+            return $this->render('@SolidInvoiceUser/Api/gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt('rest_api_access'),
+            ]);
+        }
+
+        return $this->render('@SolidInvoiceUser/Api/index.html.twig');
     }
 }

--- a/src/UserBundle/Action/InviteUser.php
+++ b/src/UserBundle/Action/InviteUser.php
@@ -16,14 +16,18 @@ namespace SolidInvoice\UserBundle\Action;
 use Exception;
 use Generator;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Response\FlashResponse;
+use SolidInvoice\SaasBundle\Feature\Feature;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\Entity\UserInvitation;
 use SolidInvoice\UserBundle\Form\Type\UserInviteType;
 use SolidInvoice\UserBundle\Repository\UserInvitationRepository;
 use SolidInvoice\UserBundle\Repository\UserRepository;
 use SolidInvoice\UserBundle\UserInvitation\UserInvitation as SendUserInvitation;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -45,6 +49,8 @@ final class InviteUser extends AbstractController
         private readonly ValidatorInterface $validator,
         private readonly SendUserInvitation $userInvitation,
         private readonly UserInvitationRepository $userInvitationRepository,
+        private readonly FeatureGate $featureGate,
+        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -53,6 +59,18 @@ final class InviteUser extends AbstractController
      */
     public function __invoke(Request $request): Response
     {
+        $company = $this->companyRepository->find($this->companySelector->getCompany());
+
+        if ($company instanceof Company && ! $this->featureGate->canUse(
+            Feature::TeamSeats->value,
+            $this->userRepository->getUserCountForCompany($company)
+                + $this->userInvitationRepository->countPending($company),
+        )) {
+            return $this->render('@SolidInvoiceUser/Users/invite_gated.html.twig', [
+                'banner' => $this->upgradePromptProvider->prompt(Feature::TeamSeats->value),
+            ]);
+        }
+
         $form = $this->createForm(UserInviteType::class);
 
         $form->handleRequest($request);
@@ -70,7 +88,7 @@ final class InviteUser extends AbstractController
             $invitedBy = $this->security->getUser();
             assert($invitedBy instanceof User);
 
-            $data->setCompany($this->companyRepository->find($this->companySelector->getCompany()));
+            $data->setCompany($company);
             $data->setInvitedBy($invitedBy);
             $data->setStatus(UserInvitation::STATUS_PENDING);
 

--- a/src/UserBundle/Action/InviteUser.php
+++ b/src/UserBundle/Action/InviteUser.php
@@ -17,7 +17,6 @@ use Exception;
 use Generator;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Company;
-use SolidInvoice\CoreBundle\Feature\UpgradePromptProvider;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Response\FlashResponse;
 use SolidInvoice\SaasBundle\Feature\Feature;
@@ -50,7 +49,6 @@ final class InviteUser extends AbstractController
         private readonly SendUserInvitation $userInvitation,
         private readonly UserInvitationRepository $userInvitationRepository,
         private readonly FeatureGate $featureGate,
-        private readonly UpgradePromptProvider $upgradePromptProvider,
     ) {
     }
 
@@ -66,9 +64,7 @@ final class InviteUser extends AbstractController
             $this->userRepository->getUserCountForCompany($company)
                 + $this->userInvitationRepository->countPending($company),
         )) {
-            return $this->render('@SolidInvoiceUser/Users/invite_gated.html.twig', [
-                'banner' => $this->upgradePromptProvider->prompt(Feature::TeamSeats->value),
-            ]);
+            return $this->render('@SolidInvoiceUser/Users/invite_gated.html.twig');
         }
 
         $form = $this->createForm(UserInviteType::class);

--- a/src/UserBundle/Action/Users.php
+++ b/src/UserBundle/Action/Users.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Action;
 
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\UserBundle\Repository\UserInvitationRepository;
 use SolidInvoice\UserBundle\Repository\UserRepository;
 use Symfony\Bridge\Twig\Attribute\Template;
@@ -22,11 +25,13 @@ final class Users
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly UserInvitationRepository $invitationRepository,
+        private readonly CompanySelector $companySelector,
+        private readonly CompanyRepository $companyRepository,
     ) {
     }
 
     /**
-     * @return array{totalActiveUsers: int, totalPendingInvitations: int, recentlyJoinedCount: int}
+     * @return array{totalActiveUsers: int, totalPendingInvitations: int, recentlyJoinedCount: int, seatsUsage: int}
      */
     #[Template('@SolidInvoiceUser/Users/index.html.twig')]
     public function __invoke(): array
@@ -35,10 +40,17 @@ final class Users
         $totalPendingInvitations = $this->invitationRepository->countPendingInvitations();
         $recentlyJoinedCount = $this->userRepository->getRecentlyJoinedCount(30);
 
+        $company = $this->companyRepository->find($this->companySelector->getCompany());
+        $seatsUsage = $company instanceof Company
+            ? $this->userRepository->getUserCountForCompany($company)
+                + $this->invitationRepository->countPending($company)
+            : 0;
+
         return [
             'totalActiveUsers' => $totalActiveUsers,
             'totalPendingInvitations' => $totalPendingInvitations,
             'recentlyJoinedCount' => $recentlyJoinedCount,
+            'seatsUsage' => $seatsUsage,
         ];
     }
 }

--- a/src/UserBundle/Repository/UserInvitationRepository.php
+++ b/src/UserBundle/Repository/UserInvitationRepository.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\UserBundle\Entity\UserInvitation;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 
@@ -85,7 +86,29 @@ final class UserInvitationRepository extends ServiceEntityRepository
 
         try {
             return (int) $qb->getQuery()->getSingleScalarResult();
-        } catch (NoResultException|NonUniqueResultException|Exception $e) {
+        } catch (NoResultException|NonUniqueResultException|Exception) {
+            return 0;
+        }
+    }
+
+    /**
+     * Counts pending invitations for the given company. Used by the
+     * `team_seats` quota gate to combine with the existing user count
+     * (a sent-but-not-yet-accepted invitation reserves a seat).
+     */
+    public function countPending(Company $company): int
+    {
+        $qb = $this->createQueryBuilder('u');
+
+        $qb->select('COUNT(u.id)')
+            ->where('u.status = :status')
+            ->andWhere('u.company = :companyId')
+            ->setParameter('status', UserInvitation::STATUS_PENDING)
+            ->setParameter('companyId', $company->getId(), UlidType::NAME);
+
+        try {
+            return (int) $qb->getQuery()->getSingleScalarResult();
+        } catch (NoResultException|NonUniqueResultException|Exception) {
             return 0;
         }
     }

--- a/src/UserBundle/Repository/UserRepository.php
+++ b/src/UserBundle/Repository/UserRepository.php
@@ -18,7 +18,9 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Bridge\Doctrine\Types\UlidType;
 
 /**
  * @see \SolidInvoice\UserBundle\Tests\Repository\UserRepositoryTest
@@ -41,6 +43,28 @@ class UserRepository extends \SolidWorx\Platform\PlatformBundle\Repository\UserR
         try {
             return (int) $qb->getQuery()->getSingleScalarResult();
         } catch (NoResultException|NonUniqueResultException|Exception $e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Counts users associated with the given company. Used by the `team_seats`
+     * quota gate. Scoped explicitly via the user-companies join (not the global
+     * `CompanyFilter`, since `User` participates as the *inverse* side of the
+     * Many-to-Many on `Company::users`).
+     */
+    public function getUserCountForCompany(Company $company): int
+    {
+        $qb = $this->createQueryBuilder('u');
+
+        $qb->select('COUNT(u.id)')
+            ->innerJoin('u.companies', 'c')
+            ->where('c.id = :companyId')
+            ->setParameter('companyId', $company->getId(), UlidType::NAME);
+
+        try {
+            return (int) $qb->getQuery()->getSingleScalarResult();
+        } catch (NoResultException|NonUniqueResultException|Exception) {
             return 0;
         }
     }

--- a/src/UserBundle/Resources/views/Api/gated.html.twig
+++ b/src/UserBundle/Resources/views/Api/gated.html.twig
@@ -1,0 +1,18 @@
+{##
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% set menuItem = 'api-tokens' %}
+
+{% extends "@SolidInvoiceUser/Layout/profile.html.twig" %}
+
+{% block title %}{{ ux_icon('tabler:key', {width: 24, height: 24, class: 'me-2'}) }}{{ "profile.api.title"|trans }}{% endblock title %}
+
+{% block profile_content %}
+    {{ banner|raw }}
+{% endblock profile_content %}

--- a/src/UserBundle/Resources/views/Api/gated.html.twig
+++ b/src/UserBundle/Resources/views/Api/gated.html.twig
@@ -14,5 +14,10 @@
 {% block title %}{{ ux_icon('tabler:key', {width: 24, height: 24, class: 'me-2'}) }}{{ "profile.api.title"|trans }}{% endblock title %}
 
 {% block profile_content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'rest_api_access',
+        icon: 'tabler:api',
+        headline: 'Enable the REST API'|trans,
+        description: 'Integrate SolidInvoice with your other tools — manage invoices, clients, and payments programmatically via a full-featured REST API.'|trans,
+    } only %}
 {% endblock profile_content %}

--- a/src/UserBundle/Resources/views/Users/index.html.twig
+++ b/src/UserBundle/Resources/views/Users/index.html.twig
@@ -22,6 +22,8 @@
 {% endblock %}
 
 {% block content %}
+    {{ feature_usage_banner('team_seats', seatsUsage) }}
+
     {# KPI Stats Row #}
     <div class="row row-deck row-cards mb-4">
         <div class="col-sm-6 col-lg-4">

--- a/src/UserBundle/Resources/views/Users/invite_gated.html.twig
+++ b/src/UserBundle/Resources/views/Users/invite_gated.html.twig
@@ -1,0 +1,16 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
+
+{% block title %}{{ 'users.invite_user'|trans }}{% endblock title %}
+
+{% block content %}
+    {{ banner|raw }}
+{% endblock content %}

--- a/src/UserBundle/Resources/views/Users/invite_gated.html.twig
+++ b/src/UserBundle/Resources/views/Users/invite_gated.html.twig
@@ -12,5 +12,10 @@
 {% block title %}{{ 'users.invite_user'|trans }}{% endblock title %}
 
 {% block content %}
-    {{ banner|raw }}
+    {% include '@SolidInvoiceCore/Feature/_gated_page.html.twig' with {
+        feature: 'team_seats',
+        icon: 'tabler:user-plus',
+        headline: 'Team seat limit reached'|trans,
+        description: 'You have hit your plan\'s seat limit. Upgrade to invite more teammates and collaborate together.'|trans,
+    } only %}
 {% endblock content %}

--- a/src/UserBundle/Tests/Repository/UserInvitationRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserInvitationRepositoryTest.php
@@ -93,4 +93,32 @@ final class UserInvitationRepositoryTest extends KernelTestCase
         $alias = $queryBuilder->getRootAliases()[0];
         self::assertCount(1, $queryBuilder->getDQLPart('select'));
     }
+
+    public function testCountPendingScopesByCompany(): void
+    {
+        $executor = $this->databaseTool->loadFixtures([LoadData::class], true);
+        $inviter = $executor->getReferenceRepository()->getReference('user2', User::class);
+
+        $registry = self::getContainer()->get('doctrine');
+        $em = $registry->getManager();
+        $company = $registry->getRepository(Company::class)->find($this->company->getId());
+
+        self::assertSame(0, $this->repository->countPending($company));
+
+        $pending = new UserInvitation();
+        $pending->setEmail($this->faker->email)
+            ->setInvitedBy($inviter)
+            ->setCompany($company)
+            ->setStatus(UserInvitation::STATUS_PENDING);
+        $this->repository->save($pending);
+
+        $accepted = new UserInvitation();
+        $accepted->setEmail($this->faker->email)
+            ->setInvitedBy($inviter)
+            ->setCompany($company)
+            ->setStatus('accepted');
+        $this->repository->save($accepted);
+
+        self::assertSame(1, $this->repository->countPending($company));
+    }
 }

--- a/src/UserBundle/Tests/Repository/UserInvitationRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserInvitationRepositoryTest.php
@@ -100,7 +100,6 @@ final class UserInvitationRepositoryTest extends KernelTestCase
         $inviter = $executor->getReferenceRepository()->getReference('user2', User::class);
 
         $registry = self::getContainer()->get('doctrine');
-        $em = $registry->getManager();
         $company = $registry->getRepository(Company::class)->find($this->company->getId());
 
         self::assertSame(0, $this->repository->countPending($company));
@@ -112,6 +111,7 @@ final class UserInvitationRepositoryTest extends KernelTestCase
             ->setStatus(UserInvitation::STATUS_PENDING);
         $this->repository->save($pending);
 
+        // A same-company invitation in a non-pending status must not be counted.
         $accepted = new UserInvitation();
         $accepted->setEmail($this->faker->email)
             ->setInvitedBy($inviter)

--- a/src/UserBundle/Tests/Repository/UserRepositoryTest.php
+++ b/src/UserBundle/Tests/Repository/UserRepositoryTest.php
@@ -218,4 +218,22 @@ final class UserRepositoryTest extends KernelTestCase
         self::assertCount(1, $queryBuilder->getDQLPart('select'));
         self::assertSame($fields, (string) $queryBuilder->getDQLPart('select')[0]);
     }
+
+    public function testGetUserCountForCompanyOnlyCountsUsersInThatCompany(): void
+    {
+        self::assertSame(0, $this->repository->getUserCountForCompany($this->company));
+
+        $user = new User();
+        $user->setEmail($this->faker->email)
+            ->setPassword($this->faker->password)
+            ->addCompany($this->company);
+        $this->repository->save($user);
+
+        $userInOtherCompany = new User();
+        $userInOtherCompany->setEmail($this->faker->email)
+            ->setPassword($this->faker->password);
+        $this->repository->save($userInOtherCompany);
+
+        self::assertSame(1, $this->repository->getUserCountForCompany($this->company));
+    }
 }

--- a/src/UserBundle/Twig/Components/CreateApiToken.php
+++ b/src/UserBundle/Twig/Components/CreateApiToken.php
@@ -17,9 +17,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use SolidInvoice\ApiBundle\ApiTokenManager;
 use SolidInvoice\UserBundle\Entity\ApiToken;
 use SolidInvoice\UserBundle\Form\Type\ApiTokenType;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -45,6 +47,7 @@ final class CreateApiToken extends AbstractController
     public function __construct(
         private readonly Security $security,
         private readonly ApiTokenManager $apiTokenManager,
+        private readonly FeatureGate $featureGate,
     ) {
     }
 
@@ -71,6 +74,10 @@ final class CreateApiToken extends AbstractController
     #[LiveAction]
     public function save(EntityManagerInterface $entityManager): void
     {
+        if (! $this->featureGate->isEnabled('rest_api_access')) {
+            throw new AccessDeniedException('REST API access is not available on the current plan.');
+        }
+
         // Submit the form! If validation fails, an exception is thrown
         // and the component is automatically re-rendered with the errors
         $this->submitForm();

--- a/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
+++ b/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
@@ -91,9 +91,17 @@
     {% endif %}
 {% endblock %}
 
+{# Plan-label upgrade badge — renders on its own line BELOW the menu title so
+   the plan name is always fully visible regardless of sidebar width and never
+   clipped by the dropdown-toggle chevron. Uses Tabler's primary tone for clear
+   contrast against the sidebar background. #}
 {% block planLabelBadge %}
     {% if item.extras.plan_label is defined and item.extras.plan_label %}
-        <span class="badge badge-sm bg-blue-lt ms-auto flex-shrink-0 fw-normal" title="{{ 'Upgrade to %plan%'|trans({'%plan%': item.extras.plan_label}) }}">{{ item.extras.plan_label }}</span>
+        <span class="d-block mt-1 text-primary fw-medium"
+              style="font-size: 0.7rem;"
+              title="{{ 'Upgrade to %plan% to unlock'|trans({'%plan%': item.extras.plan_label}) }}">
+            {{ ux_icon('tabler:arrow-up-circle', {width: 12, height: 12, class: 'me-1'}) }}{{ 'Upgrade to %plan%'|trans({'%plan%': item.extras.plan_label}) }}
+        </span>
     {% endif %}
 {% endblock %}
 
@@ -107,8 +115,8 @@
             {% endif %}
             <span class="nav-link-title">
                 {{ block('label') }}
+                {{ block('planLabelBadge') }}
             </span>
-            {{ block('planLabelBadge') }}
         </a>
     {% else %}
         <span{{ ui.attributes(item.labelAttributes) }}>
@@ -127,8 +135,8 @@
         {% endif %}
         <span class="nav-link-title">
             {{ block('label') }}
+            {{ block('planLabelBadge') }}
         </span>
-        {{ block('planLabelBadge') }}
     </a>
 {% endblock %}
 

--- a/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
+++ b/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
@@ -1,0 +1,141 @@
+{#
+# This file is part of SolidInvoice project.
+#
+# (c) Pierre du Plessis <open-source@solidworx.co>
+#
+# This source file is subject to the MIT license that is bundled
+# with this source code in the file LICENSE.
+#
+# Overrides @SolidWorxPlatform/Menu/menu.html.twig to render an optional
+# Tabler `plan_label` badge alongside menu items when a feature is gated.
+# Items set `extras.plan_label` (e.g. 'Solo', 'Business') from menu builders
+# that consult the SaaS UpgradePromptProvider.
+#}
+
+{% extends 'knp_menu.html.twig' %}
+{% import 'knp_menu.html.twig' as ui %}
+
+{% block list %}
+    {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
+        {% if item.level == 0 %}
+            <ul{{ ui.attributes(listAttributes|merge({'class': 'navbar-nav pt-lg-3'})) }}>
+                {{ block('children') }}
+            </ul>
+        {% else %}
+            {% set ddClass = 'dropdown-menu' ~ ( (matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth)) ? ' show' : '' ) %}
+            <div class="{{ ddClass }}" data-bs-popper="static">
+                <div class="dropdown-menu-columns">
+                    <div class="dropdown-menu-column">
+                        {{ block('children') }}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
+{% block item %}
+    {% if item.displayed %}
+        {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
+        {%- if matcher.isCurrent(item) %}
+            {%- set classes = classes|merge([options.currentClass, 'active']) %}
+        {%- elseif matcher.isAncestor(item, options.matchingDepth) %}
+            {%- set classes = classes|merge([options.ancestorClass, 'active']) %}
+        {%- endif %}
+        {%- if item.actsLikeFirst %}
+            {%- set classes = classes|merge([options.firstClass]) %}
+        {%- endif %}
+        {%- if item.actsLikeLast %}
+            {%- set classes = classes|merge([options.lastClass]) %}
+        {%- endif %}
+
+        {% if item.hasChildren and options.depth is not same as(0) %}
+            {% if options.branch_class is not empty and item.displayChildren %}
+                {%- set classes = classes|merge([options.branch_class]) %}
+            {% endif %}
+        {% elseif options.leaf_class is not empty %}
+            {%- set classes = classes|merge([options.leaf_class]) %}
+        {%- endif %}
+
+        {%- set tag = '' %}
+
+        {% if item.parent.isRoot %}
+            {%- set classes = classes|merge(['nav-item']) %}
+            {%- set tag = 'li' %}
+        {% endif %}
+
+        {%- set attributes = item.attributes %}
+        {%- if classes is not empty %}
+            {%- set attributes = attributes|merge({class: classes|join(' ')}) %}
+        {%- endif %}
+
+        {% if tag is not empty %}
+            <{{ tag }}{{ ui.attributes(attributes) }}>
+        {% endif %}
+
+        {%- if item.uri is not empty and (not matcher.isCurrent(item) or options.currentAsLink) %}
+            {% set linkAttributes = item.linkAttributes|merge({'class': (not item.parent.isRoot ? 'dropdown-item' : 'nav-link') ~ (matcher.isCurrent(item) ? ' active')}) %}
+            {{ block('linkElement') }}
+        {%- else %}
+            {{ block('spanElement') }}
+        {%- endif %}
+
+        {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
+        {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
+        {%- set listAttributes = item.childrenAttributes|merge({class: childrenClasses|join(' ')}) %}
+        {{ block('list') }}
+
+        {% if tag is not empty %}
+            </{{ tag }}>
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
+{% block planLabelBadge %}
+    {% if item.extras.plan_label is defined and item.extras.plan_label %}
+        <span class="badge bg-blue-lt text-uppercase ms-2">{{ item.extras.plan_label }}</span>
+    {% endif %}
+{% endblock %}
+
+{% block spanElement %}
+    {% if item.hasChildren and item.displayChildren %}
+        <a href="#" class="{{ item.parent.isRoot ? 'nav-link' : 'dropdown-item' }} dropdown-toggle{{ matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth) ? ' show' }}" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth) ? 'true' : 'false' }}">
+            {% if item.extras.icon is defined %}
+                <span class="nav-link-icon d-md-none d-lg-inline-block">
+                    {{ ux_icon('tabler:' ~ item.extras.icon) }}
+                </span>
+            {% endif %}
+            <span class="nav-link-title">
+                {{ block('label') }}
+            </span>
+            {{ block('planLabelBadge') }}
+        </a>
+    {% else %}
+        <span{{ ui.attributes(item.labelAttributes) }}>
+            {{ block('label') }}
+            {{ block('planLabelBadge') }}
+        </span>
+    {% endif %}
+{% endblock %}
+
+{% block linkElement %}
+    <a href="{{ item.uri }}"{{ ui.attributes(item.linkAttributes|merge(linkAttributes|default({}))) }}>
+        {% if item.extras.icon is defined %}
+            <span class="nav-link-icon d-md-none d-lg-inline-block">
+                {{ ux_icon('tabler:' ~ item.extras.icon) }}
+            </span>
+        {% endif %}
+        <span class="nav-link-title">
+            {{ block('label') }}
+        </span>
+        {{ block('planLabelBadge') }}
+    </a>
+{% endblock %}
+
+{% block label %}
+    {% if options.allow_safe_labels and item.getExtra('safe_label', false) %}
+        {{ item.label|trans|raw }}
+    {% else %}
+        {{ item.label|trans }}
+    {% endif %}
+{% endblock %}

--- a/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
+++ b/templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig
@@ -93,7 +93,7 @@
 
 {% block planLabelBadge %}
     {% if item.extras.plan_label is defined and item.extras.plan_label %}
-        <span class="badge bg-blue-lt text-uppercase ms-2">{{ item.extras.plan_label }}</span>
+        <span class="badge badge-sm bg-blue-lt ms-auto flex-shrink-0 fw-normal" title="{{ 'Upgrade to %plan%'|trans({'%plan%': item.extras.plan_label}) }}">{{ item.extras.plan_label }}</span>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary

Implements the full SolidInvoice SaaS feature-gating system across 9 user stories (US-001 → US-009). Adds a 12-feature catalog (3 quotas + 9 boolean flags), a Twig-driven upgrade-prompt UI, form/action/menu/listener integration points, and per-plan enforcement throughout the application.

## What's included

### Infrastructure (US-001 → US-004)
- **`SolidInvoice\SaasBundle\Feature\Feature` enum** — canonical 12-feature catalog (3 INTEGER quotas: `total_clients`, `invoices_per_month`, `team_seats`; 9 BOOLEAN flags: `quotes`, `online_payments`, `recurring_invoices`, `automated_reminders`, `multi_currency`, `custom_branding`, `rest_api_access`, `mcp_access`, `custom_domain`).
- **`platform.yaml` `saas.features:` block** registers all 12 keys with type/default; `LoadPlans` + `LoadPlanFeatures` fixtures seed the four plans (Free/Solo/Business/Agency).
- **`FeatureUsage` VO** with `isApproachingLimit(remaining, total)` — `remaining ≤ max(1, ceil(total × 0.1))`.
- **`UpgradePromptRenderer`** + Twig functions (`feature_required_plan_label`, `upgrade_prompt`, `feature_usage_banner`) for upgrade-banner UI; `_upgrade_banner.html.twig` partial.
- **`UpgradePromptProvider` interface** in CoreBundle with `NullUpgradePromptProvider` no-op so non-SaaS deployments compile cleanly; SaaS aliases the interface to the renderer.
- **`feature_gated` form-field option** via `FeatureRestrictedExtension` (SaaS) + CoreBundle no-op; SettingsType forwards the option, fields render disabled with plan-name badge when gated.
- **`custom_domain` setting moved** from `system/company/...` → `system/domain/...` with reversible Doctrine migration `Version30000_8` (the entity column `Company::customDomain` remains the source of truth for inbound host resolution).

### Boolean-flag gates (US-005 → US-008)
- `quotes` / `online_payments` — gates `QuoteBundle/Action/Create` and `PaymentBundle/Action/Settings`; menus set `plan_label` Tabler badges via the new `templates/bundles/SolidWorxPlatformBundle/Menu/menu.html.twig` override.
- `recurring_invoices` — gates `InvoiceBundle/Action/CreateRecurring` + `EditRecurring`; workflow guard listener (`workflow.recurring_invoice.guard.activate`) blocks transition with translated reason.
- `automated_reminders` — gates `SendInvoiceReminderHandler` (cleanly returns when disabled — Messenger discards the message); reminder Config entries are `feature_gated`.
- `multi_currency` — `ClientType::currencyCode` gated to company default with `FormEvents::SUBMIT` listener guaranteeing entity override even on edit.
- `custom_branding` — PDF templates gate `system/general/hide_powered_by` at runtime via `feature_enabled('custom_branding')`.
- `rest_api_access` / `mcp_access` — voter chain (`ApiAccessVoter`/`McpAccessVoter` for self-hosted, `SubscriptionVoter` for SaaS) consults `FeatureGate`; `UserBundle/Action/ApiIndex` and `McpBundle/Action/Authorize` short-circuit with upgrade pages; `CreateApiToken` LiveAction has defense-in-depth gating.
- `custom_domain` — `HostRoutingListener` falls back to `DefaultHost` when a downgraded plan loses the feature (the request continues via the canonical-host code path instead of 404).

### Quota gates + usage banners (US-009)
- `total_clients` on `ClientBundle/Action/Add`; `invoices_per_month` on `InvoiceBundle/Action/Create` + `CreateRecurring` (recurring counts toward the monthly tally); `team_seats` on `UserBundle/Action/InviteUser` (sum of `userCount + pendingInvitations`).
- New repository methods: `InvoiceRepository::countCreatedInMonth`, `UserRepository::getUserCountForCompany`, `UserInvitationRepository::countPending`.
- `feature_usage_banner` rendered at the top of Clients / Invoices / Users index pages — auto-hidden when neither approaching nor at limit (10% threshold).

## Self-hosted vs SaaS

All gates are no-ops on self-hosted deployments (`NoopFeatureGate::isEnabled`/`canUse` always return true; `NullUpgradePromptProvider` returns empty strings). Bundle loading is gated by `SOLIDINVOICE_PLATFORM=saas` in `config/bundles.php`, and conditional `services->set()` blocks ensure no-op companions are loaded only when the SaaS bundle is absent.

## Test plan

- [x] `bin/ecs check --fix` clean across all touched files
- [x] `bin/phpstan analyse` clean on production files (test mocks trigger pre-existing `InvocationMocker` PHPStan-environment limitation)
- [x] All 35 across-story gate tests pass (boolean flags + quotas + workflow + listener + handler)
- [x] `bin/phpunit src/SaasBundle`: 205 tests, 472 assertions, all pass
- [x] Repository unit tests for the 3 new methods (10 + 12 + 3 tests)
- [x] Functional tests for each quota gate cover at-limit, under-quota, and self-hosted paths
- [x] Manual verification: Free plan → 6th client blocked → Business upgrade restores access
- [ ] Pre-existing snapshot drift (15 TwoFactorSettings + 1 InvoiceBundle ViewTest + 2 ClientFormTest) is **unrelated** to this PR — modal CSS class change documented in earlier story progress notes