### PR TITLE
Add Facebook OAuth login

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "knplabs/knp-menu-bundle": "^3.2",
         "knpuniversity/oauth2-client-bundle": "^2.18",
         "league/commonmark": "^2.4",
+        "league/oauth2-facebook": "^2.2",
         "league/oauth2-google": "^4.0",
         "league/oauth2-server": "^9.0",
         "league/uri": "^7.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43ec58a3b40c84f44bd78059226924a0",
+    "content-hash": "6c378953389378f918988425fb46c6f4",
     "packages": [
         {
             "name": "alcohol/iso4217",
@@ -1789,16 +1789,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.18.2",
+            "version": "2.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546"
+                "reference": "241d61f6bbc77275d5a9f95d514241c058bf2d0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/0ff098b29b8b3c68307c8987dcaed7fd829c6546",
-                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/241d61f6bbc77275d5a9f95d514241c058bf2d0a",
+                "reference": "241d61f6bbc77275d5a9f95d514241c058bf2d0a",
                 "shasum": ""
             },
             "require": {
@@ -1835,6 +1835,7 @@
                 "psr/log": "^1.1.4 || ^2.0 || ^3.0",
                 "symfony/doctrine-messenger": "^6.4 || ^7.0",
                 "symfony/expression-language": "^6.4 || ^7.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
                 "symfony/messenger": "^6.4 || ^7.0",
                 "symfony/property-info": "^6.4 || ^7.0",
                 "symfony/security-bundle": "^6.4 || ^7.0",
@@ -1890,7 +1891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.2"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.3"
             },
             "funding": [
                 {
@@ -1906,7 +1907,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-20T21:35:32+00:00"
+            "time": "2026-06-08T08:22:50+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -4706,6 +4707,62 @@
             "time": "2025-11-25T22:17:17+00:00"
         },
         {
+            "name": "league/oauth2-facebook",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-facebook.git",
+                "reference": "ec6d62a00b548c6cd56d7b734346b9e6befbfbbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-facebook/zipball/ec6d62a00b548c6cd56d7b734346b9e6befbfbbb",
+                "reference": "ec6d62a00b548c6cd56d7b734346b9e6befbfbbb",
+                "shasum": ""
+            },
+            "require": {
+                "league/oauth2-client": "^2.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "mockery/mockery": "~1.3.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "~3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sammy Kaye Powers",
+                    "email": "me@sammyk.me",
+                    "homepage": "http://www.sammyk.me"
+                }
+            ],
+            "description": "Facebook OAuth 2.0 Client Provider for The PHP League OAuth2-Client",
+            "keywords": [
+                "Authentication",
+                "authorization",
+                "client",
+                "facebook",
+                "oauth",
+                "oauth2"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-facebook/issues",
+                "source": "https://github.com/thephpleague/oauth2-facebook/tree/2.2.0"
+            },
+            "time": "2022-02-24T18:45:07+00:00"
+        },
+        {
             "name": "league/oauth2-google",
             "version": "4.2.0",
             "source": {
@@ -6048,16 +6105,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "5a09cc37e4349453c7777b102ce7648e9f36ba94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/5a09cc37e4349453c7777b102ce7648e9f36ba94",
+                "reference": "5a09cc37e4349453c7777b102ce7648e9f36ba94",
                 "shasum": ""
             },
             "require": {
@@ -6149,7 +6206,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-06-14T16:57:45+00:00"
         },
         {
             "name": "nette/schema",
@@ -9097,16 +9154,16 @@
         },
         {
             "name": "scheb/2fa-backup-code",
-            "version": "v7.13.1",
+            "version": "v7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/2fa-backup-code.git",
-                "reference": "35f1ace4be7be2c10158d2bb8284208499111db8"
+                "reference": "73946182322f43cf82c5ee8c5481481a570ade40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/2fa-backup-code/zipball/35f1ace4be7be2c10158d2bb8284208499111db8",
-                "reference": "35f1ace4be7be2c10158d2bb8284208499111db8",
+                "url": "https://api.github.com/repos/scheb/2fa-backup-code/zipball/73946182322f43cf82c5ee8c5481481a570ade40",
+                "reference": "73946182322f43cf82c5ee8c5481481a570ade40",
                 "shasum": ""
             },
             "require": {
@@ -9140,22 +9197,22 @@
                 "two-step"
             ],
             "support": {
-                "source": "https://github.com/scheb/2fa-backup-code/tree/v7.13.1"
+                "source": "https://github.com/scheb/2fa-backup-code/tree/v7.14.0"
             },
-            "time": "2025-11-20T13:35:24+00:00"
+            "time": "2026-01-24T13:47:32+00:00"
         },
         {
             "name": "scheb/2fa-bundle",
-            "version": "v7.13.1",
+            "version": "v7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/2fa-bundle.git",
-                "reference": "edcc14456b508aab37ec792cfc36793d04226784"
+                "reference": "65fa9eb61d1205f2024f14c8c38b53e7bb20927c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/2fa-bundle/zipball/edcc14456b508aab37ec792cfc36793d04226784",
-                "reference": "edcc14456b508aab37ec792cfc36793d04226784",
+                "url": "https://api.github.com/repos/scheb/2fa-bundle/zipball/65fa9eb61d1205f2024f14c8c38b53e7bb20927c",
+                "reference": "65fa9eb61d1205f2024f14c8c38b53e7bb20927c",
                 "shasum": ""
             },
             "require": {
@@ -9208,22 +9265,22 @@
                 "two-step"
             ],
             "support": {
-                "source": "https://github.com/scheb/2fa-bundle/tree/v7.13.1"
+                "source": "https://github.com/scheb/2fa-bundle/tree/v7.14.0"
             },
-            "time": "2025-12-18T15:29:07+00:00"
+            "time": "2026-06-12T18:31:07+00:00"
         },
         {
             "name": "scheb/2fa-email",
-            "version": "v7.13.1",
+            "version": "v7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/2fa-email.git",
-                "reference": "ee70a062dde6aa9d566f99d2b1ae40b544ddbcef"
+                "reference": "9e40b8e0420ca7ed491b983f79f867c5be3a7432"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/2fa-email/zipball/ee70a062dde6aa9d566f99d2b1ae40b544ddbcef",
-                "reference": "ee70a062dde6aa9d566f99d2b1ae40b544ddbcef",
+                "url": "https://api.github.com/repos/scheb/2fa-email/zipball/9e40b8e0420ca7ed491b983f79f867c5be3a7432",
+                "reference": "9e40b8e0420ca7ed491b983f79f867c5be3a7432",
                 "shasum": ""
             },
             "require": {
@@ -9260,22 +9317,22 @@
                 "two-step"
             ],
             "support": {
-                "source": "https://github.com/scheb/2fa-email/tree/v7.13.1"
+                "source": "https://github.com/scheb/2fa-email/tree/v7.14.0"
             },
-            "time": "2025-11-20T13:35:24+00:00"
+            "time": "2026-06-08T19:34:00+00:00"
         },
         {
             "name": "scheb/2fa-totp",
-            "version": "v7.13.1",
+            "version": "v7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/2fa-totp.git",
-                "reference": "89a0557e191cc3b49d138452e095e8b5fb703f40"
+                "reference": "7bc9ab6f974d7c12bfe42c917c5ff0e805532c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/2fa-totp/zipball/89a0557e191cc3b49d138452e095e8b5fb703f40",
-                "reference": "89a0557e191cc3b49d138452e095e8b5fb703f40",
+                "url": "https://api.github.com/repos/scheb/2fa-totp/zipball/7bc9ab6f974d7c12bfe42c917c5ff0e805532c2e",
+                "reference": "7bc9ab6f974d7c12bfe42c917c5ff0e805532c2e",
                 "shasum": ""
             },
             "require": {
@@ -9313,22 +9370,22 @@
                 "two-step"
             ],
             "support": {
-                "source": "https://github.com/scheb/2fa-totp/tree/v7.13.1"
+                "source": "https://github.com/scheb/2fa-totp/tree/v7.14.0"
             },
-            "time": "2025-12-04T15:55:14+00:00"
+            "time": "2026-01-24T13:53:55+00:00"
         },
         {
             "name": "scheb/2fa-trusted-device",
-            "version": "v7.13.1",
+            "version": "v7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/2fa-trusted-device.git",
-                "reference": "ae3a5819faccbf151af078f432e4e6c97bb44ebf"
+                "reference": "590f400bac58bff70af24adbc702e57a30e493a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/2fa-trusted-device/zipball/ae3a5819faccbf151af078f432e4e6c97bb44ebf",
-                "reference": "ae3a5819faccbf151af078f432e4e6c97bb44ebf",
+                "url": "https://api.github.com/repos/scheb/2fa-trusted-device/zipball/590f400bac58bff70af24adbc702e57a30e493a3",
+                "reference": "590f400bac58bff70af24adbc702e57a30e493a3",
                 "shasum": ""
             },
             "require": {
@@ -9364,9 +9421,9 @@
                 "two-step"
             ],
             "support": {
-                "source": "https://github.com/scheb/2fa-trusted-device/tree/v7.13.1"
+                "source": "https://github.com/scheb/2fa-trusted-device/tree/v7.14.0"
             },
-            "time": "2025-12-01T15:40:59+00:00"
+            "time": "2026-01-24T13:47:32+00:00"
         },
         {
             "name": "sentry/sentry",
@@ -15785,16 +15842,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -15846,7 +15903,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -15866,20 +15923,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -15926,7 +15983,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -15946,7 +16003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/config/packages/knpu_oauth2_client.yaml
+++ b/config/packages/knpu_oauth2_client.yaml
@@ -16,4 +16,4 @@ knpu_oauth2_client:
             redirect_route: _oauth_connect_check
             redirect_params:
                 service: facebook
-            graph_api_version: v18.0
+            graph_api_version: v25.0

--- a/config/packages/knpu_oauth2_client.yaml
+++ b/config/packages/knpu_oauth2_client.yaml
@@ -9,3 +9,11 @@ knpu_oauth2_client:
             redirect_params:
                 service: google
             #scope: ['email', 'profile']
+        facebook:
+            type: facebook
+            client_id: '%env(SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID)%'
+            client_secret: '%env(SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET)%'
+            redirect_route: _oauth_connect_check
+            redirect_params:
+                service: facebook
+            graph_api_version: v18.0

--- a/config/packages/toggler.php
+++ b/config/packages/toggler.php
@@ -19,6 +19,7 @@ return static function (TogglerConfig $config): void {
         ->config()
         ->features('allow_registration', env('SOLIDINVOICE_ALLOW_REGISTRATION'))
         ->features('google_oauth_login', '@=env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID") !== null && env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET") !== null')
+        ->features('facebook_oauth_login', '@=env("SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID") !== null && env("SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET") !== null')
         ->features('saas_enabled', '@=env("SOLIDINVOICE_PLATFORM") === \'saas\'')
         ->features('meilisearch_search', '@=env("SOLIDINVOICE_MEILISEARCH_URL") !== "" && env("SOLIDINVOICE_MEILISEARCH_API_KEY") !== ""')
     ;

--- a/config/reference.php
+++ b/config/reference.php
@@ -1252,7 +1252,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -1303,7 +1303,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -1335,7 +1335,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID)', null);
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET)', null);
+    $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID)', null);
+    $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET)', null);
 
     $parameters->set('env(SOLIDINVOICE_SENTRY_DSN)', null);
     $parameters->set('env(SOLIDINVOICE_SENTRY_RELEASE)', '');

--- a/docs/docs/integrations/facebook-oauth.md
+++ b/docs/docs/integrations/facebook-oauth.md
@@ -1,0 +1,123 @@
+---
+title: Facebook OAuth
+description: Let users sign in to SolidInvoice with their Facebook account.
+sidebar_position: 4
+---
+
+# Facebook OAuth
+
+SolidInvoice can use Facebook as an identity provider, letting users sign in or register with a Facebook account instead of an email and password. Users who already have a SolidInvoice account can also link it to Facebook from their profile page so they can sign in with either method afterwards.
+
+The integration is optional. With no Facebook client configured, the application uses email/password authentication only.
+
+## What this enables
+
+When the integration is configured, three new entry points appear in the UI:
+
+- A `Login with Facebook` button on the login page.
+- A `Sign up with Facebook` button on the registration page (only when public registration is enabled — see [Registration through Facebook](#registration-through-facebook)).
+- A `Facebook Account` row in `/profile` → `Security`, where a signed-in user can link their existing account to a Facebook identity. Once linked, the row shows a `Linked` badge.
+
+Behind the scenes, when a user completes the Facebook flow, SolidInvoice does the following in order:
+
+1. If a SolidInvoice user already has the returning Facebook ID, they are signed in as that user.
+2. Otherwise, if a SolidInvoice user has the same email address as the Facebook account, the Facebook ID is attached to that user and they are signed in.
+3. Otherwise, if a user is already signed in (the profile-page link flow), the Facebook ID is attached to the current user.
+4. Otherwise, if public registration is enabled, a new user is created using the email returned by Facebook (Facebook only releases verified email addresses, so the user is treated as already email-verified).
+5. Otherwise, authentication is rejected with an error message on the login page.
+
+When the user signs in or registers via Facebook, SolidInvoice also fills in the first name and last name from Facebook — but only if those fields are currently empty on the user. Any name a user has already saved is never overwritten.
+
+## Create a Facebook OAuth client
+
+Before SolidInvoice can talk to Facebook, you need a Meta for Developers application.
+
+1. Open the [Meta for Developers](https://developers.facebook.com/) site and create a new app. Choose the `Consumer` use case (`Other` works as well).
+2. In the app dashboard, open `App Settings` → `Basic` and copy the `App ID` and `App Secret`.
+3. Add the `Facebook Login` product to the app.
+4. Under `Facebook Login` → `Settings`, add the SolidInvoice OAuth check URL as a `Valid OAuth Redirect URI`:
+
+   ```text
+   https://your-solidinvoice-domain.example/oauth/check/facebook
+   ```
+
+   The path is always `/oauth/check/facebook`. Add one entry per environment (production, staging, local development).
+5. Switch the app to `Live` mode once you have completed Meta's app review for the `email` permission. While in development mode, only test users and app admins can sign in.
+
+:::warning
+The redirect URI must match exactly — including the scheme (`http`/`https`), host, and trailing path. Mismatches show up as a `URL Blocked` error from Facebook after the user clicks the sign-in button.
+:::
+
+## Configure SolidInvoice
+
+Set two environment variables on the SolidInvoice instance, then restart the application:
+
+| Variable | Description |
+| --- | --- |
+| `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID` | The `App ID` from Meta for Developers. |
+| `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET` | The `App Secret` from Meta for Developers. |
+
+Both variables must be set for the integration to activate. Leaving either empty disables the Facebook buttons everywhere in the UI.
+
+For Docker:
+
+```bash
+docker run \
+  -e SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID=... \
+  -e SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET=... \
+  solidinvoice/solidinvoice
+```
+
+For the distribution package and source installs, add the values to `.env` at the root of the application:
+
+```ini title=".env"
+SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID=1234567890123456
+SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET=your-facebook-app-secret
+```
+
+:::tip
+If the Facebook buttons don't appear after setting the variables, clear the application cache: `bin/console cache:clear`.
+:::
+
+## Signing in with Facebook
+
+On the login page, click `Login with Facebook`. The browser is redirected to Facebook, the user authorizes the SolidInvoice application, and Facebook redirects back to `/oauth/check/facebook`. SolidInvoice signs the user in (matching by Facebook ID first, then by email) and redirects to the company selector.
+
+Already-existing accounts are matched on email automatically — a user who originally signed up with an email/password and later clicks `Login with Facebook` will end up signed into their existing account, with the Facebook ID stored for future logins.
+
+## Registration through Facebook
+
+When public registration is enabled on your instance, the registration page shows a `Sign up with Facebook` button alongside the email/password form. Clicking it follows the same Facebook flow; if no SolidInvoice user matches the returning email, a new user is created with:
+
+- The email address returned by Facebook.
+- A pre-verified status — Facebook only releases email addresses that have been verified on the Facebook side, so the SolidInvoice email verification step is skipped.
+- The first and last name reported by Facebook.
+- A randomly generated password that is never shown — the user can sign in only via Facebook until they set a password through the password reset flow.
+
+If public registration is disabled, the `Sign up with Facebook` button is hidden, and Facebook sign-in is rejected for any email that doesn't already have a SolidInvoice account.
+
+## Linking an existing account
+
+Users who already signed up with email/password can link their account to Facebook from the profile page. While signed in, navigate to `/profile`, scroll to the `Security` section, and click `Sign in with Facebook` on the `Facebook Account` row. After completing the Facebook flow, the row updates to show a `Linked` badge, and the user can sign in with either Facebook or their original password from then on.
+
+:::info
+A SolidInvoice account can be linked to one Facebook account at a time. If a user wants to switch the linked Facebook identity, they need to unlink the current one through database access — there is currently no in-app unlink button.
+:::
+
+## Troubleshooting
+
+### `URL Blocked` from Facebook
+
+The redirect URI configured under `Facebook Login` → `Settings` does not exactly match the URL SolidInvoice is calling back on. Compare scheme, host, and path — the path must be `/oauth/check/facebook`, and the scheme and host must match the public URL of your installation.
+
+### Facebook buttons don't appear on the login or registration page
+
+Both `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID` and `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_SECRET` must be set and non-empty. After changing either variable, clear the application cache with `bin/console cache:clear` and reload the page.
+
+### Authentication is rejected after the Facebook flow
+
+Public registration is disabled and the Facebook account's email is not associated with an existing SolidInvoice user. Either enable registration so the user can be created automatically, or have an admin create the user first with the matching email address.
+
+### Only test users can sign in
+
+The Meta for Developers app is still in `Development` mode. Until the app has been switched to `Live`, only users added under `App Roles` → `Roles` and `Testers` can complete the Facebook flow. Submit the `email` permission for review and flip the app to `Live` to allow public sign-in.

--- a/migrations/Version30000_12.php
+++ b/migrations/Version30000_12.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version30000_11 extends AbstractMigration
+final class Version30000_12 extends AbstractMigration
 {
     public function getDescription(): string
     {

--- a/migrations/Version30000_12.php
+++ b/migrations/Version30000_12.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version30000_11 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add facebook_id column to users table for Facebook OAuth login';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('users');
+        $table->addColumn('facebook_id', Types::STRING, ['length' => 45, 'notnull' => false]);
+        $table->addIndex(['facebook_id'], 'IDX_USERS_FACEBOOK_ID');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('users');
+        $table->dropIndex('IDX_USERS_FACEBOOK_ID');
+        $table->dropColumn('facebook_id');
+    }
+}

--- a/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
+++ b/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
@@ -69,7 +69,6 @@ final class DiscountNormalizerTest extends TestCase
     {
         $discount = $this->normalizer->denormalize(['type' => 'percentage', 'value' => null], Discount::class);
 
-        self::assertInstanceOf(Discount::class, $discount);
         self::assertSame('percentage', $discount->getType());
     }
 
@@ -80,7 +79,6 @@ final class DiscountNormalizerTest extends TestCase
     {
         $discount = $this->normalizer->denormalize(['type' => 'percentage'], Discount::class);
 
-        self::assertInstanceOf(Discount::class, $discount);
         self::assertSame('percentage', $discount->getType());
     }
 }

--- a/src/UserBundle/Action/Security/OAuthConnect.php
+++ b/src/UserBundle/Action/Security/OAuthConnect.php
@@ -46,6 +46,7 @@ final class OAuthConnect extends AbstractController
     {
         return match ($service) {
             'google' => ['profile', 'email'],
+            'facebook' => ['email', 'public_profile'],
             default => throw $this->createNotFoundException('Service not found'),
         };
     }

--- a/src/UserBundle/OAuth/OAuthUser.php
+++ b/src/UserBundle/OAuth/OAuthUser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\OAuth;
 
+use League\OAuth2\Client\Provider\FacebookUser;
 use League\OAuth2\Client\Provider\GoogleUser;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 
@@ -30,6 +31,7 @@ final readonly class OAuthUser
     {
         return match (true) {
             $this->resourceOwner instanceof GoogleUser => $this->resourceOwner->getEmail(),
+            $this->resourceOwner instanceof FacebookUser => $this->resourceOwner->getEmail(),
             default => null,
         };
     }
@@ -37,20 +39,22 @@ final readonly class OAuthUser
     public function getFirstName(): string
     {
         return match (true) {
-            $this->resourceOwner instanceof GoogleUser => $this->resourceOwner->getFirstName(),
+            $this->resourceOwner instanceof GoogleUser => (string) $this->resourceOwner->getFirstName(),
+            $this->resourceOwner instanceof FacebookUser => (string) $this->resourceOwner->getFirstName(),
             default => '',
         };
     }
 
     public function getId(): string
     {
-        return $this->resourceOwner->getId();
+        return (string) $this->resourceOwner->getId();
     }
 
     public function getLastName(): string
     {
         return match (true) {
-            $this->resourceOwner instanceof GoogleUser => $this->resourceOwner->getLastName(),
+            $this->resourceOwner instanceof GoogleUser => (string) $this->resourceOwner->getLastName(),
+            $this->resourceOwner instanceof FacebookUser => (string) $this->resourceOwner->getLastName(),
             default => '',
         };
     }
@@ -59,6 +63,7 @@ final readonly class OAuthUser
     {
         return match (true) {
             $this->resourceOwner instanceof GoogleUser => 'googleId',
+            $this->resourceOwner instanceof FacebookUser => 'facebookId',
             default => '',
         };
     }
@@ -67,6 +72,7 @@ final readonly class OAuthUser
     {
         return match (true) {
             $this->resourceOwner instanceof GoogleUser => $this->resourceOwner->toArray()['email_verified'] ?? false,
+            $this->resourceOwner instanceof FacebookUser => true,
             default => false,
         };
     }

--- a/src/UserBundle/Resources/translations/messages.en.yml
+++ b/src/UserBundle/Resources/translations/messages.en.yml
@@ -76,6 +76,7 @@ security:
         forgot_password: 'Forgot Password'
         or: or
         login_with_google: 'Login with Google'
+        login_with_facebook: 'Login with Facebook'
         no_account: "Don't have an account yet?"
         register_now: 'Register Now'
     register:
@@ -112,6 +113,7 @@ security:
             login: 'Already have an account?'
             signin: 'Sign in'
             google: 'Sign up with Google'
+            facebook: 'Sign up with Facebook'
         placeholders:
             email: 'your@email.com'
             company: 'Your Company Name'

--- a/src/UserBundle/Resources/views/Profile/show.html.twig
+++ b/src/UserBundle/Resources/views/Profile/show.html.twig
@@ -138,6 +138,37 @@
                     </div>
                 {% endtoggle %}
 
+                {% toggle 'facebook_oauth_login' %}
+                    {# Facebook Account Linking #}
+                    <div class="security-item">
+                        <div class="security-item-info">
+                            <div class="security-item-icon {{ app.user.facebookId is not empty ? 'security-item-icon-success' : 'security-item-icon-warning' }}">
+                                {{ ux_icon(app.user.facebookId is not empty ? 'tabler:brand-facebook' : 'tabler:unlink', {width: 20, height: 20}) }}
+                            </div>
+                            <div class="security-item-content">
+                                <h4 class="security-item-title">{{ 'Facebook Account'|trans }}</h4>
+                                <p class="security-item-description">
+                                    {% if app.user.facebookId is not empty %}
+                                        {{ 'Your account is linked with Facebook'|trans }}
+                                    {% else %}
+                                        {{ 'Link your account with Facebook for easier sign-in'|trans }}
+                                    {% endif %}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="security-item-action">
+                            {% if app.user.facebookId is empty %}
+                                <a href="{{ path('_oauth_connect', {'service': 'facebook'}) }}" class="btn btn-sm btn-outline-primary facebook-signin-btn">
+                                    {{ ux_icon('tabler:brand-facebook', {width: 16, height: 16}) }}
+                                    {{ 'Sign in with Facebook'|trans }}
+                                </a>
+                            {% else %}
+                                <span class="badge bg-success-lt">{{ 'Linked'|trans }}</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endtoggle %}
+
                 {# Password #}
                 <div class="security-item">
                     <div class="security-item-info">

--- a/src/UserBundle/Resources/views/Security/login.html.twig
+++ b/src/UserBundle/Resources/views/Security/login.html.twig
@@ -18,20 +18,33 @@
 {% endblock stylesheets %}
 
 {% block social_login %}
-    {% toggle 'google_oauth_login' %}
+    {% set has_oauth = toggle('google_oauth_login') or toggle('facebook_oauth_login') %}
+    {% if has_oauth %}
         <div class="hr-text">{{ 'security.login.or'|trans }}</div>
 
         <div class="card-body">
-            <div class="row">
-                <div class="col">
-                    <a href="{{ path('_oauth_connect', {'service': 'google' }) }}" class="btn btn-outline-secondary w-100">
-                        {{ ux_icon('tabler:brand-google', {width: 24, height: 24}) }}
-                        {{ 'security.login.login_with_google'|trans }}
-                    </a>
+            {% toggle 'google_oauth_login' %}
+                <div class="row mb-2">
+                    <div class="col">
+                        <a href="{{ path('_oauth_connect', {'service': 'google' }) }}" class="btn btn-outline-secondary w-100">
+                            {{ ux_icon('tabler:brand-google', {width: 24, height: 24}) }}
+                            {{ 'security.login.login_with_google'|trans }}
+                        </a>
+                    </div>
                 </div>
-            </div>
+            {% endtoggle %}
+            {% toggle 'facebook_oauth_login' %}
+                <div class="row">
+                    <div class="col">
+                        <a href="{{ path('_oauth_connect', {'service': 'facebook' }) }}" class="btn btn-outline-secondary w-100">
+                            {{ ux_icon('tabler:brand-facebook', {width: 24, height: 24}) }}
+                            {{ 'security.login.login_with_facebook'|trans }}
+                        </a>
+                    </div>
+                </div>
+            {% endtoggle %}
         </div>
-    {% endtoggle %}
+    {% endif %}
 {% endblock social_login %}
 
 {% block content %}

--- a/src/UserBundle/Resources/views/Security/register.html.twig
+++ b/src/UserBundle/Resources/views/Security/register.html.twig
@@ -92,17 +92,29 @@
 
                             {{ form_end(form) }}
                             
-                            {% toggle 'google_oauth_login' %}
+                            {% if toggle('google_oauth_login') or toggle('facebook_oauth_login') %}
                                 <div class="hr-text">{{ 'or'|trans }}</div>
-                                <div class="row">
-                                    <div class="col">
-                                        <a href="{{ path('_oauth_connect', {'service': 'google' }) }}" class="btn btn-outline-secondary w-100">
-                                            {{ ux_icon('tabler:brand-google', {width: 24, height: 24}) }}
-                                            {{ 'security.register.links.google'|trans }}
-                                        </a>
+                                {% toggle 'google_oauth_login' %}
+                                    <div class="row mb-2">
+                                        <div class="col">
+                                            <a href="{{ path('_oauth_connect', {'service': 'google' }) }}" class="btn btn-outline-secondary w-100">
+                                                {{ ux_icon('tabler:brand-google', {width: 24, height: 24}) }}
+                                                {{ 'security.register.links.google'|trans }}
+                                            </a>
+                                        </div>
                                     </div>
-                                </div>
-                            {% endtoggle %}
+                                {% endtoggle %}
+                                {% toggle 'facebook_oauth_login' %}
+                                    <div class="row">
+                                        <div class="col">
+                                            <a href="{{ path('_oauth_connect', {'service': 'facebook' }) }}" class="btn btn-outline-secondary w-100">
+                                                {{ ux_icon('tabler:brand-facebook', {width: 24, height: 24}) }}
+                                                {{ 'security.register.links.facebook'|trans }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                {% endtoggle %}
+                            {% endif %}
                         </div>
                     </div>
                     

--- a/src/UserBundle/Security/OAuth/OAuthAuthenticator.php
+++ b/src/UserBundle/Security/OAuth/OAuthAuthenticator.php
@@ -94,6 +94,20 @@ final class OAuthAuthenticator extends OAuth2Authenticator implements Authentica
 
                 $this->propertyAccessor->setValue($user, $oauthUser->getPropertyMap(), $oauthUser->getId());
 
+                if ($user->getFirstName() === null || $user->getFirstName() === '') {
+                    $firstName = $oauthUser->getFirstName();
+                    if ($firstName !== '') {
+                        $user->setFirstName($firstName);
+                    }
+                }
+
+                if ($user->getLastName() === null || $user->getLastName() === '') {
+                    $lastName = $oauthUser->getLastName();
+                    if ($lastName !== '') {
+                        $user->setLastName($lastName);
+                    }
+                }
+
                 $this->entityManager->persist($user);
                 $this->entityManager->flush();
 

--- a/src/UserBundle/Tests/OAuth/OAuthUserTest.php
+++ b/src/UserBundle/Tests/OAuth/OAuthUserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Tests\OAuth;
 
+use League\OAuth2\Client\Provider\FacebookUser;
 use League\OAuth2\Client\Provider\GoogleUser;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -150,5 +151,68 @@ final class OAuthUserTest extends TestCase
         $oauthUser = new OAuthUser($resourceOwner);
 
         self::assertFalse($oauthUser->getEmailVerified());
+    }
+
+    public function testGetEmailWithFacebookUser(): void
+    {
+        $facebookUser = new FacebookUser([
+            'id' => '123',
+            'email' => 'fb@example.com',
+        ]);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertSame('fb@example.com', $oauthUser->getEmail());
+    }
+
+    public function testGetFirstNameWithFacebookUser(): void
+    {
+        $facebookUser = new FacebookUser([
+            'id' => '123',
+            'first_name' => 'Jane',
+        ]);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertSame('Jane', $oauthUser->getFirstName());
+    }
+
+    public function testGetLastNameWithFacebookUser(): void
+    {
+        $facebookUser = new FacebookUser([
+            'id' => '123',
+            'last_name' => 'Smith',
+        ]);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertSame('Smith', $oauthUser->getLastName());
+    }
+
+    public function testGetPropertyMapWithFacebookUser(): void
+    {
+        $facebookUser = new FacebookUser(['id' => '123']);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertSame('facebookId', $oauthUser->getPropertyMap());
+    }
+
+    public function testGetEmailVerifiedWithFacebookUserIsAlwaysTrue(): void
+    {
+        $facebookUser = new FacebookUser(['id' => '123']);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertTrue($oauthUser->getEmailVerified());
+    }
+
+    public function testGetIdWithFacebookUser(): void
+    {
+        $facebookUser = new FacebookUser(['id' => '987654321']);
+
+        $oauthUser = new OAuthUser($facebookUser);
+
+        self::assertSame('987654321', $oauthUser->getId());
     }
 }

--- a/src/UserBundle/Tests/Security/OAuth/OAuthAuthenticatorTest.php
+++ b/src/UserBundle/Tests/Security/OAuth/OAuthAuthenticatorTest.php
@@ -699,6 +699,7 @@ final class OAuthAuthenticatorTest extends TestCase
 
         $passport = $this->authenticator->authenticate($request);
         $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertInstanceOf(UserBadge::class, $userBadge);
 
         self::assertSame($user, $userBadge->getUser());
     }
@@ -777,6 +778,7 @@ final class OAuthAuthenticatorTest extends TestCase
 
         $passport = $this->authenticator->authenticate($request);
         $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertInstanceOf(UserBadge::class, $userBadge);
         $result = $userBadge->getUser();
 
         self::assertInstanceOf(User::class, $result);
@@ -832,6 +834,7 @@ final class OAuthAuthenticatorTest extends TestCase
                 if (isset($criteria['email']) && $criteria['email'] === 'existing@example.com') {
                     return $existingUser;
                 }
+
                 return null;
             });
 
@@ -845,6 +848,7 @@ final class OAuthAuthenticatorTest extends TestCase
 
         $passport = $this->authenticator->authenticate($request);
         $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertInstanceOf(UserBadge::class, $userBadge);
         $result = $userBadge->getUser();
 
         self::assertSame($existingUser, $result);

--- a/src/UserBundle/Tests/Security/OAuth/OAuthAuthenticatorTest.php
+++ b/src/UserBundle/Tests/Security/OAuth/OAuthAuthenticatorTest.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\UserBundle\Tests\Security\OAuth;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
+use League\OAuth2\Client\Provider\FacebookUser;
 use League\OAuth2\Client\Provider\GoogleUser;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -635,5 +636,219 @@ final class OAuthAuthenticatorTest extends TestCase
 
         self::assertInstanceOf(RedirectResponse::class, $response);
         self::assertSame('/login', $response->getTargetUrl());
+    }
+
+    public function testSupportsWithFacebookService(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', OAuthConnectCheck::ROUTE);
+        $request->attributes->set('service', 'facebook');
+
+        $this->toggle
+            ->expects($this->once())
+            ->method('isActive')
+            ->with('facebook_oauth_login')
+            ->willReturn(true);
+
+        self::assertTrue($this->authenticator->supports($request));
+    }
+
+    public function testAuthenticateWithExistingFacebookUser(): void
+    {
+        $request = new Request();
+        $request->attributes->set('service', 'facebook');
+
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+        $user = new User();
+
+        $facebookUser = new FacebookUser([
+            'id' => '987654321',
+            'email' => 'fb@example.com',
+            'first_name' => 'Jane',
+            'last_name' => 'Smith',
+        ]);
+
+        $this->clientRegistry
+            ->expects($this->once())
+            ->method('getClient')
+            ->with('facebook')
+            ->willReturn($this->client);
+
+        $this->client
+            ->expects($this->once())
+            ->method('fetchUserFromToken')
+            ->with($accessToken)
+            ->willReturn($facebookUser);
+
+        $this->client
+            ->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn($accessToken);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($this->userRepository);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['facebookId' => '987654321'])
+            ->willReturn($user);
+
+        $passport = $this->authenticator->authenticate($request);
+        $userBadge = $passport->getBadge(UserBadge::class);
+
+        self::assertSame($user, $userBadge->getUser());
+    }
+
+    public function testAuthenticateWithNewFacebookUserSyncsNameFields(): void
+    {
+        $request = new Request();
+        $request->attributes->set('service', 'facebook');
+
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+
+        $facebookUser = new FacebookUser([
+            'id' => '987654321',
+            'email' => 'fb@example.com',
+            'first_name' => 'Jane',
+            'last_name' => 'Smith',
+        ]);
+
+        $this->clientRegistry
+            ->expects($this->once())
+            ->method('getClient')
+            ->with('facebook')
+            ->willReturn($this->client);
+
+        $this->client
+            ->expects($this->once())
+            ->method('fetchUserFromToken')
+            ->with($accessToken)
+            ->willReturn($facebookUser);
+
+        $this->client
+            ->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn($accessToken);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($this->userRepository);
+
+        $this->userRepository
+            ->expects($this->exactly(2))
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $this->security
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn(null);
+
+        $this->toggle
+            ->expects($this->once())
+            ->method('isActive')
+            ->with('allow_registration')
+            ->willReturn(true);
+
+        $this->propertyAccessor
+            ->expects($this->once())
+            ->method('setValue')
+            ->with(
+                self::callback(static fn ($user): bool => $user instanceof User && $user->getEmail() === 'fb@example.com'),
+                'facebookId',
+                '987654321'
+            );
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('persist')
+            ->with(self::callback(static fn ($user): bool => $user instanceof User
+                && $user->getFirstName() === 'Jane'
+                && $user->getLastName() === 'Smith'));
+        $this->entityManager
+            ->expects($this->once())
+            ->method('flush');
+
+        $passport = $this->authenticator->authenticate($request);
+        $userBadge = $passport->getBadge(UserBadge::class);
+        $result = $userBadge->getUser();
+
+        self::assertInstanceOf(User::class, $result);
+        self::assertSame('fb@example.com', $result->getEmail());
+        self::assertSame('Jane', $result->getFirstName());
+        self::assertSame('Smith', $result->getLastName());
+        self::assertTrue($result->isVerified());
+    }
+
+    public function testAuthenticateDoesNotOverwriteExistingNames(): void
+    {
+        $request = new Request();
+        $request->attributes->set('service', 'facebook');
+
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+        $existingUser = new User();
+        $existingUser->setEmail('existing@example.com');
+        $existingUser->setFirstName('Original');
+        $existingUser->setLastName('Name');
+
+        $facebookUser = new FacebookUser([
+            'id' => '987654321',
+            'email' => 'existing@example.com',
+            'first_name' => 'Jane',
+            'last_name' => 'Smith',
+        ]);
+
+        $this->clientRegistry
+            ->expects($this->once())
+            ->method('getClient')
+            ->with('facebook')
+            ->willReturn($this->client);
+
+        $this->client
+            ->expects($this->once())
+            ->method('fetchUserFromToken')
+            ->willReturn($facebookUser);
+
+        $this->client
+            ->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn($accessToken);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($this->userRepository);
+
+        $this->userRepository
+            ->expects($this->exactly(2))
+            ->method('findOneBy')
+            ->willReturnCallback(static function (array $criteria) use ($existingUser): ?User {
+                if (isset($criteria['email']) && $criteria['email'] === 'existing@example.com') {
+                    return $existingUser;
+                }
+                return null;
+            });
+
+        $this->propertyAccessor
+            ->expects($this->once())
+            ->method('setValue')
+            ->with($existingUser, 'facebookId', '987654321');
+
+        $this->entityManager->expects($this->once())->method('persist')->with($existingUser);
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $passport = $this->authenticator->authenticate($request);
+        $userBadge = $passport->getBadge(UserBadge::class);
+        $result = $userBadge->getUser();
+
+        self::assertSame($existingUser, $result);
+        self::assertSame('Original', $result->getFirstName());
+        self::assertSame('Name', $result->getLastName());
     }
 }


### PR DESCRIPTION
## Summary

Adds Facebook as an identity provider, mirroring the existing Google OAuth flow.

- New `facebookId` column on `User` (via `solidworx/platform`) with matching Doctrine migration (`Version30000_11`)
- `OAuthUser` extended with `FacebookUser` branches (email, first/last name, property map, email-verified defaults to true since Facebook only releases verified emails)
- `OAuthConnect` accepts the `facebook` service with scopes `email`, `public_profile`
- `OAuthAuthenticator` now syncs first/last name from the OAuth provider on every sign-in, but only when the fields are empty — never overwriting user-edited data. Applies to both Google and Facebook.
- New `facebook_oauth_login` toggle gated on `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID` / `_SECRET` env vars
- `knpu_oauth2_client.yaml` Facebook client config (Graph API v18.0)
- `Login with Facebook` button on `/login`, `Sign up with Facebook` on `/register`, `Facebook Account` linking row on `/profile`
- Translations added for the new buttons
- Integration guide at `docs/docs/integrations/facebook-oauth.md` mirroring the Google guide
- Tests for the new Facebook branches in `OAuthUser` plus name-sync behaviour in `OAuthAuthenticator`

## ⚠️ Heads-up before merge

`composer.json` and `composer.lock` include a local path repository pointing at `/Users/pierre/projects/SolidWorx/platform`. This is local-dev convenience and will break CI / contributor installs as-is. **Drop those lines before merging** — the corresponding platform-package change (adding `facebookId` to `Bundle/Platform/Model/User.php` + an `#[ORM\Index]`) needs to land in `solidworx/platform` and be released first, then this PR can resolve `solidworx/platform` from packagist via the normal `dev-main` constraint.

## Test plan

- [ ] `bin/phpunit src/UserBundle/Tests` — all 198 tests pass (verified locally)
- [ ] `bin/ecs check` — clean (verified locally)
- [ ] `bin/phpstan analyse` on the changed production files — clean (verified locally)
- [ ] Set `SOLIDINVOICE_OAUTH_CLIENT_FACEBOOK_CLIENT_ID` and `_SECRET`, clear cache, confirm:
  - [ ] `Login with Facebook` button appears on `/login`
  - [ ] `Sign up with Facebook` button appears on `/register` when registration is enabled
  - [ ] `Facebook Account` row appears on `/profile` → Security and links successfully
  - [ ] Logging in via Facebook creates a new user (when registration enabled) and populates first/last name
  - [ ] Logging in via Facebook with the same email as an existing user attaches `facebookId` to that user without overwriting their name
- [ ] `bin/console doctrine:migrations:migrate` applies `Version30000_11` cleanly