### PR TITLE
Fix unhandled LemonSqueezy checkout API error in SubscribeController

### DIFF
--- a/src/SaasBundle/Controller/SubscribeController.php
+++ b/src/SaasBundle/Controller/SubscribeController.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\SaasBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
 use SolidInvoice\UserBundle\Entity\User;
@@ -27,13 +27,15 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class SubscribeController extends AbstractController
 {
     public function __construct(
         private readonly SubscriptionManager $subscriptionManager,
         private readonly CompanyRepository $companyRepository,
-        private readonly CompanySelector $companySelector,
+        private readonly CompanySelectorInterface $companySelector,
         private readonly PlanRepositoryInterface $planRepository,
         private readonly EntityManagerInterface $entityManager,
     ) {
@@ -77,6 +79,10 @@ class SubscribeController extends AbstractController
         try {
             $checkoutUrl = $this->subscriptionManager
                 ->getCheckoutUrl($subscription, $options);
+        } catch (HttpExceptionInterface | TransportExceptionInterface) {
+            $this->addFlash('error', 'Unable to create checkout session. Please try again later.');
+
+            return $this->redirectToRoute('billing_index');
         } finally {
             // Discard the in-memory plan swap. The subscription entity is
             // reloaded from the database so the in-memory mutation is never

--- a/src/SaasBundle/Controller/SubscribeController.php
+++ b/src/SaasBundle/Controller/SubscribeController.php
@@ -30,6 +30,9 @@ use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
+/**
+ * @see \SolidInvoice\SaasBundle\Tests\Controller\SubscribeControllerTest
+ */
 class SubscribeController extends AbstractController
 {
     public function __construct(

--- a/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
+++ b/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\SaasBundle\Controller\SubscribeController;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[CoversClass(SubscribeController::class)]
+final class SubscribeControllerTest extends TestCase
+{
+    public function testTransportExceptionRedirectsToOverviewWithErrorFlash(): void
+    {
+        $exception = new TransportException('HTTP/2 404 returned for "https://api.lemonsqueezy.com/v1/checkouts"');
+
+        $response = $this->invokeControllerWithCheckoutException($exception);
+
+        self::assertInstanceOf(RedirectResponse::class, $response[0]);
+        self::assertSame('/billing/', $response[0]->getTargetUrl());
+        self::assertArrayHasKey('error', $response[1]);
+        self::assertNotEmpty($response[1]['error']);
+    }
+
+    public function testHttpClientExceptionRedirectsToOverviewWithErrorFlash(): void
+    {
+        $exception = new class() extends \RuntimeException implements ClientExceptionInterface {
+            public function getResponse(): ResponseInterface
+            {
+                throw new \LogicException('Not needed in test');
+            }
+        };
+
+        $response = $this->invokeControllerWithCheckoutException($exception);
+
+        self::assertInstanceOf(RedirectResponse::class, $response[0]);
+        self::assertSame('/billing/', $response[0]->getTargetUrl());
+        self::assertArrayHasKey('error', $response[1]);
+        self::assertNotEmpty($response[1]['error']);
+    }
+
+    /**
+     * @return array{0: RedirectResponse, 1: array<string, list<string|\Stringable>>}
+     */
+    private function invokeControllerWithCheckoutException(\Throwable $exception): array
+    {
+        $paymentIntegration = $this->createMock(PaymentIntegrationInterface::class);
+        $paymentIntegration->method('checkout')->willThrowException($exception);
+
+        $plan = new Plan();
+        $plan->setName('Pro');
+        $plan->setPlanId('variant-123');
+        $plan->setPrice(1000);
+
+        $subscription = new Subscription();
+        $subscription->setPlan($plan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+
+        $subscriptionManager = new SubscriptionManager(
+            $subscriptionRepository,
+            $this->createMock(PlanRepositoryInterface::class),
+            $paymentIntegration,
+        );
+
+        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector->method('getCompany')->willReturn(new Ulid());
+
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository->method('find')->willReturn(new Company());
+
+        $controller = new SubscribeController(
+            $subscriptionManager,
+            $companyRepository,
+            $companySelector,
+            $this->createMock(PlanRepositoryInterface::class),
+            $this->createMock(EntityManagerInterface::class),
+        );
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/billing/subscription/activate');
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/billing/');
+
+        $user = new User();
+        $user->setEmail('test@example.com');
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        $container = new Container();
+        $container->set('request_stack', $requestStack);
+        $container->set('router', $router);
+        $container->set('security.token_storage', $tokenStorage);
+
+        $controller->setContainer($container);
+
+        /** @var RedirectResponse $response */
+        $response = $controller(new Request());
+
+        return [$response, $session->getFlashBag()->all()];
+    }
+}

--- a/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
+++ b/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace SolidInvoice\SaasBundle\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
@@ -27,6 +29,7 @@ use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use Stringable;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -40,6 +43,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Throwable;
 
 #[CoversClass(SubscribeController::class)]
 final class SubscribeControllerTest extends TestCase
@@ -58,10 +62,10 @@ final class SubscribeControllerTest extends TestCase
 
     public function testHttpClientExceptionRedirectsToOverviewWithErrorFlash(): void
     {
-        $exception = new class() extends \RuntimeException implements ClientExceptionInterface {
+        $exception = new class() extends RuntimeException implements ClientExceptionInterface {
             public function getResponse(): ResponseInterface
             {
-                throw new \LogicException('Not needed in test');
+                throw new LogicException('Not needed in test');
             }
         };
 
@@ -74,9 +78,9 @@ final class SubscribeControllerTest extends TestCase
     }
 
     /**
-     * @return array{0: RedirectResponse, 1: array<string, list<string|\Stringable>>}
+     * @return array{0: RedirectResponse, 1: array<string, list<string|Stringable>>}
      */
-    private function invokeControllerWithCheckoutException(\Throwable $exception): array
+    private function invokeControllerWithCheckoutException(Throwable $exception): array
     {
         $paymentIntegration = $this->createMock(PaymentIntegrationInterface::class);
         $paymentIntegration->method('checkout')->willThrowException($exception);
@@ -94,7 +98,7 @@ final class SubscribeControllerTest extends TestCase
 
         $subscriptionManager = new SubscriptionManager(
             $subscriptionRepository,
-            $this->createMock(PlanRepositoryInterface::class),
+            $this->createStub(PlanRepositoryInterface::class),
             $paymentIntegration,
         );
 
@@ -108,16 +112,15 @@ final class SubscribeControllerTest extends TestCase
             $subscriptionManager,
             $companyRepository,
             $companySelector,
-            $this->createMock(PlanRepositoryInterface::class),
-            $this->createMock(EntityManagerInterface::class),
+            $this->createStub(PlanRepositoryInterface::class),
+            $this->createStub(EntityManagerInterface::class),
         );
 
         $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/billing/subscription/activate');
         $request->setSession($session);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $router = $this->createMock(RouterInterface::class);
         $router->method('generate')->willReturn('/billing/');


### PR DESCRIPTION
Closes #2429

## Root cause

When the LemonSqueezy API returns an HTTP error (4xx/5xx — in production a 404 for an unknown store or variant) or a transport-level failure, `LemonSqueezy::checkout()` calls `$response->toArray()` which triggers Symfony HttpClient's `checkStatusCode()` and throws a `ClientException`. This exception propagated uncaught through `SubscribeController::__invoke()` because the existing `try/finally` block had **no `catch` clause**, surfacing as a 500 crash to every user who hit the checkout route (Sentry SOLIDINVOICE-8C, 2 occurrences affecting 2 users).

Stack trace summary:
```
SubscribeController::__invoke() line 79
  → SubscriptionManager::getCheckoutUrl()
    → LemonSqueezy::checkout() — $response->toArray()
      → CommonResponseTrait::checkStatusCode()
        → throws ClientException: HTTP/2 404 returned for "https://api.lemonsqueezy.com/v1/checkouts"
```

## Fix

- Added `catch (HttpExceptionInterface | TransportExceptionInterface)` to the existing `try/finally` in `SubscribeController::__invoke()`. The catch block sets an error flash message and redirects to `billing_index`. The `finally` block still executes (entity refresh) before the redirect is returned.
- Widened the `CompanySelector` constructor parameter from the concrete `final` class to its `CompanySelectorInterface` — a one-liner that follows the existing interface and is required for unit-testing the controller.

## Test approach

Added `SubscribeControllerTest` with two cases:

1. `testTransportExceptionRedirectsToOverviewWithErrorFlash` — exercises a `TransportException` (network/connection failure), verifies redirect to `/billing/` with `error` flash set.
2. `testHttpClientExceptionRedirectsToOverviewWithErrorFlash` — exercises a `ClientExceptionInterface` (HTTP 4xx/5xx), same assertions.

Both tests use a real `SubscriptionManager` constructed with a mocked `PaymentIntegrationInterface` that throws, avoiding the need to mock the `final readonly` class directly.

All checks pass: 2/2 tests green, ECS clean, PHPStan level 6 no new errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk3GRqR3LVm4sRg7o4fBSa)_