### PR TITLE
Add ability to send paid invoices via email (closes #2405)

### DIFF
--- a/src/InvoiceBundle/Resources/translations/messages.en.yml
+++ b/src/InvoiceBundle/Resources/translations/messages.en.yml
@@ -200,6 +200,12 @@ invoice:
             message: 'This will send a payment reminder email for invoice %invoice_id% to the contacts listed below.'
             recipients: 'Email will be sent to:'
             confirm: 'Send Reminder'
+        send_paid:
+            title: 'Send Paid Invoice'
+            heading: 'Send invoice receipt?'
+            message: 'This will resend the invoice email for invoice %invoice_id% to the contacts listed below.'
+            recipients: 'Email will be sent to:'
+            confirm: 'Send Invoice'
     recurring:
         create:
             title: 'Create Recurring Invoice'

--- a/src/InvoiceBundle/Resources/views/Default/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view.html.twig
@@ -80,6 +80,27 @@
                             </li>
                         {% endif %}
 
+                        {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Paid and invoice.users|length > 0 %}
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                {% if is_email_verification_gated() %}
+                                    <span class="d-block" tabindex="0"
+                                          data-bs-toggle="tooltip"
+                                          title="{{ email_verification_message('sending this invoice') }}">
+                                        <button type="button" class="dropdown-item disabled" disabled style="pointer-events: none;">
+                                            {{ ux_icon('tabler:send', {width: 16, height: 16}) }}
+                                            {{ "invoice.view.toolbar.send"|trans }}
+                                        </button>
+                                    </span>
+                                {% else %}
+                                    <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#send-paid-invoice-modal">
+                                        {{ ux_icon('tabler:send', {width: 16, height: 16}) }}
+                                        {{ "invoice.view.toolbar.send"|trans }}
+                                    </a>
+                                {% endif %}
+                            </li>
+                        {% endif %}
+
                         {% if workflow_can(invoice, 'edit') %}
                             <li>
                                 <a class="dropdown-item" href="{{ path('_invoices_edit', {'id' : invoice.id}) }}">
@@ -556,6 +577,38 @@
                         {{ 'invoice.modal.send_reminder.confirm'|trans }}
                     </button>
                 </form>
+            </twig:block>
+        </twig:Ui:Modal>
+    {% endif %}
+
+    {% if invoice.status == enum('SolidInvoice\\InvoiceBundle\\Enum\\InvoiceStatus').Paid and invoice.users|length > 0 %}
+        <twig:Ui:Modal id="send-paid-invoice-modal" title="{{ 'invoice.modal.send_paid.title'|trans }}" :centered="true">
+            <div class="text-center py-3">
+                <div class="mb-3">
+                    {{ ux_icon('tabler:send', {width: 48, height: 48, class: 'text-primary'}) }}
+                </div>
+                <h3>{{ 'invoice.modal.send_paid.heading'|trans }}</h3>
+                <p class="text-muted">{{ 'invoice.modal.send_paid.message'|trans({'%invoice_id%': invoice.invoiceId}) }}</p>
+
+                <div class="mt-3">
+                    <p class="text-sm text-muted mb-2">{{ 'invoice.modal.send_paid.recipients'|trans }}</p>
+                    <div class="d-flex flex-column gap-1 align-items-center">
+                        {% for user in invoice.users %}
+                            <div class="text-sm">
+                                {{ ux_icon('tabler:mail', {width: 14, height: 14}) }}
+                                {{ user.email }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+
+            <twig:block name="footer">
+                <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">{{ 'invoice.view.toolbar.cancel'|trans }}</button>
+                <a href="{{ path('_send_invoice', {'id': invoice.id}) }}" class="btn btn-primary">
+                    {{ ux_icon('tabler:send', {width: 16, height: 16}) }}
+                    {{ 'invoice.modal.send_paid.confirm'|trans }}
+                </a>
             </twig:block>
         </twig:Ui:Modal>
     {% endif %}

--- a/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
+++ b/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
@@ -141,7 +141,7 @@ final class SendTest extends TestCase
     public function testSendWithPaidStatusSkipsTransitionAndDispatchesEmail(): void
     {
         $invoice = new Invoice();
-        $invoice->addUser((new Contact())->setEmail('test@example.com'));
+        $invoice->addUser(new Contact()->setEmail('test@example.com'));
         $invoice->setStatus(InvoiceStatus::Paid);
 
         $workflow = $this->createMock(WorkflowInterface::class);

--- a/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
+++ b/src/InvoiceBundle/Tests/Action/Transition/SendTest.php
@@ -138,6 +138,51 @@ final class SendTest extends TestCase
         self::assertSame('invoice.transition.action.sent', $flashes[FlashResponse::FLASH_SUCCESS]);
     }
 
+    public function testSendWithPaidStatusSkipsTransitionAndDispatchesEmail(): void
+    {
+        $invoice = new Invoice();
+        $invoice->addUser((new Contact())->setEmail('test@example.com'));
+        $invoice->setStatus(InvoiceStatus::Paid);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects(self::once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_ACCEPT)
+            ->willReturn(false);
+        $workflow->expects(self::never())->method('apply');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::isInstanceOf(InvoiceEmail::class));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/123');
+
+        $em = $this->createMock(ObjectManager::class);
+        $em->expects(self::once())->method('persist')->with($invoice);
+        $em->expects(self::once())->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->expects(self::once())->method('getManager')->willReturn($em);
+
+        $action = new Send($workflow, $mailer, $router, $this->createGate(false));
+        $action->setDoctrine($doctrine);
+
+        $response = $action(new Request(), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/invoices/view/123', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_SUCCESS, $flashes);
+        self::assertSame('invoice.transition.action.sent', $flashes[FlashResponse::FLASH_SUCCESS]);
+    }
+
     public function testSendWithContactsAndNonPendingStatusAppliesTransition(): void
     {
         $invoice = new Invoice();


### PR DESCRIPTION
Closes #2405

## Root cause

The invoice view page's "Send" button was gated behind `workflow_can(invoice, 'pay')`, which is only true for `Pending` and `Overdue` invoices. Once an invoice transitioned to `Paid`, the send button disappeared entirely — making it impossible to email a receipt to the client.

The existing `Send` action (`src/InvoiceBundle/Action/Transition/Send.php`) already handled paid invoices correctly: it checks whether the `accept` workflow transition is available before applying it, and since `accept` is not defined from the `Paid` state, it simply skips the transition and sends the email. No changes to the action were needed.

## Fix

- **`view.html.twig`**: Added a "Send" entry in the More Actions dropdown that appears when `invoice.status == Paid` and the invoice has at least one contact. Respects the email verification gate (shows a disabled + tooltip when gated, a modal link otherwise). Added a confirmation modal (`send-paid-invoice-modal`) so users see the recipient list before confirming the send.
- **`messages.en.yml`**: Added translation keys under `invoice.modal.send_paid.*` for the modal title, heading, body copy, and confirm button.

## Test approach

Added `testSendWithPaidStatusSkipsTransitionAndDispatchesEmail` to `SendTest.php`:
- Creates an invoice with `Paid` status and one contact
- Asserts `WorkflowInterface::can()` is called once (returns `false`) and `apply()` is **never** called
- Asserts `MailerInterface::send()` is called once with an `InvoiceEmail`
- Asserts the response is a success flash redirect

All 5 tests in `SendTest` pass. ECS reports no style violations.

https://claude.ai/code/session_01MUGnFYzm2qD8YjWJPf4jUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUGnFYzm2qD8YjWJPf4jUa)_