### PR TITLE
Fix "email must have a To header" crash when invoice has no recipients (#2360)

### DIFF
--- a/src/InvoiceBundle/Listener/Mailer/InvoiceMailerListener.php
+++ b/src/InvoiceBundle/Listener/Mailer/InvoiceMailerListener.php
@@ -53,6 +53,13 @@ class InvoiceMailerListener implements EventSubscriberInterface
             return;
         }
 
+        if ($invoice->getUsers()->isEmpty()) {
+            $this->logger->warning('Cannot send invoice email: invoice has no recipients', [
+                'invoice_id' => (string) $invoice->getId(),
+            ]);
+            return;
+        }
+
         try {
             $this->mailer->send(new InvoiceEmail($invoice));
         } catch (TransportExceptionInterface $e) {

--- a/src/InvoiceBundle/Tests/Listener/Mailer/InvoiceMailerListenerTest.php
+++ b/src/InvoiceBundle/Tests/Listener/Mailer/InvoiceMailerListenerTest.php
@@ -83,6 +83,22 @@ final class InvoiceMailerListenerTest extends TestCase
         self::assertSame(['invoice.email.send_failed'], $flashBag->get('error'));
     }
 
+    public function testListenerSkipsSendingWhenNoUsers(): void
+    {
+        $invoice = new Invoice();
+
+        $mailer = M::spy(MailerInterface::class);
+        $logger = M::spy(LoggerInterface::class);
+        $requestStack = new RequestStack();
+
+        $listener = new InvoiceMailerListener($mailer, $logger, $requestStack);
+        $listener->onInvoiceAccepted(new InvoiceEvent($invoice));
+
+        $mailer->shouldNotHaveReceived('send');
+        $logger->shouldHaveReceived('warning')
+            ->with(M::pattern('/no recipients/'), M::type('array'));
+    }
+
     public function testEvents(): void
     {
         self::assertSame([InvoiceEvents::INVOICE_POST_ACCEPT], \array_keys(InvoiceMailerListener::getSubscribedEvents()));

--- a/src/InvoiceBundle/Twig/Components/CreateInvoice.php
+++ b/src/InvoiceBundle/Twig/Components/CreateInvoice.php
@@ -245,7 +245,11 @@ final class CreateInvoice extends AbstractController
             $this->entityManager->flush();
 
             if ('send' === $action) {
-                $this->mailer->send(new InvoiceEmail($this->invoice));
+                if ($this->invoice->getUsers()->isEmpty()) {
+                    $this->addFlash('error', 'invoice.send.no_recipients');
+                } else {
+                    $this->mailer->send(new InvoiceEmail($this->invoice));
+                }
             }
 
             $this->addFlash('success', 'invoice.edit.success');
@@ -283,7 +287,11 @@ final class CreateInvoice extends AbstractController
 
         // Send the invoice only if the action is 'send'
         if ('send' === $action) {
-            $this->mailer->send(new InvoiceEmail($invoice));
+            if ($invoice->getUsers()->isEmpty()) {
+                $this->addFlash('error', 'invoice.send.no_recipients');
+            } else {
+                $this->mailer->send(new InvoiceEmail($invoice));
+            }
         }
 
         // Add flash message and redirect


### PR DESCRIPTION
Closes #2360

## Root cause

When a user clicks "Save & Send" on an invoice whose `users` collection is empty, `InvoiceReceiverListener::__invoke()` iterates over an empty collection and adds no `To` addresses to the `InvoiceEmail`. The Mailer then dispatches the message to the Messenger bus, and when the Messenger worker processes the `SendEmailMessage`, the MIME layer throws:

```
Symfony\Component\Mime\Exception\LogicException:
  An email must have a "To", "Cc", or "Bcc" header.
```

Messenger wraps this in `HandlerFailedException` — the exact error captured in Sentry SOLIDINVOICE-7R.

The same guard already existed in `Send::__invoke()`:
```php
if ($invoice->getUsers()->isEmpty()) {
    // redirect with error flash
}
```

but was missing from `CreateInvoice::saveInvoice()` (both the edit and create send paths) and from `InvoiceMailerListener::onInvoiceAccepted()` (which sends the email via the `INVOICE_POST_ACCEPT` workflow event).

## Fix

- **`InvoiceMailerListener::onInvoiceAccepted()`** — return early and log a warning when the invoice has no recipients, preventing any email dispatch to Messenger.
- **`CreateInvoice::saveInvoice()`** — guard both the edit-mode and create-mode `mailer->send()` calls with the same `getUsers()->isEmpty()` check; add an `invoice.send.no_recipients` error flash (translation already exists) and skip sending instead of crashing.

## Test approach

Added `testListenerSkipsSendingWhenNoUsers()` to `InvoiceMailerListenerTest`:

- Creates an `Invoice` with no users
- Calls `onInvoiceAccepted()` on a spy mailer
- **Before fix**: `mailer->send()` IS called (Mockery `shouldNotHaveReceived` assertion fails)
- **After fix**: early return triggered — `mailer->send()` is NOT called, warning IS logged

All 4 `InvoiceMailerListenerTest` cases pass. All 21 mailer-listener tests pass. Pre-existing failures in `InvoiceReminderFlowTest` (unrelated reminder logic) and `CreateInvoiceTest`/`ViewTest` (iconify CDN blocked in CI environment) are unchanged by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F44gQ67wsYrBm9bzyQmfBC)_