### PR TITLE
Fix DataGrid bulk-action bar calling non-existent executeBatchAction live action

### DIFF
--- a/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
+++ b/src/DataGridBundle/Resources/views/Components/DataGrid.html.twig
@@ -564,7 +564,7 @@
                                 class="datagrid-bulk-btn {{ action.getColor == 'danger' ? 'btn-danger' : '' }}"
                                 data-action="live#action"
                                 data-live-action-name-param="{{ action.getLabel }}"
-                                data-live-action-param="debounce(300)|executeBatchAction"
+                                data-live-action-param="debounce(300)|executeBatch"
                             >
                                 {% if action.getIcon is not empty %}
                                     {{ ux_icon('tabler:' ~ action.getIcon, {width: 16, height: 16}) }}
@@ -608,7 +608,7 @@
                             data-bs-dismiss="modal"
                             data-action="live#action"
                             data-live-action-name-param="{{ action.getLabel }}"
-                            data-live-action-param="debounce(300)|executeBatchAction"
+                            data-live-action-param="debounce(300)|executeBatch"
                         >
                             {{ 'Confirm'|trans }}
                         </button>

--- a/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
+++ b/src/DataGridBundle/Tests/Twig/Components/DataGridTemplateActionNameTest.php
@@ -76,4 +76,59 @@ final class DataGridTemplateActionNameTest extends TestCase
             'There must be no "executeSingleAction" method — the template should use "executeSingle".',
         );
     }
+
+    /**
+     * Regression tests for https://github.com/SolidInvoice/SolidInvoice/issues/2430:
+     * The DataGrid template was referencing "executeBatchAction" which does not exist —
+     * the correct LiveAction method name is "executeBatch".
+     */
+    public function testTemplateDoesNotReferenceNonexistentExecuteBatchActionName(): void
+    {
+        $content = file_get_contents(self::TEMPLATE_PATH);
+        self::assertIsString($content);
+
+        self::assertStringNotContainsString(
+            'executeBatchAction',
+            $content,
+            'Template must use "executeBatch", not "executeBatchAction" — the latter does not exist on the DataGrid component.',
+        );
+    }
+
+    public function testTemplateReferencesExecuteBatchLiveAction(): void
+    {
+        $content = file_get_contents(self::TEMPLATE_PATH);
+        self::assertIsString($content);
+
+        self::assertStringContainsString(
+            'executeBatch"',
+            $content,
+            'Template must reference the executeBatch live action.',
+        );
+    }
+
+    public function testExecuteBatchMethodExistsWithLiveActionAttribute(): void
+    {
+        $reflection = new ReflectionClass(DataGrid::class);
+
+        self::assertTrue(
+            $reflection->hasMethod('executeBatch'),
+            'DataGrid must have an executeBatch method.',
+        );
+
+        $attrs = $reflection->getMethod('executeBatch')->getAttributes(LiveAction::class);
+        self::assertNotEmpty(
+            $attrs,
+            'executeBatch must carry the #[LiveAction] attribute so the Live Component router can find it.',
+        );
+    }
+
+    public function testExecuteBatchActionMethodDoesNotExist(): void
+    {
+        $reflection = new ReflectionClass(DataGrid::class);
+
+        self::assertFalse(
+            $reflection->hasMethod('executeBatchAction'),
+            'There must be no "executeBatchAction" method — the template should use "executeBatch".',
+        );
+    }
 }


### PR DESCRIPTION
Closes #2430

## Root cause

`DataGrid.html.twig` referenced `executeBatchAction` in two places:

- **Line 567** — the direct "execute" button in the floating bulk-action bar (for non-confirm actions)
- **Line 611** — the "Confirm" button inside the batch confirmation modal

The PHP component (`DataGrid`) only defines a `#[LiveAction]` method named `executeBatch` (no `Action` suffix). Symfony UX Live Component routes by exact method name, so clicking either button threw:

```
InvalidArgumentException: The controller for URI "/_components/DataGrid/executeBatchAction"
is not callable: Expected method "executeBatchAction" on class
"SolidInvoice\DataGridBundle\Twig\Components\DataGrid", did you mean "executeBatch"?
```

## Fix

Renamed both `data-live-action-param` occurrences from `executeBatchAction` → `executeBatch` in `DataGrid.html.twig`. This is the exact parallel of the `executeSingleAction` → `executeSingle` rename from issue #2428.

## Test approach

Added four regression tests to the existing `DataGridTemplateActionNameTest`, mirroring the pattern established for the `executeSingle` fix:

1. `testTemplateDoesNotReferenceNonexistentExecuteBatchActionName` — asserts the wrong name is absent from the template
2. `testTemplateReferencesExecuteBatchLiveAction` — asserts the correct name is present
3. `testExecuteBatchMethodExistsWithLiveActionAttribute` — asserts the PHP method exists with `#[LiveAction]`
4. `testExecuteBatchActionMethodDoesNotExist` — asserts no `executeBatchAction` method exists on the component

All 8 tests in `DataGridTemplateActionNameTest` pass (including the 4 pre-existing `executeSingle` tests). ECS and PHPStan report no issues on the changed files.

https://claude.ai/code/session_01Y6f4sPUSbTiUtzckDBA7Vr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6f4sPUSbTiUtzckDBA7Vr)_