### PR TITLE
Guard accept transition before applying when editing invoice (fixes #2347)

### DIFF
--- a/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
@@ -19,10 +19,16 @@ use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Test\LiveComponentTest;
 use SolidInvoice\InvoiceBundle\DTO\InvoiceFormDTO;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\Line;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Manager\InvoiceFormManager;
+use SolidInvoice\InvoiceBundle\Model\Graph;
 use SolidInvoice\InvoiceBundle\Twig\Components\CreateInvoice;
 use SolidInvoice\TaxBundle\Entity\Tax;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Workflow\WorkflowInterface;
 use Zenstruck\Foundry\Test\Factories;
 
 final class CreateInvoiceTest extends LiveComponentTest
@@ -140,6 +146,82 @@ final class CreateInvoiceTest extends LiveComponentTest
         self::assertStringContainsString('checked', $rendered);
 
         $this->assertMatchesHtmlSnapshot($this->replaceChecksum($this->replaceUuid($rendered)));
+    }
+
+    /**
+     * Regression test for issue #2347.
+     *
+     * When editing a Pending invoice (accept transition already applied) and clicking
+     * "Save & Send", the component must not throw NotEnabledTransitionException.
+     * The workflow guard introduced in CreateInvoice::saveInvoice() skips the
+     * accept transition when it is no longer enabled.
+     */
+    public function testSaveSendDoesNotThrowWhenInvoiceAlreadyPending(): void
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+
+        $client = ClientFactory::createOne([
+            'name' => 'Acme Corp',
+            'currencyCode' => 'USD',
+        ])->_real();
+
+        $contact = ContactFactory::createOne([
+            'firstName' => 'Alice',
+            'lastName' => 'Smith',
+            'email' => 'alice@example.com',
+            'client' => $client,
+        ])->_real();
+
+        // Build a persisted Pending invoice (accept transition already applied).
+        $line = (new Line())
+            ->setDescription('Consulting')
+            ->setPrice(10000)
+            ->setQty(1.0);
+
+        $invoice = new Invoice();
+        $invoice->setStatus(InvoiceStatus::Pending);
+        $invoice->setClient($client);
+        $invoice->setInvoiceId('INV-TEST-001');
+        $invoice->setInvoiceDate(new DateTimeImmutable('2024-01-15'));
+        $invoice->addUser($contact);
+        $invoice->addLine($line);
+
+        $em->persist($invoice);
+        $em->flush();
+
+        // Verify the accept transition is indeed unavailable for a Pending invoice.
+        /** @var WorkflowInterface $stateMachine */
+        $stateMachine = self::getContainer()->get('state_machine.invoice');
+        self::assertFalse(
+            $stateMachine->can($invoice, Graph::TRANSITION_ACCEPT),
+            'The accept transition must not be available for a Pending invoice.',
+        );
+
+        // Build the DTO from the existing invoice (simulates the edit page load).
+        /** @var InvoiceFormManager $formManager */
+        $formManager = self::getContainer()->get(InvoiceFormManager::class);
+        $dto = $formManager->createDTOFromInvoice($invoice);
+
+        $component = $this->createLiveComponent(
+            name: CreateInvoice::class,
+            data: [
+                'dto' => $dto,
+                'isEdit' => true,
+                'invoiceEntity' => $invoice,
+            ],
+            client: $this->client,
+        )->actingAs($this->getUser());
+
+        // Before the fix this threw NotEnabledTransitionException.
+        $component->call('saveSend');
+
+        // The invoice status must remain Pending — no re-accept attempted.
+        $em->refresh($invoice);
+        self::assertSame(InvoiceStatus::Pending, $invoice->getStatus());
+
+        // The action must have produced a redirect (not a 422 / exception page).
+        $response = $this->client->getResponse();
+        self::assertInstanceOf(RedirectResponse::class, $response);
     }
 
     /**

--- a/src/InvoiceBundle/Twig/Components/CreateInvoice.php
+++ b/src/InvoiceBundle/Twig/Components/CreateInvoice.php
@@ -219,7 +219,7 @@ final class CreateInvoice extends AbstractController
 
             $this->formManager->updateInvoiceFromDTO($this->invoice, $dto);
 
-            if ('send' === $action || 'publish' === $action) {
+            if (('send' === $action || 'publish' === $action) && $this->invoiceStateMachine->can($this->invoice, Graph::TRANSITION_ACCEPT)) {
                 $this->invoiceStateMachine->apply($this->invoice, Graph::TRANSITION_ACCEPT);
             }
 


### PR DESCRIPTION
Closes #2347

## Root cause

In `CreateInvoice::saveInvoice()`, when editing an existing invoice and the user clicks "Save & Send" (or "Publish"), the code applied the `accept` workflow transition unconditionally:

```php
if ('send' === $action || 'publish' === $action) {
    $this->invoiceStateMachine->apply($this->invoice, Graph::TRANSITION_ACCEPT);
}
```

The `accept` transition is only available from `New` or `Draft` states (per the workflow config). If the invoice is already in `Pending`, `Overdue`, `Paid`, or any other non-draft state, Symfony's workflow engine throws `NotEnabledTransitionException`.

This scenario is easy to reach: a user creates and sends an invoice (it moves to `Pending`), then opens the edit page and clicks "Save & Send" again to resend it.

## Fix

Added a `can()` guard before `apply()` in the edit path:

```php
if (('send' === $action || 'publish' === $action) && $this->invoiceStateMachine->can($this->invoice, Graph::TRANSITION_ACCEPT)) {
    $this->invoiceStateMachine->apply($this->invoice, Graph::TRANSITION_ACCEPT);
}
```

When the invoice is already in `Pending` state the transition is skipped; the entity update, DB flush, and email dispatch all still proceed normally. The invoice correctly stays in `Pending`.

## Test approach

Added `testSaveSendDoesNotThrowWhenInvoiceAlreadyPending()` to `CreateInvoiceTest`:

1. Creates a client, contact (with email), and a Pending invoice with one line item.
2. Asserts that `state_machine.invoice->can($invoice, TRANSITION_ACCEPT)` returns `false` — confirming the transition is unavailable.
3. Builds the edit-mode DTO via `InvoiceFormManager::createDTOFromInvoice()` and calls `saveSend()` through the LiveComponent test framework.
4. Asserts the invoice remains in `Pending` status and the response is a redirect (not a 422/exception).

https://claude.ai/code/session_01UFcv5Q6rq5ACSxpeuK8Wz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFcv5Q6rq5ACSxpeuK8Wz2)_