### PR TITLE
Fix deleteCompany crash: unknown column 'details_id' in security_token

### DIFF
--- a/src/CoreBundle/Repository/CompanyRepository.php
+++ b/src/CoreBundle/Repository/CompanyRepository.php
@@ -16,8 +16,11 @@ namespace SolidInvoice\CoreBundle\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
+use Payum\Core\Model\Identity;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\PaymentBundle\Entity\Payment;
+use SolidInvoice\PaymentBundle\Entity\SecurityToken;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
 
@@ -104,25 +107,42 @@ class CompanyRepository extends ServiceEntityRepository
             return;
         }
 
-        $conn = $this->getEntityManager()->getConnection();
+        $em = $this->getEntityManager();
 
         // Delete Payum security tokens for this company's payments.
         // security_token.details stores a PHP-serialized Identity object (no FK to payments),
-        // so ORM cascade cannot reach these rows. We look up each payment ULID and delete
-        // any token whose serialized details blob contains that ULID string.
-        $paymentIds = $conn->fetchFirstColumn(
-            'SELECT id FROM payments WHERE company_id = ?',
-            [$companyId->toBinary()]
-        );
+        // so ORM cascade cannot reach these rows. Load the company's payments, then match
+        // SecurityToken records by their deserialized Identity rather than raw SQL.
+        $payments = $em->getRepository(Payment::class)->findBy(['company' => $companyId]);
 
-        foreach ($paymentIds as $binary) {
-            $conn->executeStatement(
-                'DELETE FROM security_token WHERE details LIKE ?',
-                ['%"' . Ulid::fromBinary($binary)->toString() . '"%']
-            );
+        if ($payments !== []) {
+            $paymentIds = [];
+            foreach ($payments as $payment) {
+                $paymentIds[(string) $payment->getId()] = true;
+            }
+
+            /** @var SecurityToken[] $tokens */
+            $tokens = $em->getRepository(SecurityToken::class)->findAll();
+            foreach ($tokens as $token) {
+                $details = $token->getDetails();
+
+                if (! $details instanceof Identity) {
+                    continue;
+                }
+
+                if ($details->getClass() !== Payment::class) {
+                    continue;
+                }
+
+                if (! isset($paymentIds[(string) $details->getId()])) {
+                    continue;
+                }
+
+                $em->remove($token);
+            }
         }
 
-        $this->getEntityManager()->remove($company);
-        $this->getEntityManager()->flush();
+        $em->remove($company);
+        $em->flush();
     }
 }

--- a/src/CoreBundle/Repository/CompanyRepository.php
+++ b/src/CoreBundle/Repository/CompanyRepository.php
@@ -104,13 +104,23 @@ class CompanyRepository extends ServiceEntityRepository
             return;
         }
 
-        // Delete Payum security tokens for this company's payments (no company_id FK, invisible to ORM cascade)
-        $this->getEntityManager()
-            ->getConnection()
-            ->executeStatement(
-                'DELETE FROM security_token WHERE details_id IN (SELECT id FROM payments WHERE company_id = ?)',
-                [$companyId->toBinary()]
+        $conn = $this->getEntityManager()->getConnection();
+
+        // Delete Payum security tokens for this company's payments.
+        // security_token.details stores a PHP-serialized Identity object (no FK to payments),
+        // so ORM cascade cannot reach these rows. We look up each payment ULID and delete
+        // any token whose serialized details blob contains that ULID string.
+        $paymentIds = $conn->fetchFirstColumn(
+            'SELECT id FROM payments WHERE company_id = ?',
+            [$companyId->toBinary()]
+        );
+
+        foreach ($paymentIds as $binary) {
+            $conn->executeStatement(
+                'DELETE FROM security_token WHERE details LIKE ?',
+                ['%"' . Ulid::fromBinary($binary)->toString() . '"%']
             );
+        }
 
         $this->getEntityManager()->remove($company);
         $this->getEntityManager()->flush();

--- a/src/CoreBundle/Tests/Repository/CompanyRepositoryTest.php
+++ b/src/CoreBundle/Tests/Repository/CompanyRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Repository;
+
+use Payum\Core\Model\Identity;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use SolidInvoice\PaymentBundle\Entity\Payment;
+use SolidInvoice\PaymentBundle\Entity\SecurityToken;
+use SolidInvoice\PaymentBundle\Test\Factory\PaymentFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+
+/** @covers \SolidInvoice\CoreBundle\Repository\CompanyRepository */
+final class CompanyRepositoryTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+    use Factories;
+
+    public function testDeleteCompanyAlsoRemovesOrphanedSecurityTokens(): void
+    {
+        $companyId = $this->company->getId();
+        $payment = PaymentFactory::createOne()->_real();
+
+        $token = new SecurityToken();
+        $token->setDetails(new Identity($payment->getId()->toString(), $payment));
+        $token->setTargetUrl('https://example.com/payment');
+        $token->setGatewayName('test_gateway');
+
+        $this->em->persist($token);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var CompanyRepository $companyRepository */
+        $companyRepository = $this->em->getRepository(Company::class);
+
+        $companyRepository->deleteCompany($companyId);
+
+        $this->em->clear();
+
+        self::assertNull($this->em->find(Company::class, $companyId));
+        self::assertCount(0, $this->em->getRepository(Payment::class)->findAll());
+        self::assertCount(0, $this->em->getRepository(SecurityToken::class)->findAll());
+    }
+
+    public function testDeleteCompanyWithNoPaymentsDoesNotFail(): void
+    {
+        $companyId = $this->company->getId();
+
+        /** @var CompanyRepository $companyRepository */
+        $companyRepository = $this->em->getRepository(Company::class);
+
+        $companyRepository->deleteCompany($companyId);
+
+        $this->em->clear();
+
+        self::assertNull($this->em->find(Company::class, $companyId));
+    }
+
+    public function testDeleteCompanyWithNullIdDoesNothing(): void
+    {
+        /** @var CompanyRepository $companyRepository */
+        $companyRepository = $this->em->getRepository(Company::class);
+
+        $companyRepository->deleteCompany(null);
+
+        self::assertNotNull($this->em->find(Company::class, $this->company->getId()));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2345

- **Root cause:** `CompanyRepository::deleteCompany()` tried to delete Payum security tokens with `DELETE FROM security_token WHERE details_id IN (...)`. The column `details_id` does not exist — the correct column is `details`, which stores a PHP-serialized `Payum\Core\Model\Identity` object (no foreign key to `payments`).
- **Fix:** Load the company's payments via ORM, then iterate all `SecurityToken` records and remove any whose deserialized `Identity` points at one of those payments. This avoids relying on PHP serialization internals and works correctly across all database platforms. (Approach taken from draft PR #2400.)
- **Tests:** Added `CompanyRepositoryTest` with three cases — token cleanup on delete, delete with no payments, and no-op on null company id.

## Test plan

- [x] `bin/ecs check --fix` — no issues
- [x] `bin/phpstan analyse` — no errors
- [x] `bin/phpunit src/CoreBundle/Tests/Repository/CompanyRepositoryTest.php` — all 3 tests pass

https://claude.ai/code/session_011Vk4oxHj8qSZ1TdyeXtcRF