### PR TITLE
Fix CSRF token failure in CustomField DeleteAction throwing 403 instead of redirecting

### DIFF
--- a/src/SettingsBundle/Action/CustomField/DeleteAction.php
+++ b/src/SettingsBundle/Action/CustomField/DeleteAction.php
@@ -24,6 +24,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Uid\Ulid;
 
+/**
+ * @see \SolidInvoice\SettingsBundle\Tests\Action\CustomField\DeleteActionTest
+ */
 final class DeleteAction extends AbstractController
 {
     public function __construct(
@@ -40,7 +43,8 @@ final class DeleteAction extends AbstractController
 
         $token = (string) $request->request->get('_token');
         if (! $this->isCsrfTokenValid('cf_delete_' . $id, $token)) {
-            throw $this->createAccessDeniedException('Invalid CSRF token.');
+            $this->addFlash('error', 'Invalid CSRF token. Please try again.');
+            return new RedirectResponse($this->generateUrl('_settings_custom_fields'));
         }
 
         $field = $this->em->find(CustomField::class, Ulid::fromString($id));

--- a/src/SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php
+++ b/src/SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SettingsBundle\Tests\Action\CustomField;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SolidInvoice\SettingsBundle\Action\CustomField\DeleteAction;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Ulid;
+
+final class DeleteActionTest extends KernelTestCase
+{
+    public function testInvalidCsrfTokenRedirectsWithErrorFlashInsteadOfThrowing(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $em = $this->createStub(EntityManagerInterface::class);
+
+        /** @var FeatureGate $featureGate */
+        $featureGate = $container->get('test.' . FeatureGate::class);
+
+        $action = new DeleteAction($em, $featureGate);
+        $action->setContainer($container);
+
+        $fieldId = new Ulid();
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+
+        $request = Request::create('/settings/custom-fields/' . $fieldId . '/delete', Request::METHOD_POST);
+        $request->setSession($session);
+
+        $requestStack = $container->get('request_stack');
+        $requestStack->push($request);
+
+        $request->request->set('_token', 'invalid_token');
+
+        $response = $action($request, (string) $fieldId);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringEndsWith('/settings/custom-fields', $response->getTargetUrl());
+
+        /** @var FlashBagInterface $flashBag */
+        $flashBag = $session->getBag('flashes');
+        $flashes = $flashBag->all();
+        self::assertArrayHasKey('error', $flashes);
+        self::assertContains('Invalid CSRF token. Please try again.', $flashes['error']);
+    }
+
+    public function testValidCsrfTokenPassesCsrfCheck(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('find')->willReturn(null);
+
+        /** @var FeatureGate $featureGate */
+        $featureGate = $container->get('test.' . FeatureGate::class);
+
+        $action = new DeleteAction($em, $featureGate);
+        $action->setContainer($container);
+
+        $fieldId = new Ulid();
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+
+        $request = Request::create('/settings/custom-fields/' . $fieldId . '/delete', Request::METHOD_POST);
+        $request->setSession($session);
+
+        $requestStack = $container->get('request_stack');
+        $requestStack->push($request);
+
+        // Generate a real CSRF token for the expected key
+        $csrfTokenManager = $container->get('security.csrf.token_manager');
+        $token = $csrfTokenManager->getToken('cf_delete_' . $fieldId);
+        $request->request->set('_token', $token->getValue());
+
+        // A valid CSRF token passes the check; the action proceeds to the entity
+        // lookup and throws NotFoundHttpException (em->find returns null).
+        $this->expectException(NotFoundHttpException::class);
+        $action($request, (string) $fieldId);
+    }
+}


### PR DESCRIPTION
Closes #2438

## Root cause

`DeleteAction::__invoke()` validated the CSRF token correctly but responded to a failed check by calling `$this->createAccessDeniedException('Invalid CSRF token.')` and throwing it. Symfony converts that into a 403 `AccessDeniedHttpException`, which was caught by Sentry as an unhandled exception (SOLIDINVOICE-8P).

A legitimate user who has the custom-fields settings page open across multiple tabs, or leaves the tab idle long enough for the session to rotate the CSRF token, would see a generic "Access Denied" error page rather than a helpful message. There was no way for them to retry the delete.

## Fix

Replace the `throw createAccessDeniedException(...)` with the same graceful pattern already used by `SendManualReminder` for its own CSRF check:

- `$this->addFlash('error', 'Invalid CSRF token. Please try again.')` — tells the user what happened
- `return new RedirectResponse($this->generateUrl('_settings_custom_fields'))` — sends them back to the list page where the form (and a fresh CSRF token) will be rendered again

The `AccessDeniedException` path for the _feature gate_ check (`Custom fields are not available on the current plan`) is intentionally left as-is, since that is a legitimate authorization denial rather than a transient session issue.

## Test approach

Added `src/SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php` with two cases:

1. **`testInvalidCsrfTokenRedirectsWithErrorFlashInsteadOfThrowing`** — submits an invalid `_token`; asserts the response is a `RedirectResponse` to `/settings/custom-fields` and that an `error` flash (`'Invalid CSRF token. Please try again.'`) was added to the session. This test **fails** on the old code (the thrown exception is not caught) and **passes** after the fix.

2. **`testValidCsrfTokenPassesCsrfCheck`** — submits a genuinely valid CSRF token (obtained from the container's `security.csrf.token_manager`); stubs `EntityManager::find()` to return `null`; asserts a `NotFoundHttpException` is thrown, proving the CSRF check was passed and execution continued into the entity-lookup logic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWn5H1zUb1ApZaYrzaemXX)_