### PR TITLE
Fix TypeError when discount value is null in DiscountNormalizer

### DIFF
--- a/src/ApiBundle/Serializer/Normalizer/DiscountNormalizer.php
+++ b/src/ApiBundle/Serializer/Normalizer/DiscountNormalizer.php
@@ -27,14 +27,18 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 final class DiscountNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     /**
-     * @param array{type: string|null, value: string|int|null} $data
+     * @param array{type: string|null, value?: string|int|null} $data
      * @throws MathException
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Discount
     {
         $discount = new Discount();
         $discount->setType($data['type'] ?? null);
-        $discount->setValue($data['value'] ?? null);
+
+        $value = $data['value'] ?? null;
+        if (null !== $value) {
+            $discount->setValue($value);
+        }
 
         return $discount;
     }

--- a/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
+++ b/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
@@ -61,4 +61,26 @@ final class DiscountNormalizerTest extends TestCase
 
         self::assertEquals($discount, $this->normalizer->denormalize(['type' => 'money', 'value' => 10000], Discount::class));
     }
+
+    /**
+     * @throws MathException
+     */
+    public function testDenormalizationWithNullValue(): void
+    {
+        $discount = $this->normalizer->denormalize(['type' => 'percentage', 'value' => null], Discount::class);
+
+        self::assertInstanceOf(Discount::class, $discount);
+        self::assertSame('percentage', $discount->getType());
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testDenormalizationWithMissingValue(): void
+    {
+        $discount = $this->normalizer->denormalize(['type' => 'percentage'], Discount::class);
+
+        self::assertInstanceOf(Discount::class, $discount);
+        self::assertSame('percentage', $discount->getType());
+    }
 }


### PR DESCRIPTION
Closes #2448

## Root cause

`DiscountNormalizer::denormalize()` unconditionally called `$discount->setValue($data['value'] ?? null)`. When the API payload omits the `value` field or sends it as `null`, the `?? null` fallback produces a `null` that is passed to `Discount::setValue()`, which requires `BigNumber|float|int|string` — causing:

```
TypeError: SolidInvoice\CoreBundle\Entity\Discount::setValue(): Argument #1 ($value)
must be of type Brick\Math\BigNumber|string|int|float, null given
```

This is the crash captured in Sentry issue **SOLIDINVOICE-8T** (#2448).

## Root cause in detail

The denormalizer received valid API input where `value` was either absent or explicitly `null` (e.g. a discount payload with only a `type` field). The `?? null` fallback was introduced to handle the missing key case, but it propagated `null` directly into a non-nullable method.

## Fix

Guard the `setValue()` call so it is only invoked when a non-null value is present:

```php
$value = $data['value'] ?? null;
if (null !== $value) {
    $discount->setValue($value);
}
```

When `value` is absent or null, the `Discount` entity retains its constructor defaults (`valueMoney = BigInteger::zero()`, `valuePercentage = null`), which is the correct behaviour for an unset discount.

Also corrected the `@param` array-shape docblock to mark `value` as an optional key (`value?:`) — accurately reflecting that the field may be absent from the input.

## Test approach

Added two new test cases to `DiscountNormalizerTest`:

1. `testDenormalizationWithNullValue` — passes `['type' => 'percentage', 'value' => null]`; asserts no TypeError is thrown and returns a valid `Discount`
2. `testDenormalizationWithMissingValue` — passes `['type' => 'percentage']` (no `value` key); same assertion

Both tests **fail** on the original code (TypeError) and **pass** after the fix. All 6 tests in `DiscountNormalizerTest` pass. ECS and PHPStan report no issues on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119EzVLjPDacYhYGdqo44qS)_