### PR TITLE
Fix HydrationException crash when LiveComponent checksum is stale

### DIFF
--- a/src/CoreBundle/Listener/LiveComponentHydrationExceptionListener.php
+++ b/src/CoreBundle/Listener/LiveComponentHydrationExceptionListener.php
@@ -27,11 +27,12 @@ use Symfony\UX\LiveComponent\Exception\HydrationException;
  *
  * This typically occurs when APP_SECRET rotates on redeployment or the
  * user's session expires while a Live Component form is open.
+ * @see \SolidInvoice\CoreBundle\Tests\Listener\LiveComponentHydrationExceptionListenerTest
  */
-final class LiveComponentHydrationExceptionListener implements EventSubscriberInterface
+final readonly class LiveComponentHydrationExceptionListener implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RouterInterface $router,
+        private RouterInterface $router,
     ) {
     }
 

--- a/src/CoreBundle/Listener/LiveComponentHydrationExceptionListener.php
+++ b/src/CoreBundle/Listener/LiveComponentHydrationExceptionListener.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Listener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\UX\LiveComponent\Exception\HydrationException;
+
+/**
+ * Converts a LiveComponent HydrationException (invalid checksum) into a
+ * user-friendly redirect instead of a 500 error page.
+ *
+ * This typically occurs when APP_SECRET rotates on redeployment or the
+ * user's session expires while a Live Component form is open.
+ */
+final class LiveComponentHydrationExceptionListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', 64],
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        if (! $event->getThrowable() instanceof HydrationException) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $request->getSession();
+
+        if ($session instanceof Session) {
+            $session->getFlashBag()->add('error', 'live_component.session_expired');
+        }
+
+        $referer = $request->headers->get('Referer');
+        $url = ($referer !== null && $referer !== '') ? $referer : $this->router->generate('_home');
+
+        $event->setResponse(new RedirectResponse($url));
+        $event->stopPropagation();
+    }
+}

--- a/src/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/CoreBundle/Resources/translations/messages.en.yml
@@ -48,3 +48,4 @@ create_new: 'Create New'
 invoice: Invoice
 quote: Quote
 client: Client
+live_component.session_expired: 'The page has expired. Please refresh and try again.'

--- a/src/CoreBundle/Tests/Listener/LiveComponentHydrationExceptionListenerTest.php
+++ b/src/CoreBundle/Tests/Listener/LiveComponentHydrationExceptionListenerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Listener;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use SolidInvoice\CoreBundle\Listener\LiveComponentHydrationExceptionListener;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\UX\LiveComponent\Exception\HydrationException;
+
+#[CoversClass(LiveComponentHydrationExceptionListener::class)]
+final class LiveComponentHydrationExceptionListenerTest extends TestCase
+{
+    public function testSubscribesToKernelExceptionAtPriority64(): void
+    {
+        $events = LiveComponentHydrationExceptionListener::getSubscribedEvents();
+
+        self::assertArrayHasKey(KernelEvents::EXCEPTION, $events);
+        self::assertSame(['onKernelException', 64], $events[KernelEvents::EXCEPTION]);
+    }
+
+    public function testHydrationExceptionWithRefererRedirectsToReferer(): void
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::never())->method('generate');
+
+        $listener = new LiveComponentHydrationExceptionListener($router);
+
+        $request = Request::create('/_components/CreateInvoice/saveUpdate', 'POST');
+        $request->headers->set('Referer', 'https://example.com/invoices/create');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $event = new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new HydrationException('Invalid checksum sent when updating the live component.'),
+        );
+
+        $listener->onKernelException($event);
+
+        $response = $event->getResponse();
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('https://example.com/invoices/create', $response->getTargetUrl());
+        self::assertTrue($event->isPropagationStopped());
+        self::assertSame(['live_component.session_expired'], $session->getFlashBag()->get('error'));
+    }
+
+    public function testHydrationExceptionWithoutRefererRedirectsToHome(): void
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_home')
+            ->willReturn('/');
+
+        $listener = new LiveComponentHydrationExceptionListener($router);
+
+        $request = Request::create('/_components/CreateInvoice/saveUpdate', 'POST');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $event = new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new HydrationException('Invalid checksum sent when updating the live component.'),
+        );
+
+        $listener->onKernelException($event);
+
+        $response = $event->getResponse();
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/', $response->getTargetUrl());
+        self::assertTrue($event->isPropagationStopped());
+        self::assertSame(['live_component.session_expired'], $session->getFlashBag()->get('error'));
+    }
+
+    public function testOtherExceptionsAreIgnored(): void
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::never())->method('generate');
+
+        $listener = new LiveComponentHydrationExceptionListener($router);
+
+        $request = Request::create('/some-page', 'GET');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $event = new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new RuntimeException('Unrelated exception'),
+        );
+
+        $listener->onKernelException($event);
+
+        self::assertNull($event->getResponse());
+        self::assertFalse($event->isPropagationStopped());
+    }
+}

--- a/src/CoreBundle/Tests/Listener/LiveComponentHydrationExceptionListenerTest.php
+++ b/src/CoreBundle/Tests/Listener/LiveComponentHydrationExceptionListenerTest.php
@@ -45,8 +45,9 @@ final class LiveComponentHydrationExceptionListenerTest extends TestCase
 
         $listener = new LiveComponentHydrationExceptionListener($router);
 
-        $request = Request::create('/_components/CreateInvoice/saveUpdate', 'POST');
+        $request = Request::create('/_components/CreateInvoice/saveUpdate', Request::METHOD_POST);
         $request->headers->set('Referer', 'https://example.com/invoices/create');
+
         $session = new Session(new MockArraySessionStorage());
         $request->setSession($session);
 
@@ -76,7 +77,7 @@ final class LiveComponentHydrationExceptionListenerTest extends TestCase
 
         $listener = new LiveComponentHydrationExceptionListener($router);
 
-        $request = Request::create('/_components/CreateInvoice/saveUpdate', 'POST');
+        $request = Request::create('/_components/CreateInvoice/saveUpdate', Request::METHOD_POST);
         $session = new Session(new MockArraySessionStorage());
         $request->setSession($session);
 
@@ -103,7 +104,7 @@ final class LiveComponentHydrationExceptionListenerTest extends TestCase
 
         $listener = new LiveComponentHydrationExceptionListener($router);
 
-        $request = Request::create('/some-page', 'GET');
+        $request = Request::create('/some-page', Request::METHOD_GET);
         $request->setSession(new Session(new MockArraySessionStorage()));
 
         $event = new ExceptionEvent(


### PR DESCRIPTION
Closes #2437

## Root cause

When `APP_SECRET` rotates on a redeployment (or a user's session expires while a Live Component form is open), Symfony UX LiveComponent throws:

```
Symfony\UX\LiveComponent\Exception\HydrationException:
Invalid checksum sent when updating the live component.
  LiveComponentHydrator.php line 491
```

This propagated uncaught through the kernel and produced a 500 error page. Affected Sentry issue: **SOLIDINVOICE-7V** (14 occurrences, 2 users, status: regressed).

The most recent event was a POST to `/_components/CreateInvoice/saveUpdate` — a user who had the invoice form open when the app was redeployed.

## Fix

Added `LiveComponentHydrationExceptionListener` in `CoreBundle/Listener/`:

- Subscribes to `kernel.exception` at **priority 64** (runs before Symfony's default error handler at 0)
- Catches only `HydrationException` — all other exceptions pass through unchanged
- Adds an `error` flash message (`live_component.session_expired` — translated in `flash.html.twig` via `|trans`)
- Redirects to the `Referer` header URL (returns the user to the form they were on) or falls back to the home route if no referer is present
- Calls `stopPropagation()` so no 500 page is rendered

The listener is auto-registered via CoreBundle's existing `$services->load()` autodiscovery — no manual DI wiring needed.

## Test approach

Added `LiveComponentHydrationExceptionListenerTest` with four cases:

1. **`testSubscribesToKernelExceptionAtPriority64`** — asserts the event/priority contract
2. **`testHydrationExceptionWithRefererRedirectsToReferer`** — provides a `Referer` header; asserts a `RedirectResponse` to that URL, flash message set, propagation stopped
3. **`testHydrationExceptionWithoutRefererRedirectsToHome`** — no `Referer` header; asserts redirect to `/` (via `_home` route), flash message set, propagation stopped
4. **`testOtherExceptionsAreIgnored`** — passes a `RuntimeException`; asserts no response is set and propagation is not stopped

All 4 tests pass. ECS reports no style issues on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3dyT7hN9fqL7xzTqo7rJY)_