### PR TITLE
Fix Settings component crash when settings DB is empty (Sentry SOLIDINVOICE-8K)

### DIFF
--- a/src/SettingsBundle/Tests/Twig/Components/SettingsEmptyStateTest.php
+++ b/src/SettingsBundle/Tests/Twig/Components/SettingsEmptyStateTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SettingsBundle\Tests\Twig\Components;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\SettingsBundle\Repository\SettingsRepository;
+use SolidInvoice\SettingsBundle\Twig\Components\Settings;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+// Exercises preMount() and instantiateForm() directly; avoids full template render (iconify network).
+#[CoversClass(Settings::class)]
+final class SettingsEmptyStateTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+
+    private MockObject&SettingsRepository $emptyRepo;
+
+    private Settings $component;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var MockObject&SettingsRepository $repo */
+        $repo = $this->createMock(SettingsRepository::class);
+        $repo->method('findAll')->willReturn([]);
+        $this->emptyRepo = $repo;
+
+        /** @var PropertyAccessorInterface $propertyAccessor */
+        $propertyAccessor = self::getContainer()->get('property_accessor');
+
+        $this->component = new Settings($this->emptyRepo, $propertyAccessor);
+        $this->component->setContainer(self::getContainer());
+    }
+
+    public function testPreMountDoesNotThrowWhenSettingsEmpty(): void
+    {
+        $this->component->preMount();
+
+        self::assertSame('', $this->component->section);
+    }
+
+    public function testInstantiateFormDoesNotThrowWhenSettingsEmpty(): void
+    {
+        $this->component->preMount();
+
+        $method = new ReflectionMethod(Settings::class, 'instantiateForm');
+        $form = $method->invoke($this->component);
+
+        self::assertInstanceOf(FormInterface::class, $form);
+    }
+
+    public function testInstantiateFormWithGarbageSectionAndEmptySettings(): void
+    {
+        $this->component->preMount();
+        // Simulates a garbage ?section= URL param applied after preMount
+        $this->component->section = '\'"""""""';
+
+        $method = new ReflectionMethod(Settings::class, 'instantiateForm');
+        $form = $method->invoke($this->component);
+
+        self::assertInstanceOf(FormInterface::class, $form);
+    }
+}

--- a/src/SettingsBundle/Tests/Twig/Components/SettingsEmptyStateTest.php
+++ b/src/SettingsBundle/Tests/Twig/Components/SettingsEmptyStateTest.php
@@ -29,8 +29,6 @@ final class SettingsEmptyStateTest extends KernelTestCase
 {
     use EnsureApplicationInstalled;
 
-    private MockObject&SettingsRepository $emptyRepo;
-
     private Settings $component;
 
     protected function setUp(): void
@@ -40,12 +38,12 @@ final class SettingsEmptyStateTest extends KernelTestCase
         /** @var MockObject&SettingsRepository $repo */
         $repo = $this->createMock(SettingsRepository::class);
         $repo->method('findAll')->willReturn([]);
-        $this->emptyRepo = $repo;
+        $emptyRepo = $repo;
 
         /** @var PropertyAccessorInterface $propertyAccessor */
         $propertyAccessor = self::getContainer()->get('property_accessor');
 
-        $this->component = new Settings($this->emptyRepo, $propertyAccessor);
+        $this->component = new Settings($emptyRepo, $propertyAccessor);
         $this->component->setContainer(self::getContainer());
     }
 

--- a/src/SettingsBundle/Twig/Components/Settings.php
+++ b/src/SettingsBundle/Twig/Components/Settings.php
@@ -78,7 +78,7 @@ final class Settings extends AbstractController
     #[PreMount()]
     public function preMount(): void
     {
-        $this->section = key($this->getAppSettings());
+        $this->section = array_key_first($this->getAppSettings()) ?? '';
     }
 
     /**
@@ -112,6 +112,7 @@ final class Settings extends AbstractController
     {
         $isTrialSubscription = $this->subscriptionService?->isTrialSubscription() ?? false;
         $appSettings = $this->getAppSettings(false);
+        $appSettingsObjects = $this->getAppSettings(true);
 
         if (! isset($appSettings[$this->section])) {
             $this->section = (string) array_key_first($appSettings);
@@ -119,9 +120,9 @@ final class Settings extends AbstractController
 
         return $this->createForm(
             SettingsType::class,
-            $appSettings[$this->section],
+            $appSettings[$this->section] ?? [],
             [
-                'settings' => $this->getAppSettings(true)[$this->section],
+                'settings' => $appSettingsObjects[$this->section] ?? [],
                 'subscription_in_trial' => $isTrialSubscription,
             ]
         );


### PR DESCRIPTION
Closes #2440

## Root cause

Two crash paths remained in `Settings::instantiateForm()` and `preMount()` after the earlier partial fix (commit `18c0c2d`):

**`preMount()` — TypeError on empty settings DB**

```php
// Old code
$this->section = key($this->getAppSettings());
```

`key([])` returns `null`. Assigning `null` to the `string`-typed `$section` property throws:
```
TypeError: Cannot assign null to property Settings::$section of type string
```

**`instantiateForm()` — Undefined array key / double DB query**

```php
// Old code
'settings' => $this->getAppSettings(true)[$this->section],
```

- `getAppSettings(true)` was called a second time (double DB query) and the result accessed with a bare array subscript — no null-safety guard.
- If `$section` resolved to `''` (because the settings table is empty), this access would throw `ErrorException: Warning: Undefined array key ''`.

The Sentry report (SOLIDINVOICE-8K) pinpoints exactly this line as the crash site.

## Fix

1. **`preMount()`**: switch from `key()` to `array_key_first() ?? ''`, which is null-safe and consistent with the fallback already used in `instantiateForm()`.

2. **`instantiateForm()`**:
   - Cache `getAppSettings(true)` into `$appSettingsObjects` (single DB query, eliminates the double call).
   - Guard both array accesses with `?? []` so an empty or missing key degrades gracefully to an empty form rather than crashing.

## Test approach

Added `SettingsEmptyStateTest` (unit-level, avoids full Twig render which requires outbound network access to `api.iconify.design`):

1. `testPreMountDoesNotThrowWhenSettingsEmpty` — mocks `SettingsRepository::findAll()` → `[]`; asserts `preMount()` sets `section = ''` without TypeError.
2. `testInstantiateFormDoesNotThrowWhenSettingsEmpty` — calls `instantiateForm()` via reflection after `preMount()`; asserts a `FormInterface` is returned.
3. `testInstantiateFormWithGarbageSectionAndEmptySettings` — simulates the Sentry-reported URL pattern (`?section='"""""""`) applied after `preMount()`; asserts `instantiateForm()` still returns a `FormInterface`.

All 3 tests **fail** on the pre-fix code (TypeError / Undefined array key) and **pass** after the fix. ECS and PHPStan report no issues on the changed files.

https://claude.ai/code/session_01Cks8c8C4qTj3GRK1bSmGFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cks8c8C4qTj3GRK1bSmGFG)_