### PR TITLE
Add middleware to block installation routes when app is already installed

### DIFF
--- a/src/InstallBundle/Listener/RequestListener.php
+++ b/src/InstallBundle/Listener/RequestListener.php
@@ -107,6 +107,8 @@ final class RequestListener implements EventSubscriberInterface, ServiceSubscrib
                     $container->resetEnvCache();
                 }
             }
+        } elseif ($route === self::INSTALLER_ROUTE) {
+            $this->redirectToRoute($event, '_home');
         }
     }
 

--- a/src/InstallBundle/Tests/Listener/RequestListenerTest.php
+++ b/src/InstallBundle/Tests/Listener/RequestListenerTest.php
@@ -184,6 +184,38 @@ final class RequestListenerTest extends TestCase
         self::assertFalse($event->isPropagationStopped());
     }
 
+    public function testItRedirectsToHomeWhenApplicationIsInstalledAndInstallerRouteIsAccessed(): void
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects(self::once())
+            ->method('generate')
+            ->with('_home')
+            ->willReturn('/');
+
+        $listener = new RequestListener(
+            $router,
+            $this->createMock(ContainerInterface::class),
+            date('Y-m-d H:i:s'),
+        );
+
+        $request = Request::createFromGlobals();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $request->attributes->set('_route', RequestListener::INSTALLER_ROUTE);
+
+        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        self::assertNull($event->getResponse());
+
+        $listener->onKernelRequest($event);
+
+        $response = $event->getResponse();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/', $response->getTargetUrl());
+        self::assertTrue($event->isPropagationStopped());
+    }
+
     public function testItSetsSessionIdAsAppSecretWhenNotInstalled(): void
     {
         $router = $this->createMock(RouterInterface::class);


### PR DESCRIPTION
Closes #2410

## Root cause

`RequestListener::onKernelRequest` only handled the "not yet installed" path — when `$this->installed` was set (app already installed), the listener did nothing. The only gate blocking access to `/install` was inside `Install::__invoke`, which threw a 404 after the controller had already been dispatched.

## Fix

Added an `elseif` branch to `RequestListener::onKernelRequest`: when the application is already installed and the incoming route is `_system_install`, the listener redirects to `_home` and stops propagation before the request ever reaches the controller.

This is a defence-in-depth layer: the controller-level check in `Install::__invoke` stays in place as a fallback; the listener now provides a second barrier at the earliest point in the request lifecycle.

## Test approach

Added `testItRedirectsToHomeWhenApplicationIsInstalledAndInstallerRouteIsAccessed` to `RequestListenerTest`:
- Constructs the listener with a non-null `$installed` value (app is installed)
- Fires a request with `_route = _system_install`
- Asserts the response is a `RedirectResponse` to `/`, and that propagation is stopped

All 10 `RequestListenerTest` tests pass; no regressions in other InstallBundle unit tests.

https://claude.ai/code/session_01YPp1VDWDrBeFPhHCtfbJCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPp1VDWDrBeFPhHCtfbJCB)_