### PR TITLE
Fix ORMInvalidArgumentException when marking multiple invoices overdue

### DIFF
--- a/src/InvoiceBundle/Command/MarkOverdueInvoicesCommand.php
+++ b/src/InvoiceBundle/Command/MarkOverdueInvoicesCommand.php
@@ -85,8 +85,11 @@ final class MarkOverdueInvoicesCommand extends Command
                     ));
                 }
 
-                // Detach entity to free memory
-                $entityManager->detach($invoice);
+                // Clear the entire identity map to prevent stale entity references.
+                // detach($invoice) only removes the invoice itself, leaving lazy-loaded
+                // associations (e.g. Lines) managed but pointing to a non-managed invoice,
+                // which causes ORMInvalidArgumentException on the next flush.
+                $entityManager->clear();
             }
         } finally {
             // Re-enable company filter if it was enabled

--- a/src/InvoiceBundle/Tests/Command/MarkOverdueInvoicesCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/MarkOverdueInvoicesCommandTest.php
@@ -19,6 +19,7 @@ use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Command\MarkOverdueInvoicesCommand;
+use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidWorx\Platform\PlatformBundle\Console\IO;
@@ -130,6 +131,49 @@ final class MarkOverdueInvoicesCommandTest extends KernelTestCase
         $output = $this->runCommand();
 
         self::assertStringContainsString('Processed 3 overdue invoices', $output);
+    }
+
+    /**
+     * Regression test for https://github.com/SolidInvoice/SolidInvoice/issues/2380
+     *
+     * When invoice lines are lazy-loaded into the Doctrine identity map during a
+     * workflow transition flush (e.g. by a postUpdate listener), a subsequent
+     * detach($invoice) left the lines managed but pointing to the now-detached
+     * invoice entity. The next flush then threw ORMInvalidArgumentException
+     * ("A new entity was found through Line#invoice"). The fix is to call
+     * clear() instead of detach() to purge the entire identity map between
+     * iterations, preventing stale association references.
+     */
+    public function testCommandHandlesMultipleOverdueInvoicesWithLines(): void
+    {
+        $company = CompanyFactory::createOne();
+        $client = ClientFactory::createOne(['company' => $company]);
+
+        InvoiceFactory::createOne([
+            'status' => InvoiceStatus::Pending,
+            'due' => new DateTimeImmutable('2 days ago'),
+            'company' => $company,
+            'client' => $client,
+            'lines' => [
+                (new Line())->setDescription('Service A')->setQty(1)->setPrice(5000),
+                (new Line())->setDescription('Service B')->setQty(2)->setPrice(2500),
+            ],
+        ]);
+
+        InvoiceFactory::createOne([
+            'status' => InvoiceStatus::Pending,
+            'due' => new DateTimeImmutable('yesterday'),
+            'company' => $company,
+            'client' => $client,
+            'lines' => [
+                (new Line())->setDescription('Service C')->setQty(1)->setPrice(7500),
+            ],
+        ]);
+
+        $output = $this->runCommand();
+
+        self::assertStringContainsString('Processed 2 overdue invoices', $output);
+        self::assertStringContainsString('Errors: 0', $output);
     }
 
     private function runCommand(): string


### PR DESCRIPTION
## Summary

Fixes `Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'SolidInvoice\InvoiceBundle\Entity\Line#invoice'` that crashed the `solidinvoice:invoices:mark-overdue` cron command when multiple invoices were processed in the same run.

Closes #2380

## Root cause

`MarkOverdueInvoicesCommand` iterates overdue invoices via `toIterable()` and after dispatching each `MarkInvoiceOverdue` message (processed synchronously) it called `$entityManager->detach($invoice)` to free memory.

`detach()` only removes the invoice itself from the identity map. If any listener accessed invoice lines during the flush (e.g. a Meilisearch `postUpdate` listener calling `$invoice->getLineDescriptions()`), those `Line` entities were loaded into the identity map **and remained managed** after the invoice was detached. Their `invoice` association still pointed to the now-non-managed invoice entity.

On the next iteration, when `WorkFlowSubscriber` called `$em->flush()` for the second invoice, Doctrine's unit-of-work traversed all managed entities, found `Line` rows with a pending change whose `invoice` property referenced a "new" (unregistered) entity, and threw the exception.

## Fix

Replace `$entityManager->detach($invoice)` with `$entityManager->clear()`.

`clear()` purges the **entire** identity map, removing both the invoice and every associated entity loaded during its processing. This is safe here because `toIterable()` holds the PDO cursor independently of the entity manager — clearing the identity map does not close or invalidate the result iteration.

## Test

Added `testCommandHandlesMultipleOverdueInvoicesWithLines` to `MarkOverdueInvoicesCommandTest`: creates two overdue invoices each with multiple line items, runs the command, and asserts both are processed without error. This guards against regressions where line entities accumulate in the identity map between iterations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VN6wbBh5WtvEDtPkGusfMF)_