### PR TITLE
Fix TypeError when Payum builds gateway with private action/extension services

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,7 @@ use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
+use Rector\Symfony\Configs\Rector\Closure\FromServicePublicToDefaultsPublicRector;
 use Rector\Symfony\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector;
 use Rector\Symfony\Configs\Rector\Closure\ServiceSettersToSettersAutodiscoveryRector;
 use Rector\Symfony\Set\SymfonySetList;
@@ -115,5 +116,10 @@ return RectorConfig::configure()
         RemoveNewArrayCollectionOutsideConstructorRector::class => [
             // This file uses __clone() which must use a new array collection
             'src/InvoiceBundle/Entity/Invoice.php'
+        ],
+
+        FromServicePublicToDefaultsPublicRector::class => [
+            // This rule removes ->public() calls on services that must be defined as public.
+            'src/PaymentBundle/Resources/config/services/services.php'
         ],
     ]);

--- a/src/PaymentBundle/Resources/config/services/services.php
+++ b/src/PaymentBundle/Resources/config/services/services.php
@@ -27,7 +27,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->defaults()
         ->autoconfigure()
         ->autowire()
-        ->private()
         ->bind('$invoiceStateMachine', service('state_machine.invoice'))
     ;
 
@@ -41,14 +40,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->set(PaymentDetailsStatusAction::class)
+        ->public()
         ->tag('payum.action', ['factory' => 'paypal_express_checkout', 'prepend' => true]);
 
     $services
         ->set(StatusAction::class)
+        ->public()
         ->tag('payum.action', ['factory' => 'offline']);
 
     $services
         ->set(UpdatePaymentDetailsExtension::class)
+        ->public()
         ->tag('payum.extension', ['all' => true]);
 
     $services->alias(RegistryInterface::class, 'payum');

--- a/src/PaymentBundle/Resources/config/services/services.php
+++ b/src/PaymentBundle/Resources/config/services/services.php
@@ -41,14 +41,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->set(PaymentDetailsStatusAction::class)
+        ->public()
         ->tag('payum.action', ['factory' => 'paypal_express_checkout', 'prepend' => true]);
 
     $services
         ->set(StatusAction::class)
+        ->public()
         ->tag('payum.action', ['factory' => 'offline']);
 
     $services
         ->set(UpdatePaymentDetailsExtension::class)
+        ->public()
         ->tag('payum.extension', ['all' => true]);
 
     $services->alias(RegistryInterface::class, 'payum');

--- a/src/PaymentBundle/Resources/config/services/services.php
+++ b/src/PaymentBundle/Resources/config/services/services.php
@@ -21,12 +21,12 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->defaults()->public();
 
     $services
         ->defaults()
         ->autoconfigure()
         ->autowire()
+        ->private()
         ->bind('$invoiceStateMachine', service('state_machine.invoice'))
     ;
 

--- a/src/PaymentBundle/Resources/config/services/services.php
+++ b/src/PaymentBundle/Resources/config/services/services.php
@@ -41,17 +41,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->set(PaymentDetailsStatusAction::class)
-        ->public()
         ->tag('payum.action', ['factory' => 'paypal_express_checkout', 'prepend' => true]);
 
     $services
         ->set(StatusAction::class)
-        ->public()
         ->tag('payum.action', ['factory' => 'offline']);
 
     $services
         ->set(UpdatePaymentDetailsExtension::class)
-        ->public()
         ->tag('payum.extension', ['all' => true]);
 
     $services->alias(RegistryInterface::class, 'payum');

--- a/src/PaymentBundle/Tests/DependencyInjection/PayumActionServicesPublicTest.php
+++ b/src/PaymentBundle/Tests/DependencyInjection/PayumActionServicesPublicTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\PaymentBundle\Tests\DependencyInjection;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Extension\ExtensionInterface;
+use SolidInvoice\PaymentBundle\PaymentAction\Offline\StatusAction;
+use SolidInvoice\PaymentBundle\PaymentAction\PaypalExpress\PaymentDetailsStatusAction;
+use SolidInvoice\PaymentBundle\Payum\Extension\UpdatePaymentDetailsExtension;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Regression test for https://github.com/SolidInvoice/SolidInvoice/issues/2436
+ *
+ * PayumBundle's ContainerAwareCoreGatewayFactory resolves "@serviceId" strings
+ * to real service objects via $container->has() / $container->get(). In Symfony's
+ * compiled container, has() returns false for private services, so Payum-tagged
+ * action/extension services MUST be public or the gateway builder passes raw
+ * strings to Gateway::addAction(), causing a TypeError at runtime.
+ */
+final class PayumActionServicesPublicTest extends KernelTestCase
+{
+    public function testOfflineStatusActionIsPubliclyAccessible(): void
+    {
+        $container = self::getContainer();
+
+        self::assertTrue(
+            $container->has(StatusAction::class),
+            StatusAction::class . ' must be a public service so ContainerAwareCoreGatewayFactory can resolve it'
+        );
+        self::assertInstanceOf(ActionInterface::class, $container->get(StatusAction::class));
+    }
+
+    public function testPaypalExpressPaymentDetailsStatusActionIsPubliclyAccessible(): void
+    {
+        $container = self::getContainer();
+
+        self::assertTrue(
+            $container->has(PaymentDetailsStatusAction::class),
+            PaymentDetailsStatusAction::class . ' must be a public service so ContainerAwareCoreGatewayFactory can resolve it'
+        );
+        self::assertInstanceOf(ActionInterface::class, $container->get(PaymentDetailsStatusAction::class));
+    }
+
+    public function testUpdatePaymentDetailsExtensionIsPubliclyAccessible(): void
+    {
+        $container = self::getContainer();
+
+        self::assertTrue(
+            $container->has(UpdatePaymentDetailsExtension::class),
+            UpdatePaymentDetailsExtension::class . ' must be a public service so ContainerAwareCoreGatewayFactory can resolve it'
+        );
+        self::assertInstanceOf(ExtensionInterface::class, $container->get(UpdatePaymentDetailsExtension::class));
+    }
+}


### PR DESCRIPTION
Closes #2436

## Root cause

`PayumBundle`'s `ContainerAwareCoreGatewayFactory::buildClosures()` resolves `@serviceId` strings in the gateway factory config to real service objects at runtime:

```php
if ('@' === $value[0] && $this->container->has(substr($value, 1))) {
    $config[$name] = $this->container->get(substr($value, 1));
}
```

`BuildConfigsPass` stores tagged `payum.action` / `payum.extension` services as `"@serviceId"` strings in the factory config. These strings are meant to be resolved back to real objects in `buildClosures()` before `buildActions()` calls `$gateway->addAction($value)`.

The problem: in Symfony's compiled container, `Container::has()` returns **`false`** for private services. The three SolidInvoice services tagged for Payum (`StatusAction`, `PaymentDetailsStatusAction`, `UpdatePaymentDetailsExtension`) inherited the `->private()` default from `services.php`. Because `has()` returned false, the `"@serviceId"` strings were **not** resolved to service objects and were passed directly to `Gateway::addAction()`, which type-declares `ActionInterface $action` — hence:

```
TypeError: Payum\Core\Gateway::addAction(): Argument #1 ($action) must be of type
Payum\Core\Action\ActionInterface, string given
```

This is the crash captured in Sentry SOLIDINVOICE-84 (5 occurrences, 2 users, substatus: regressed).

## Fix

Added `->public()` to the three Payum-tagged service definitions in `src/PaymentBundle/Resources/config/services/services.php`:

- `PaymentDetailsStatusAction` (tagged `payum.action` for `paypal_express_checkout` factory)
- `StatusAction` (tagged `payum.action` for `offline` factory)
- `UpdatePaymentDetailsExtension` (tagged `payum.extension` for all factories)

This matches how PayumBundle's own built-in actions are registered (`setPublic(true)` in its `payum.php`).

## Test approach

Added `src/PaymentBundle/Tests/DependencyInjection/PayumActionServicesPublicTest.php` with three tests that assert each affected service is:
1. Accessible via `$container->has($serviceId)` — returns `true` (false before the fix)
2. An instance of the expected interface (`ActionInterface` / `ExtensionInterface`)

All three tests fail before the fix and pass after it.

https://claude.ai/code/session_01XoNK9b4rYbaWgRzssK5une

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoNK9b4rYbaWgRzssK5une)_