### PR TITLE
Fix Helm chart publish failing on branch checkout during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
 
+          # Discard the working-tree edits made by the version bump and
+          # 'helm dep update' (Chart.yaml / Chart.lock). They're already baked
+          # into the packaged .tgz, and would otherwise block the branch switch
+          # ("local changes would be overwritten by checkout").
+          git checkout -- .
+
           # Switch to gh-pages branch, creating an orphan if it doesn't exist yet
           if git ls-remote --heads origin gh-pages | grep -q gh-pages; then
             git checkout gh-pages


### PR DESCRIPTION
## Summary

Fixes the `publish-helm` job in the release workflow, which was failing during a release with:

```
error: Your local changes to the following files would be overwritten by checkout:
	helm/solidinvoice/Chart.lock
	helm/solidinvoice/Chart.yaml
Please commit your changes or stash them before you switch branches.
Aborting
```

## Root cause

Both `helm/solidinvoice/Chart.yaml` and `helm/solidinvoice/Chart.lock` are git-tracked. Earlier steps in the same job leave them modified in the working tree:

- **Set chart version** rewrites `version`/`appVersion` in `Chart.yaml` via `sed`.
- **Update Helm dependencies** (`helm dep update`) regenerates `Chart.lock`.

The **Publish to Helm repository (gh-pages)** step then runs `git checkout gh-pages`. Since `gh-pages` is an orphan branch that doesn't contain those files, switching branches would discard the local modifications, so git aborts.

## Fix

By the time the publish step runs, the chart has already been packaged into `/tmp/helm-packages/*.tgz`, so the working-tree edits are no longer needed. A `git checkout -- .` is added right before the branch switch to discard them, allowing the checkout to proceed.

## Notes

This branch is ahead of `3.0.x` by several previously-committed changes; the net-new change in this session is the one-line Helm publish fix in `.github/workflows/release.yml`.
