### PR TITLE
Fix TypeError in JSON-LD serializer caused by GraphQL Query operation on Payment resource (#2388)

### DIFF
--- a/src/PaymentBundle/Entity/Payment.php
+++ b/src/PaymentBundle/Entity/Payment.php
@@ -87,7 +87,8 @@ use Traversable;
     ],
     denormalizationContext: [
         AbstractObjectNormalizer::SKIP_NULL_VALUES => false,
-    ]
+    ],
+    graphQlOperations: [],
 )]
 #[ApiResource(
     operations: [
@@ -99,7 +100,8 @@ use Traversable;
     ],
     denormalizationContext: [
         AbstractObjectNormalizer::SKIP_NULL_VALUES => false,
-    ]
+    ],
+    graphQlOperations: [],
 )]
 class Payment extends BasePayment
 {

--- a/src/PaymentBundle/Tests/Functional/Api/PaymentTest.php
+++ b/src/PaymentBundle/Tests/Functional/Api/PaymentTest.php
@@ -35,6 +35,26 @@ final class PaymentTest extends ApiTestCase
         return Payment::class;
     }
 
+    public function testGetPaymentsForInvoiceWithClient(): void
+    {
+        $client = ClientFactory::createOne()->_real();
+        $invoice = InvoiceFactory::createOne(['client' => $client])->_real();
+        $payment = PaymentFactory::createOne([
+            'invoice' => $invoice,
+            'client' => $client,
+            'status' => PaymentStatus::Captured,
+        ])->_real();
+
+        $data = $this->requestGet($this->getIriFromResource($invoice) . '/payments');
+        unset($data['search'], $data['view']);
+
+        self::assertSame(1, $data['totalItems']);
+        self::assertCount(1, $data['member']);
+        self::assertSame($this->getIriFromResource($payment), $data['member'][0]['@id']);
+        self::assertSame($this->getIriFromResource($invoice), $data['member'][0]['invoice']);
+        self::assertSame($this->getIriFromResource($client), $data['member'][0]['client']);
+    }
+
     public function testGetPaymentsForInvoice(): void
     {
         $invoice = InvoiceFactory::createOne()->_real();


### PR DESCRIPTION
Closes #2388

## Root cause

API Platform's GraphQL support is enabled globally in `config/packages/api_platform.php`. When enabled, it auto-generates `GraphQl\Query` operations for every `#[ApiResource]`-annotated class — including `Payment`, which has two `#[ApiResource]` blocks neither of which previously opted out of GraphQL.

During JSON-LD serialisation of `GET /api/invoices/{invoiceId}/payments`, the API Platform serializer stack can end up with one of these auto-generated `GraphQl\Query` operations in the normalisation context for an embedded `Payment` item. The method that builds the JSON-LD context:

```php
// ContextBuilder.php line 199
private function getResourceContextWithShortname(
    string $resourceClass,
    int $referenceType,
    string $shortName,
    ?HttpOperation $operation = null  // ← only accepts HttpOperation
): array
```

declares `$operation` as `?HttpOperation`. Passing a `GraphQl\Query` object triggers a fatal `TypeError` (Sentry SOLIDINVOICE-84, 4 occurrences, 1 affected user).

## Fix

Add `graphQlOperations: []` to both `#[ApiResource]` blocks on the `Payment` entity. This prevents API Platform from auto-generating any GraphQL operations for `Payment`, ensuring the serialiser context only ever contains HTTP operations.

This is the same pattern already used on `ApiToken` (which has `graphQlOperations: []` on both its `#[ApiResource]` blocks for the same reason).

## Test approach

- Added `testGetPaymentsForInvoiceWithClient` — a new functional test that mirrors the production scenario: a payment with **both** `invoice` and `client` set, fetched via `GET /api/invoices/{id}/payments`. This is the combination that was absent from the existing `testGetPaymentsForInvoice` fixture (which left `client` null) and that corresponds to the endpoint URL from the Sentry event.
- All 7 `PaymentTest` tests pass (`OK (7 tests, 32 assertions)`).
- All 3 `RecordPaymentTest` tests pass (`OK (3 tests, 7 assertions)`).
- ECS and PHPStan report no errors on the modified files.

https://claude.ai/code/session_01YQAuaNcb21NgVskbdV3sQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQAuaNcb21NgVskbdV3sQd)_