### PR TITLE
Fix DQL "Invalid PathExpression" error when searching the payments grid

### DIFF
--- a/src/PaymentBundle/DataGrid/PaymentsGrid.php
+++ b/src/PaymentBundle/DataGrid/PaymentsGrid.php
@@ -43,6 +43,7 @@ final class PaymentsGrid extends Grid
         return [
             StringColumn::new('invoice')
                 ->label('Invoice #')
+                ->searchable(false)
                 ->formatValue(static function (Invoice $invoice) {
                     try {
                         return $invoice->getInvoiceId();
@@ -52,8 +53,10 @@ final class PaymentsGrid extends Grid
                 })
                 ->linkToRoute('_invoices_view', ['id' => 'invoice.id']),
             StringColumn::new('client')
+                ->searchable(false)
                 ->linkToRoute('_clients_view', ['id' => 'client.id']),
             StringColumn::new('method')
+                ->searchable(false)
                 ->linkToRoute('_payment_settings_index', ['method' => 'method.gatewayName'])
                 ->filter(
                     EntityFilter::new(PaymentMethod::class, 'method', 'name')
@@ -68,6 +71,7 @@ final class PaymentsGrid extends Grid
                 ->filter(new DateRangeFilter('completed')),
             StringColumn::new('message'),
             MoneyColumn::new('amount')
+                ->searchable(false)
                 ->sortableField('totalAmount'),
             DateTimeColumn::new('created')
                 ->format('d F Y')

--- a/src/PaymentBundle/Tests/DataGrid/PaymentsGridTest.php
+++ b/src/PaymentBundle/Tests/DataGrid/PaymentsGridTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\PaymentBundle\Tests\DataGrid;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\DateTimeColumn;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\MoneyColumn;
+use SolidInvoice\DataGridBundle\GridBuilder\Column\StringColumn;
+use SolidInvoice\PaymentBundle\DataGrid\PaymentsGrid;
+use SolidInvoice\PaymentBundle\Entity\Payment;
+
+/**
+ * @covers \SolidInvoice\PaymentBundle\DataGrid\PaymentsGrid
+ */
+final class PaymentsGridTest extends TestCase
+{
+    private PaymentsGrid $grid;
+
+    protected function setUp(): void
+    {
+        $this->grid = new PaymentsGrid();
+    }
+
+    public function testEntityFQCNReturnsPaymentClass(): void
+    {
+        self::assertSame(Payment::class, $this->grid->entityFQCN());
+    }
+
+    public function testColumnsCount(): void
+    {
+        self::assertCount(8, $this->grid->columns());
+    }
+
+    /**
+     * Relationship fields must not be searchable — applying LIKE to them in DQL
+     * produces a Doctrine "Invalid PathExpression" semantical error.
+     */
+    public function testRelationshipColumnsAreNotSearchable(): void
+    {
+        $columns = $this->grid->columns();
+
+        $byField = [];
+        foreach ($columns as $column) {
+            $byField[$column->getField()] = $column;
+        }
+
+        self::assertFalse($byField['invoice']->isSearchable(), 'invoice (ManyToOne) must not be searchable');
+        self::assertFalse($byField['client']->isSearchable(), 'client (ManyToOne) must not be searchable');
+        self::assertFalse($byField['method']->isSearchable(), 'method (ManyToOne) must not be searchable');
+    }
+
+    /**
+     * The 'amount' column is a virtual getter — the underlying DB column is
+     * 'totalAmount'.  Searching on 'amount' via LIKE generates invalid DQL.
+     */
+    public function testAmountColumnIsNotSearchable(): void
+    {
+        $columns = $this->grid->columns();
+
+        $byField = [];
+        foreach ($columns as $column) {
+            $byField[$column->getField()] = $column;
+        }
+
+        self::assertFalse($byField['amount']->isSearchable(), 'amount (virtual field) must not be searchable');
+    }
+
+    public function testScalarColumnsRemainSearchable(): void
+    {
+        $columns = $this->grid->columns();
+
+        $byField = [];
+        foreach ($columns as $column) {
+            $byField[$column->getField()] = $column;
+        }
+
+        self::assertTrue($byField['status']->isSearchable(), 'status should be searchable');
+        self::assertTrue($byField['message']->isSearchable(), 'message should be searchable');
+    }
+
+    public function testColumnTypes(): void
+    {
+        $columns = $this->grid->columns();
+
+        $byField = [];
+        foreach ($columns as $column) {
+            $byField[$column->getField()] = $column;
+        }
+
+        self::assertInstanceOf(StringColumn::class, $byField['invoice']);
+        self::assertInstanceOf(StringColumn::class, $byField['client']);
+        self::assertInstanceOf(StringColumn::class, $byField['method']);
+        self::assertInstanceOf(StringColumn::class, $byField['status']);
+        self::assertInstanceOf(DateTimeColumn::class, $byField['completed']);
+        self::assertInstanceOf(StringColumn::class, $byField['message']);
+        self::assertInstanceOf(MoneyColumn::class, $byField['amount']);
+        self::assertInstanceOf(DateTimeColumn::class, $byField['created']);
+    }
+}


### PR DESCRIPTION
Closes #2386

## Root cause

`SearchFilter` builds a DQL `WHERE … LIKE :q` clause for every column that reports `isSearchable() === true`. By default every `Column` is searchable. The payments grid defines `invoice`, `client`, and `method` as `StringColumn` fields that map to Doctrine `ManyToOne` associations, not scalar DB columns. Doctrine's DQL parser rejects a `LIKE` expression on an association path, throwing:

```
[Semantical Error] line 0, col 66 near 'invoice LIKE': Error: Invalid PathExpression. Must be a StateFieldPathExpression.
```

Additionally, the `amount` column field does not correspond to any Doctrine-mapped property — the actual DB column is `totalAmount` (exposed via `->sortableField('totalAmount')`). Searching on the non-existent `amount` field would also produce invalid DQL once the association-field error is resolved.

## Fix

Mark the four problematic columns as `->searchable(false)` in `PaymentsGrid::columns()`:

| Column | Reason |
|--------|--------|
| `invoice` | `ManyToOne` association — cannot use `LIKE` in DQL |
| `client` | `ManyToOne` association — cannot use `LIKE` in DQL |
| `method` | `ManyToOne` association — cannot use `LIKE` in DQL |
| `amount` | Virtual getter; underlying mapped field is `totalAmount` |

This mirrors the existing convention in `BaseInvoiceGrid` where the `client` column is already marked `->searchable(false)` for the same reason.

## Test approach

Added `src/PaymentBundle/Tests/DataGrid/PaymentsGridTest.php` covering:

- `testRelationshipColumnsAreNotSearchable` — `invoice`, `client`, `method` have `isSearchable() === false`
- `testAmountColumnIsNotSearchable` — `amount` has `isSearchable() === false`
- `testScalarColumnsRemainSearchable` — `status` and `message` remain searchable
- `testColumnTypes` — each column has the expected class
- `testEntityFQCNReturnsPaymentClass` and `testColumnsCount` — basic smoke tests

All 6 new tests pass; pre-existing network failures in the payment bundle (`api.iconify.design` blocked) are unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QudmTinu4mhdujxQKgLwYi)_