### PR TITLE
Fix 406 on /api/docs.{format} URLs when Accept header lacks matching MIME type

### DIFF
--- a/src/ApiBundle/Event/Listener/FormatNegotiationListener.php
+++ b/src/ApiBundle/Event/Listener/FormatNegotiationListener.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Event\Listener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * When a URL extension (e.g. .json, .jsonld, .xml) explicitly pins a format,
+ * ensure the Accept header includes the corresponding MIME type so API Platform's
+ * content negotiation does not reject the request with 406.
+ *
+ * Bots and crawlers often send generic HTML Accept headers while targeting
+ * typed URLs like /api/docs.json; the URL extension should take precedence.
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 4)]
+final readonly class FormatNegotiationListener
+{
+    /** @var array<string, string> Maps Symfony request-format names to their primary MIME type. */
+    private const array FORMAT_MIME_MAP = [
+        'json' => 'application/json',
+        'jsonld' => 'application/ld+json',
+        'jsonopenapi' => 'application/vnd.openapi+json',
+        'xml' => 'application/xml',
+        'html' => 'text/html',
+    ];
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (! $event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (! str_starts_with($request->getPathInfo(), '/api/')) {
+            return;
+        }
+
+        // getRequestFormat(null) returns null when no _format was set by the router;
+        // passing null avoids the 'html' fallback that would match any Accept header.
+        $requestFormat = $request->getRequestFormat(null);
+
+        if ($requestFormat === null || ! isset(self::FORMAT_MIME_MAP[$requestFormat])) {
+            return;
+        }
+
+        $expectedMime = self::FORMAT_MIME_MAP[$requestFormat];
+        $accept = $request->headers->get('Accept', '');
+
+        if ($accept === '' || str_contains($accept, $expectedMime) || str_contains($accept, '*/*')) {
+            return;
+        }
+
+        // The URL extension explicitly requests a specific format but the Accept header
+        // (e.g. from a crawler) does not include the corresponding MIME type.
+        // Override it so content negotiation can succeed.
+        $request->headers->set('Accept', $expectedMime);
+    }
+}

--- a/src/ApiBundle/Event/Listener/FormatNegotiationListener.php
+++ b/src/ApiBundle/Event/Listener/FormatNegotiationListener.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * Bots and crawlers often send generic HTML Accept headers while targeting
  * typed URLs like /api/docs.json; the URL extension should take precedence.
+ * @see \SolidInvoice\ApiBundle\Tests\Event\Listener\FormatNegotiationListenerTest
  */
 #[AsEventListener(event: KernelEvents::REQUEST, priority: 4)]
 final readonly class FormatNegotiationListener
@@ -60,7 +61,7 @@ final readonly class FormatNegotiationListener
         $expectedMime = self::FORMAT_MIME_MAP[$requestFormat];
         $accept = $request->headers->get('Accept', '');
 
-        if ($accept === '' || str_contains($accept, $expectedMime) || str_contains($accept, '*/*')) {
+        if ($accept === '' || str_contains((string) $accept, $expectedMime) || str_contains((string) $accept, '*/*')) {
             return;
         }
 

--- a/src/ApiBundle/Tests/Event/Listener/FormatNegotiationListenerTest.php
+++ b/src/ApiBundle/Tests/Event/Listener/FormatNegotiationListenerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\Event\Listener;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ApiBundle\Event\Listener\FormatNegotiationListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class FormatNegotiationListenerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private FormatNegotiationListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->listener = new FormatNegotiationListener();
+    }
+
+    private function makeEvent(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent(M::mock(KernelInterface::class), $request, $type);
+    }
+
+    public function testSkipsSubRequests(): void
+    {
+        $request = Request::create('/api/docs.json');
+        $request->setRequestFormat('json');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request, HttpKernelInterface::SUB_REQUEST));
+
+        // Accept header must not be changed for sub-requests
+        self::assertSame('text/html', $request->headers->get('Accept'));
+    }
+
+    public function testSkipsNonApiRoutes(): void
+    {
+        $request = Request::create('/some/other/path.json');
+        $request->setRequestFormat('json');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('text/html', $request->headers->get('Accept'));
+    }
+
+    public function testSkipsWhenNoFormatSet(): void
+    {
+        $request = Request::create('/api/docs');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('text/html', $request->headers->get('Accept'));
+    }
+
+    public function testSkipsWhenFormatNotInMap(): void
+    {
+        $request = Request::create('/api/docs.csv');
+        $request->setRequestFormat('csv');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('text/html', $request->headers->get('Accept'));
+    }
+
+    public function testSkipsWhenAcceptIsEmpty(): void
+    {
+        $request = Request::create('/api/docs.json');
+        $request->setRequestFormat('json');
+        $request->headers->remove('Accept');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertNull($request->headers->get('Accept'));
+    }
+
+    public function testSkipsWhenAcceptAlreadyIncludesExpectedMime(): void
+    {
+        $request = Request::create('/api/docs.json');
+        $request->setRequestFormat('json');
+        $request->headers->set('Accept', 'application/json, text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('application/json, text/html', $request->headers->get('Accept'));
+    }
+
+    public function testSkipsWhenAcceptIncludesWildcard(): void
+    {
+        $request = Request::create('/api/docs.json');
+        $request->setRequestFormat('json');
+        $request->headers->set('Accept', 'text/html, */*');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('text/html, */*', $request->headers->get('Accept'));
+    }
+
+    public function testOverridesAcceptForJsonFormatWithBotAcceptHeader(): void
+    {
+        $request = Request::create('/api/docs.json');
+        $request->setRequestFormat('json');
+        $request->headers->set(
+            'Accept',
+            'text/html, application/rss+xml, application/atom+xml, text/xml, text/rss+xml, application/xhtml+xml'
+        );
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('application/json', $request->headers->get('Accept'));
+    }
+
+    public function testOverridesAcceptForJsonldFormat(): void
+    {
+        $request = Request::create('/api/docs.jsonld');
+        $request->setRequestFormat('jsonld');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('application/ld+json', $request->headers->get('Accept'));
+    }
+
+    public function testOverridesAcceptForXmlFormat(): void
+    {
+        $request = Request::create('/api/docs.xml');
+        $request->setRequestFormat('xml');
+        $request->headers->set('Accept', 'text/html');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('application/xml', $request->headers->get('Accept'));
+    }
+
+    public function testOverridesAcceptForJsonOpenApiFormat(): void
+    {
+        $request = Request::create('/api/docs.jsonopenapi');
+        $request->setRequestFormat('jsonopenapi');
+        $request->headers->set('Accept', 'text/html, application/rss+xml');
+
+        $this->listener->__invoke($this->makeEvent($request));
+
+        self::assertSame('application/vnd.openapi+json', $request->headers->get('Accept'));
+    }
+}


### PR DESCRIPTION
Closes #2426

## Root cause

Bots and web crawlers (SemrushBot in the Sentry report) request typed API documentation URLs like `/api/docs.json` with generic browser-style Accept headers (`text/html, application/rss+xml, application/atom+xml, text/xml, text/rss+xml, application/xhtml+xml`) that do not include `application/json`.

API Platform's `DocumentationAction` calls `ContentNegotiationTrait::getRequestFormat()` which validates the Accept header against the documentation formats. Because the `.json` URL extension constrains the available formats to just `application/json`, and the bot's Accept header contains none of the matching MIME types, API Platform throws `NotAcceptableHttpException` (406). This surfaces as an error in Sentry (SOLIDINVOICE-63, 18 occurrences).

The HTTP intent is clear: the `.json` URL extension explicitly requests JSON format. The Accept header from the bot is irrelevant noise; the URL extension should take precedence.

## Fix

Add `FormatNegotiationListener` on `KernelEvents::REQUEST` at priority 4 (after the Symfony router at priority 32 has already set the `_format` attribute from the URL extension).

For API routes (`/api/...`) where:
1. The router has pinned a specific format via URL extension (e.g. `.json`, `.jsonld`, `.xml`)
2. The Accept header does **not** already include the corresponding MIME type
3. The Accept header does **not** use a wildcard (`*/*`, which already accepts any format)

…the listener overrides the Accept header with the correct MIME type so API Platform's content negotiation succeeds and returns the format the URL explicitly requested.

## Test approach

`FormatNegotiationListenerTest` — 11 unit tests covering:

- Sub-requests are skipped (no change)
- Non-API routes are skipped (no change)
- Requests with no pinned format are skipped (no change)
- Requests with an unknown format extension are skipped (no change)
- Requests with an empty Accept header are skipped (no change)
- Requests whose Accept header already includes the expected MIME type are skipped (no change)
- Requests whose Accept header includes `*/*` are skipped (no change)
- The exact bot Accept header from the Sentry report is overridden to `application/json`
- `.jsonld`, `.xml`, and `.jsonopenapi` extensions are also overridden correctly

All 53 existing ApiBundle tests continue to pass.

## Files changed

- `src/ApiBundle/Event/Listener/FormatNegotiationListener.php` — new listener
- `src/ApiBundle/Tests/Event/Listener/FormatNegotiationListenerTest.php` — unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_017c6uWRSoV2qJWLi4TGUcsR)_