### PR TITLE
Fix crash when Settings page is visited with invalid/empty section URL param

### DIFF
--- a/src/SettingsBundle/Tests/Twig/Components/SettingsTest.php
+++ b/src/SettingsBundle/Tests/Twig/Components/SettingsTest.php
@@ -76,6 +76,34 @@ final class SettingsTest extends LiveComponentTest
         $this->assertMatchesHtmlSnapshot($this->replaceChecksum((string) $this->settingsComponent->render()));
     }
 
+    public function testInvalidSectionFallsBackToFirstSection(): void
+    {
+        $this->ensureSessionIsSet();
+
+        // Reproduce Sentry SOLIDINVOICE-8M / SOLIDINVOICE-8J: URL param ?section='"""""""
+        // sets $this->section to a key that does not exist in getAppSettings()
+        $this->settingsComponent->set('section', '\'"""""""');
+
+        // Before fix: throws ErrorException "Undefined array key '\"\"\"\"\"\"'"
+        // After fix: falls back to the first valid section and renders without crashing
+        $html = (string) $this->settingsComponent->render();
+
+        self::assertNotEmpty($html);
+    }
+
+    public function testEmptySectionFallsBackToFirstSection(): void
+    {
+        $this->ensureSessionIsSet();
+
+        // Reproduce Sentry SOLIDINVOICE-8J / SOLIDINVOICE-8K: URL param ?section= (empty)
+        // Before fix: throws ErrorException "Undefined array key ''"
+        // After fix: falls back to the first valid section and renders without crashing
+        $this->settingsComponent->set('section', '');
+        $html = (string) $this->settingsComponent->render();
+
+        self::assertNotEmpty($html);
+    }
+
     public function testSaveOnDifferentSection(): void
     {
         $this->csrfTokenManager

--- a/src/SettingsBundle/Twig/Components/Settings.php
+++ b/src/SettingsBundle/Twig/Components/Settings.php
@@ -33,6 +33,7 @@ use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 use Throwable;
+use function array_key_first;
 use function str_replace;
 
 /**
@@ -110,10 +111,15 @@ final class Settings extends AbstractController
     protected function instantiateForm(): FormInterface
     {
         $isTrialSubscription = $this->subscriptionService?->isTrialSubscription() ?? false;
+        $appSettings = $this->getAppSettings(false);
+
+        if (! isset($appSettings[$this->section])) {
+            $this->section = (string) array_key_first($appSettings);
+        }
 
         return $this->createForm(
             SettingsType::class,
-            $this->getAppSettings(false)[$this->section],
+            $appSettings[$this->section],
             [
                 'settings' => $this->getAppSettings(true)[$this->section],
                 'subscription_in_trial' => $isTrialSubscription,


### PR DESCRIPTION
Closes #2439

## Root cause

The `Settings` Live Component exposes its `$section` property as a URL-bound `#[LiveProp]`. When a visitor browses to `/settings?section=<garbage>` (e.g. the actual URL captured in Sentry was `?section=%27%22%22%22%22%22%22%22`), Symfony UX sets `$this->section` to that garbage value *after* `preMount()` has already set it to the first valid key.

`instantiateForm()` then did:

```php
$this->getAppSettings(false)[$this->section]   // line 116 — ErrorException on invalid key
$this->getAppSettings(true)[$this->section]    // line 118 — same
```

With PHP 8 + `failOnWarning=true`, accessing a missing array key triggers `ErrorException: Warning: Undefined array key "..."` and a fatal 500.

This is the root cause of three closely-related Sentry issues:
- **SOLIDINVOICE-8M** (`foreach()` null — issue #2439)
- **SOLIDINVOICE-8K** (Undefined array key on `getAppSettings(true)` — issue #2440)
- **SOLIDINVOICE-8J** (Undefined array key on `getAppSettings(false)` — issue #2441)

## Fix

Added a guard at the top of `instantiateForm()`: if `$this->section` is missing from the settings map (or is an empty string), fall back to `array_key_first($appSettings)` — the same key that `preMount()` would have chosen on a clean mount.

```php
$appSettings = $this->getAppSettings(false);

if (! isset($appSettings[$this->section])) {
    $this->section = (string) array_key_first($appSettings);
}
```

This keeps the page functional for benign bookmarks/links with a stale section, and prevents malicious/garbage section values from crashing the application.

## Test approach

Added two regression tests to `SettingsTest`:

- `testInvalidSectionFallsBackToFirstSection` — exercises the exact garbage string from Sentry (`'"""""""`)
- `testEmptySectionFallsBackToFirstSection` — exercises the empty-string case (`section=`)

Before the fix these tests would fail with `ErrorException: Undefined array key` during form instantiation. After the fix they progress past form instantiation and fail only at the pre-existing blocked-network `api.iconify.design` call (same failure mode as every other `SettingsTest` in this environment), confirming the array-key crash is resolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTubUC8d5PEVJs1FYwUbR7)_