### PR TITLE
Fix crash when sending invoice with no email contacts (#2387)

### DIFF
--- a/src/InvoiceBundle/Action/Transition/Send.php
+++ b/src/InvoiceBundle/Action/Transition/Send.php
@@ -52,6 +52,15 @@ final class Send
             };
         }
 
+        if ($invoice->getUsers()->isEmpty()) {
+            return new class($route) extends RedirectResponse implements FlashResponse {
+                public function getFlash(): Generator
+                {
+                    yield FlashResponse::FLASH_ERROR => 'invoice.send.no_recipients';
+                }
+            };
+        }
+
         if (InvoiceStatus::Pending !== $invoice->getStatus() && $this->invoiceStateMachine->can($invoice, Graph::TRANSITION_ACCEPT)) {
             $this->invoiceStateMachine->apply($invoice, Graph::TRANSITION_ACCEPT);
         }

--- a/src/InvoiceBundle/Resources/translations/messages.en.yml
+++ b/src/InvoiceBundle/Resources/translations/messages.en.yml
@@ -317,3 +317,4 @@ invoice:
 invoice_status_update: 'Invoice Status Update'
 
 invoice.email.send_failed: 'Failed to send invoice email. Please verify your email configuration in Settings.'
+invoice.send.no_recipients: 'Cannot send invoice: no contacts with email addresses found'

--- a/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
+++ b/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\Action\Transition;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\CoreBundle\Contracts\EmailVerificationGateInterface;
+use SolidInvoice\CoreBundle\Response\FlashResponse;
+use SolidInvoice\InvoiceBundle\Action\Transition\Send;
+use SolidInvoice\InvoiceBundle\Email\InvoiceEmail;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Model\Graph;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+final class SendTest extends TestCase
+{
+    private function createGate(bool $gated): EmailVerificationGateInterface
+    {
+        $gate = $this->createStub(EmailVerificationGateInterface::class);
+        $gate->method('isGated')->willReturn($gated);
+
+        return $gate;
+    }
+
+    public function testSendWithNoContactsReturnsErrorFlash(): void
+    {
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects(self::never())->method('can');
+        $workflow->expects(self::never())->method('apply');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/123');
+
+        $action = new Send($workflow, $mailer, $router, $this->createGate(false));
+
+        $invoice = new Invoice();
+        // No users added — getUsers()->isEmpty() === true
+
+        $response = $action(new Request(), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/invoices/view/123', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_ERROR, $flashes);
+        self::assertSame('invoice.send.no_recipients', $flashes[FlashResponse::FLASH_ERROR]);
+    }
+
+    public function testSendWithEmailGateBlockedReturnsErrorFlash(): void
+    {
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects(self::never())->method('can');
+        $workflow->expects(self::never())->method('apply');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/123');
+
+        $action = new Send($workflow, $mailer, $router, $this->createGate(true));
+
+        $invoice = new Invoice();
+        $invoice->addUser((new Contact())->setEmail('test@example.com'));
+
+        $response = $action(new Request(), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_ERROR, $flashes);
+        self::assertSame('email_verification.flash.send_invoice', $flashes[FlashResponse::FLASH_ERROR]);
+    }
+
+    public function testSendWithContactsAndPendingStatusDispatchesEmail(): void
+    {
+        $invoice = new Invoice();
+        $invoice->addUser((new Contact())->setEmail('test@example.com'));
+        $invoice->setStatus(InvoiceStatus::Pending);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects(self::never())->method('apply');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::isInstanceOf(InvoiceEmail::class));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/123');
+
+        $em = $this->createMock(ObjectManager::class);
+        $em->expects(self::once())->method('persist')->with($invoice);
+        $em->expects(self::once())->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->expects(self::once())->method('getManager')->willReturn($em);
+
+        $action = new Send($workflow, $mailer, $router, $this->createGate(false));
+        $action->setDoctrine($doctrine);
+
+        $response = $action(new Request(), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/invoices/view/123', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_SUCCESS, $flashes);
+        self::assertSame('invoice.transition.action.sent', $flashes[FlashResponse::FLASH_SUCCESS]);
+    }
+
+    public function testSendWithContactsAndNonPendingStatusAppliesTransition(): void
+    {
+        $invoice = new Invoice();
+        $invoice->addUser((new Contact())->setEmail('test@example.com'));
+        $invoice->setStatus(InvoiceStatus::Draft);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects(self::once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_ACCEPT)
+            ->willReturn(true);
+        $workflow->expects(self::once())
+            ->method('apply')
+            ->with($invoice, Graph::TRANSITION_ACCEPT);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::isInstanceOf(InvoiceEmail::class));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->willReturn('/invoices/view/123');
+
+        $em = $this->createStub(ObjectManager::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        $doctrine = $this->createStub(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        $action = new Send($workflow, $mailer, $router, $this->createGate(false));
+        $action->setDoctrine($doctrine);
+
+        $response = $action(new Request(), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_SUCCESS, $flashes);
+        self::assertSame('invoice.transition.action.sent', $flashes[FlashResponse::FLASH_SUCCESS]);
+    }
+}


### PR DESCRIPTION
Closes #2387

## Root cause

When a user clicks the "Send" button on an invoice that has no contacts, `Action/Transition/Send::__invoke()` calls `$this->mailer->send(new InvoiceEmail($invoice))` unconditionally. The `InvoiceReceiverListener` then iterates the empty contacts collection and adds zero `To` recipients. When Symfony's mailer later validates the outbound message it throws:

```
Symfony\Component\Mime\Exception\LogicException: An email must have a "To", "Cc", or "Bcc" header.
```

This surfaces as a `HandlerFailedException` in the async Messenger worker (since the mailer uses the async transport) and as a 500 crash for the user visiting `GET /invoices/action/send/{id}`. Sentry captured 11 occurrences affecting 8 users (SOLIDINVOICE-7S).

## Fix

Added a guard in `Send::__invoke()` that checks `$invoice->getUsers()->isEmpty()` **before** the workflow transition, save, and email dispatch. When no contacts are present the action now redirects back to the invoice view with a flash error message (`invoice.send.no_recipients`) instead of crashing. The invoice state is intentionally left unchanged — the user must add contacts before the send can succeed.

This mirrors the existing guard in `SendManualReminder::__invoke()` which already handles the same scenario for manual reminder emails.

## Test approach

Added `Tests/Action/Transition/SendTest.php` with four unit tests:

- **`testSendWithNoContactsReturnsErrorFlash`** — verifies the new guard: no contacts → error flash with `invoice.send.no_recipients`, workflow and mailer never invoked.
- **`testSendWithEmailGateBlockedReturnsErrorFlash`** — existing gate check still returns the correct error flash.
- **`testSendWithContactsAndPendingStatusDispatchesEmail`** — already-pending invoice skips the workflow transition and dispatches the email.
- **`testSendWithContactsAndNonPendingStatusAppliesTransition`** — non-pending invoice applies the `accept` transition before dispatching.

All four tests pass (`OK (4 tests, 45 assertions)`). ECS and PHPStan on the production file report no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoEJB8j88EHNdxXz7VGi7p)_