### PR TITLE
Fix DataGrid single-row batch action 500: template called non-existent executeSingleAction

### DIFF
--- a/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
+++ b/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
@@ -459,7 +459,7 @@
                                                                         type="button"
                                                                         class="dropdown-item {{ action.getColor == 'danger' ? 'text-danger' : '' }}"
                                                                         data-action="live#action"
-                                                                        data-live-action-param="executeSingleAction"
+                                                                        data-live-action-param="executeSingle"
                                                                         data-live-action-name-param="{{ action.getLabel }}"
                                                                         data-live-entity-id-param="{{ this.entityId(row) }}"
                                                                     >
@@ -634,7 +634,7 @@
                                 class="btn btn-{{ action.getColor|default('primary') }}"
                                 data-bs-dismiss="modal"
                                 data-action="live#action"
-                                data-live-action-param="executeSingleAction"
+                                data-live-action-param="executeSingle"
                                 data-live-action-name-param="{{ action.getLabel }}"
                                 data-live-entity-id-param="{{ gridComponent.entityId(row) }}"
                             >

--- a/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
+++ b/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\DataGridBundle\Tests\Twig\Components;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SolidInvoice\DataGridBundle\Twig\Components\DataGrid;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 
@@ -24,7 +25,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveAction;
  */
 final class DataGridTemplateActionNameTest extends TestCase
 {
-    private const TEMPLATE_PATH = __DIR__ . '/../../../Resources/views/Components/DataGrid.html.twig';
+    private const string TEMPLATE_PATH = __DIR__ . '/../../../Resources/views/Components/DataGrid.html.twig';
 
     public function testTemplatDoesNotReferenceNonexistentExecuteSingleActionName(): void
     {
@@ -52,7 +53,7 @@ final class DataGridTemplateActionNameTest extends TestCase
 
     public function testExecuteSingleMethodExistsWithLiveActionAttribute(): void
     {
-        $reflection = new \ReflectionClass(DataGrid::class);
+        $reflection = new ReflectionClass(DataGrid::class);
 
         self::assertTrue(
             $reflection->hasMethod('executeSingle'),
@@ -68,7 +69,7 @@ final class DataGridTemplateActionNameTest extends TestCase
 
     public function testExecuteSingleActionMethodDoesNotExist(): void
     {
-        $reflection = new \ReflectionClass(DataGrid::class);
+        $reflection = new ReflectionClass(DataGrid::class);
 
         self::assertFalse(
             $reflection->hasMethod('executeSingleAction'),

--- a/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
+++ b/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\DataGridBundle\Tests\Twig\Components;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\DataGridBundle\Twig\Components\DataGrid;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+
+/**
+ * Regression test for https://github.com/SolidInvoice/SolidInvoice/issues/2428:
+ * The DataGrid template was referencing "executeSingleAction" which does not exist —
+ * the correct LiveAction method name is "executeSingle".
+ */
+final class DataGridTemplateActionNameTest extends TestCase
+{
+    private const TEMPLATE_PATH = __DIR__ . '/../../../Resources/views/Components/DataGrid.html.twig';
+
+    public function testTemplatDoesNotReferenceNonexistentExecuteSingleActionName(): void
+    {
+        $content = file_get_contents(self::TEMPLATE_PATH);
+        self::assertIsString($content);
+
+        self::assertStringNotContainsString(
+            'executeSingleAction',
+            $content,
+            'Template must use "executeSingle", not "executeSingleAction" — the latter does not exist on the DataGrid component.',
+        );
+    }
+
+    public function testTemplateReferencesExecuteSingleLiveAction(): void
+    {
+        $content = file_get_contents(self::TEMPLATE_PATH);
+        self::assertIsString($content);
+
+        self::assertStringContainsString(
+            '"executeSingle"',
+            $content,
+            'Template must reference the executeSingle live action.',
+        );
+    }
+
+    public function testExecuteSingleMethodExistsWithLiveActionAttribute(): void
+    {
+        $reflection = new \ReflectionClass(DataGrid::class);
+
+        self::assertTrue(
+            $reflection->hasMethod('executeSingle'),
+            'DataGrid must have an executeSingle method.',
+        );
+
+        $attrs = $reflection->getMethod('executeSingle')->getAttributes(LiveAction::class);
+        self::assertNotEmpty(
+            $attrs,
+            'executeSingle must carry the #[LiveAction] attribute so the Live Component router can find it.',
+        );
+    }
+
+    public function testExecuteSingleActionMethodDoesNotExist(): void
+    {
+        $reflection = new \ReflectionClass(DataGrid::class);
+
+        self::assertFalse(
+            $reflection->hasMethod('executeSingleAction'),
+            'There must be no "executeSingleAction" method — the template should use "executeSingle".',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2428

**Root cause:** The `DataGrid.html.twig` template called `executeSingleAction` as the Live Component action name in two places — the direct row-action button and the confirmation-modal confirm button. The PHP class (`DataGrid`) only has a `#[LiveAction]`-annotated method named `executeSingle` (not `executeSingleAction`). Symfony UX Live Component routes requests by method name, so every click on a single-row batch action that doesn't require confirmation produced:

```
InvalidArgumentException: The controller for URI "/_components/DataGrid/executeSingleAction"
is not callable: Expected method "executeSingleAction" on class
"SolidInvoice\DataGridBundle\Twig\Components\DataGrid", did you mean "executeSingle"?
```

**Fix:** Rename `executeSingleAction` → `executeSingle` in both button elements inside `DataGrid.html.twig`.

## Changes

- `src/DataGridBundle/Resources/views/Components/DataGrid.html.twig` — fix action name in 2 places
- `src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php` — regression tests

## Test approach

Added `DataGridTemplateActionNameTest` (plain `TestCase`, no kernel required):

1. **`testTemplatDoesNotReferenceNonexistentExecuteSingleActionName`** — asserts the template does not contain the string `executeSingleAction` (this test would have **failed** on the old template).
2. **`testTemplateReferencesExecuteSingleLiveAction`** — asserts the template contains `"executeSingle"` so a future rename can't silently break it again.
3. **`testExecuteSingleMethodExistsWithLiveActionAttribute`** — asserts the PHP method exists and carries `#[LiveAction]`.
4. **`testExecuteSingleActionMethodDoesNotExist`** — asserts there is no `executeSingleAction` method on the component (the method the old template was trying to call).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdMNteXnW7tATz77zHMRHT)_