### PR TITLE
Route SendInvoiceReminderMessage to async transport to fix cron timeout

### DIFF
--- a/config/packages/messenger.php
+++ b/config/packages/messenger.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use SolidInvoice\CoreBundle\Export\Message\RequestCompanyExport;
 use SolidInvoice\CronBundle\Messenger\SentrySchedulerMiddleware;
+use SolidInvoice\InvoiceBundle\Message\SendInvoiceReminderMessage;
 use SolidInvoice\SaasBundle\Message\SendOnboardingEmailMessage;
 use Symfony\Config\FrameworkConfig;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
@@ -40,6 +41,14 @@ return static function (FrameworkConfig $config): void {
     // scheduler returns quickly and Messenger's retry strategy handles
     // transient mailer failures.
     $messenger->routing(SendOnboardingEmailMessage::class)
+        ->senders(['async']);
+
+    // Route invoice reminder dispatch through the async transport for the same
+    // reason: the hourly cron command must return quickly (seconds), not block
+    // while sending one SMTP email per qualifying invoice.  Without this routing
+    // the handler runs synchronously and a slow/unreachable mail server causes
+    // the cron to exceed Sentry's max_runtime → perpetual "timeout" alerts.
+    $messenger->routing(SendInvoiceReminderMessage::class)
         ->senders(['async']);
 
     // Full company data exports are long-running and email the user on completion,

--- a/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
@@ -121,6 +121,7 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         // was queued in the async transport and the handler did not run inline.
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->clear();
+
         $reminderCount = $em->getRepository(InvoiceReminder::class)->count([]);
         self::assertSame(0, $reminderCount, 'SendInvoiceReminderMessage must be routed to the async transport, not handled inline during the cron run');
 

--- a/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InvoiceBundle\Tests\Command;
 
-use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use const PHP_EOL;
 use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,6 +34,7 @@ use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 use Symfony\Component\Console\Tester\TesterTrait;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Zenstruck\Foundry\Test\Factories;
 use function rewind;
 use function str_replace;

--- a/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
@@ -119,6 +119,7 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         // If SendInvoiceReminderMessage were handled synchronously, the handler
         // would persist an InvoiceReminder row. Zero rows confirms the message
         // was queued in the async transport and the handler did not run inline.
+        $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->clear();
         $reminderCount = $em->getRepository(InvoiceReminder::class)->count([]);
         self::assertSame(0, $reminderCount, 'SendInvoiceReminderMessage must be routed to the async transport, not handled inline during the cron run');

--- a/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
@@ -13,11 +13,21 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InvoiceBundle\Tests\Command;
 
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use const PHP_EOL;
+use Carbon\CarbonImmutable;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Command\SendInvoiceRemindersCommand;
+use SolidInvoice\InvoiceBundle\Entity\InvoiceReminder;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Message\SendInvoiceReminderMessage;
+use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidWorx\Platform\PlatformBundle\Console\IO;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -69,6 +79,56 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         self::assertStringContainsString('Processing overdue reminders', $output);
     }
 
+    /**
+     * Regression test for the cron timeout detected by Sentry (SOLIDINVOICE-74).
+     *
+     * SendInvoiceReminderMessage must be routed to the async transport so the
+     * hourly cron command returns in seconds rather than blocking on SMTP for
+     * every qualifying invoice. Without async routing the handler runs inline,
+     * and a slow or unreachable mail server causes the command to exceed
+     * Sentry's cron max_runtime, producing perpetual "timeout check-in" alerts.
+     *
+     * If this test fails it means the message is handled synchronously: the
+     * handler would have created an InvoiceReminder record during the command run.
+     */
+    public function testReminderMessagesAreDispatchedAsyncNotHandledInline(): void
+    {
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // Reminder settings (invoice/reminder/enabled, pre_due_enabled, pre_due_days=3)
+        // are seeded automatically by DefaultData when the test company is created in
+        // installApplication(), so no manual insert is needed here.
+
+        // Create a pending invoice due in exactly 3 days — matches the default
+        // pre_due_days = 3, so getInvoicesNeedingPreDueReminders(3) will return it.
+        $client = ClientFactory::createOne(['company' => $this->company, 'currencyCode' => 'USD']);
+        $contact = ContactFactory::createOne(['client' => $client, 'company' => $this->company]);
+        InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Pending,
+            'due' => CarbonImmutable::now()->addDays(3),
+            'users' => [$contact],
+        ]);
+
+        $output = $this->runCommand();
+
+        self::assertThat($this->statusCode, new CommandIsSuccessful());
+        self::assertStringContainsString('Dispatched 1 pre-due reminder', $output);
+
+        // If SendInvoiceReminderMessage were handled synchronously, the handler
+        // would persist an InvoiceReminder row. Zero rows confirms the message
+        // was queued in the async transport and the handler did not run inline.
+        $em->clear();
+        $reminderCount = $em->getRepository(InvoiceReminder::class)->count([]);
+        self::assertSame(0, $reminderCount, 'SendInvoiceReminderMessage must be routed to the async transport, not handled inline during the cron run');
+
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.async');
+        self::assertCount(1, $transport->getSent());
+        self::assertInstanceOf(SendInvoiceReminderMessage::class, $transport->getSent()[0]->getMessage());
+    }
+
     private function runCommand(): string
     {
         $application = new Application(self::bootKernel());
@@ -91,6 +151,6 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());
-        return str_replace(\PHP_EOL, "\n", $display);
+        return str_replace(PHP_EOL, "\n", $display);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2342

**Root cause:** `SendInvoiceReminderMessage` lacked async routing in `config/packages/messenger.php`. The handler ran synchronously inside the hourly cron command, sending one SMTP email per qualifying invoice inline. A slow or unreachable mail server caused the command to exceed Sentry's cron `max_runtime`, producing perpetual "timeout check-in" alerts.

**Fix:** Route `SendInvoiceReminderMessage` to the `async` transport, exactly as `SendOnboardingEmailMessage` is already routed. The command now dispatches messages to the queue and returns in seconds; workers consume and send the emails out-of-band.

**Regression test:** `testReminderMessagesAreDispatchedAsyncNotHandledInline` creates a qualifying invoice (pending, due in 3 days), runs the command, and asserts that no `InvoiceReminder` record was persisted. Before this fix the handler ran inline and would create the record; after the fix the handler is deferred to the queue so the count stays at zero.

## Changes

- `config/packages/messenger.php` — add `SendInvoiceReminderMessage → async` routing
- `src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php` — add async-dispatch regression test

## Test plan

- [ ] All 4 tests in `SendInvoiceRemindersCommandTest` pass (`bin/phpunit src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php`)
- [ ] ECS passes on modified files
- [ ] PHPStan reports no new errors on modified files

https://claude.ai/code/session_01QYyR34QxQRwjYys46uqXEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYyR34QxQRwjYys46uqXEu)_