### PR TITLE
Fix NotEnabledTransitionException when publishing recurring invoice (#2454)

### DIFF
--- a/src/InvoiceBundle/Action/CreateRecurring.php
+++ b/src/InvoiceBundle/Action/CreateRecurring.php
@@ -97,7 +97,7 @@ final class CreateRecurring extends AbstractController
                 $this->recurringInvoiceStateMachine->apply($invoice, Graph::TRANSITION_NEW);
             }
 
-            if ('publish' === $action) {
+            if ('publish' === $action && $this->recurringInvoiceStateMachine->can($invoice, Graph::TRANSITION_ACTIVATE)) {
                 $this->recurringInvoiceStateMachine->apply($invoice, Graph::TRANSITION_ACTIVATE);
             }
 

--- a/src/InvoiceBundle/Action/CreateRecurring.php
+++ b/src/InvoiceBundle/Action/CreateRecurring.php
@@ -36,6 +36,9 @@ use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Workflow\WorkflowInterface;
 use function assert;
 
+/**
+ * @see \SolidInvoice\InvoiceBundle\Tests\Action\CreateRecurringTest
+ */
 final class CreateRecurring extends AbstractController
 {
     public function __construct(

--- a/src/InvoiceBundle/Action/EditRecurring.php
+++ b/src/InvoiceBundle/Action/EditRecurring.php
@@ -60,7 +60,7 @@ final class EditRecurring extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $action = $request->request->get('save');
 
-            if ('publish' === $action) {
+            if ('publish' === $action && $this->recurringInvoiceStateMachine->can($invoice, Graph::TRANSITION_ACTIVATE)) {
                 $this->recurringInvoiceStateMachine->apply($invoice, Graph::TRANSITION_ACTIVATE);
             }
 

--- a/src/InvoiceBundle/Action/EditRecurring.php
+++ b/src/InvoiceBundle/Action/EditRecurring.php
@@ -31,6 +31,9 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Workflow\WorkflowInterface;
 use function assert;
 
+/**
+ * @see \SolidInvoice\InvoiceBundle\Tests\Action\EditRecurringTest
+ */
 final class EditRecurring extends AbstractController
 {
     public function __construct(

--- a/src/InvoiceBundle/Tests/Action/CreateRecurringTest.php
+++ b/src/InvoiceBundle/Tests/Action/CreateRecurringTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InvoiceBundle\Tests\Action;
 
-use DateTimeImmutable;
+use Carbon\CarbonImmutable;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
@@ -37,12 +37,13 @@ use Symfony\Component\Workflow\WorkflowInterface;
 
 final class CreateRecurringTest extends TestCase
 {
+    /**
+     * @param FormInterface<mixed> $form
+     */
     private function buildAction(WorkflowInterface $workflow, RouterInterface $router, ManagerRegistry $doctrine, FormInterface $form): CreateRecurring
     {
         $clientRepository = $this->createMock(ClientRepository::class);
         $clientRepository->method('getTotalClients')->willReturn(2);
-
-        $totalCalculator = $this->createMock(TotalCalculator::class);
 
         $featureGate = $this->createMock(FeatureGate::class);
         $featureGate->method('isEnabled')->willReturn(true);
@@ -52,7 +53,7 @@ final class CreateRecurringTest extends TestCase
         $invoiceRepository->method('countCreatedInMonth')->willReturn(0);
 
         $clock = $this->createMock(ClockInterface::class);
-        $clock->method('now')->willReturn(new DateTimeImmutable());
+        $clock->method('now')->willReturn(CarbonImmutable::now());
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->method('create')->willReturn($form);
@@ -68,7 +69,7 @@ final class CreateRecurringTest extends TestCase
             $workflow,
             $router,
             $doctrine,
-            $totalCalculator,
+            $this->createStub(TotalCalculator::class),
             $featureGate,
             $invoiceRepository,
             $clock,
@@ -78,6 +79,9 @@ final class CreateRecurringTest extends TestCase
         return $action;
     }
 
+    /**
+     * @return FormInterface<mixed>
+     */
     private function buildSubmittedForm(): FormInterface
     {
         $form = $this->createMock(FormInterface::class);
@@ -91,7 +95,7 @@ final class CreateRecurringTest extends TestCase
     private function buildRequest(string $saveAction): Request
     {
         $session = new Session(new MockArraySessionStorage());
-        $request = Request::create('/', 'POST', ['save' => $saveAction]);
+        $request = Request::create('/', Request::METHOD_POST, ['save' => $saveAction]);
         $request->setSession($session);
 
         return $request;

--- a/src/InvoiceBundle/Tests/Action/CreateRecurringTest.php
+++ b/src/InvoiceBundle/Tests/Action/CreateRecurringTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\Action;
+
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerInterface;
+use SolidInvoice\ClientBundle\Repository\ClientRepository;
+use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\InvoiceBundle\Action\CreateRecurring;
+use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+final class CreateRecurringTest extends TestCase
+{
+    private function buildAction(WorkflowInterface $workflow, RouterInterface $router, ManagerRegistry $doctrine, FormInterface $form): CreateRecurring
+    {
+        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository->method('getTotalClients')->willReturn(2);
+
+        $totalCalculator = $this->createMock(TotalCalculator::class);
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+        $featureGate->method('canUse')->willReturn(true);
+
+        $invoiceRepository = $this->createMock(InvoiceRepository::class);
+        $invoiceRepository->method('countCreatedInMonth')->willReturn(0);
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->method('now')->willReturn(new DateTimeImmutable());
+
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $formFactory->method('create')->willReturn($form);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->with('form.factory')
+            ->willReturn($formFactory);
+        $container->method('has')->willReturn(true);
+
+        $action = new CreateRecurring(
+            $clientRepository,
+            $workflow,
+            $router,
+            $doctrine,
+            $totalCalculator,
+            $featureGate,
+            $invoiceRepository,
+            $clock,
+        );
+        $action->setContainer($container);
+
+        return $action;
+    }
+
+    private function buildSubmittedForm(): FormInterface
+    {
+        $form = $this->createMock(FormInterface::class);
+        $form->method('isSubmitted')->willReturn(true);
+        $form->method('isValid')->willReturn(true);
+        $form->method('handleRequest');
+
+        return $form;
+    }
+
+    private function buildRequest(string $saveAction): Request
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/', 'POST', ['save' => $saveAction]);
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    private function buildDoctrineWithManager(): ManagerRegistry
+    {
+        $em = $this->createMock(ObjectManager::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        return $doctrine;
+    }
+
+    public function testPublishDoesNotActivateWhenTransitionNotEnabled(): void
+    {
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->once())
+            ->method('apply')
+            ->with($this->anything(), Graph::TRANSITION_NEW);
+        $workflow->expects($this->once())
+            ->method('can')
+            ->with($this->anything(), Graph::TRANSITION_ACTIVATE)
+            ->willReturn(false);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/invoices/recurring/view/123');
+
+        $action = $this->buildAction($workflow, $router, $this->buildDoctrineWithManager(), $this->buildSubmittedForm());
+        $response = $action($this->buildRequest('publish'));
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testPublishActivatesWhenTransitionIsEnabled(): void
+    {
+        $appliedTransitions = [];
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->exactly(2))
+            ->method('apply')
+            ->willReturnCallback(static function (object $subject, string $transition) use (&$appliedTransitions): Marking {
+                $appliedTransitions[] = $transition;
+
+                return new Marking();
+            });
+        $workflow->expects($this->once())
+            ->method('can')
+            ->with($this->anything(), Graph::TRANSITION_ACTIVATE)
+            ->willReturn(true);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/invoices/recurring/view/123');
+
+        $action = $this->buildAction($workflow, $router, $this->buildDoctrineWithManager(), $this->buildSubmittedForm());
+        $response = $action($this->buildRequest('publish'));
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame([Graph::TRANSITION_NEW, Graph::TRANSITION_ACTIVATE], $appliedTransitions);
+    }
+}

--- a/src/InvoiceBundle/Tests/Action/EditRecurringTest.php
+++ b/src/InvoiceBundle/Tests/Action/EditRecurringTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\Action;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\CoreBundle\Billing\TotalCalculator;
+use SolidInvoice\InvoiceBundle\Action\EditRecurring;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\InvoiceBundle\Enum\RecurringInvoiceStatus;
+use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+final class EditRecurringTest extends TestCase
+{
+    private function buildAction(
+        FormFactoryInterface $formFactory,
+        RouterInterface $router,
+        WorkflowInterface $workflow,
+        ManagerRegistry $doctrine,
+    ): EditRecurring {
+        $totalCalculator = $this->createMock(TotalCalculator::class);
+
+        $featureGate = $this->createMock(FeatureGate::class);
+        $featureGate->method('isEnabled')->willReturn(true);
+
+        return new EditRecurring($formFactory, $router, $workflow, $doctrine, $totalCalculator, $featureGate);
+    }
+
+    private function buildInvoice(RecurringInvoiceStatus $status): RecurringInvoice
+    {
+        $client = new Client();
+        $client->setCurrencyCode('USD');
+
+        $invoice = new RecurringInvoice();
+        $invoice->setStatus($status);
+        $invoice->setClient($client);
+
+        return $invoice;
+    }
+
+    private function buildSubmittedForm(): FormInterface
+    {
+        $form = $this->createMock(FormInterface::class);
+        $form->method('isSubmitted')->willReturn(true);
+        $form->method('isValid')->willReturn(true);
+        $form->method('handleRequest');
+
+        return $form;
+    }
+
+    private function buildRequest(string $saveAction): Request
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/', 'POST', ['save' => $saveAction]);
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    public function testPublishDoesNotActivateWhenTransitionNotEnabled(): void
+    {
+        $invoice = $this->buildInvoice(RecurringInvoiceStatus::Active);
+
+        $form = $this->buildSubmittedForm();
+
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $formFactory->method('create')->willReturn($form);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_ACTIVATE)
+            ->willReturn(false);
+        $workflow->expects($this->never())
+            ->method('apply');
+
+        $em = $this->createMock(ObjectManager::class);
+        $em->expects($this->once())->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/invoices/recurring/view/123');
+
+        $action = $this->buildAction($formFactory, $router, $workflow, $doctrine);
+        $response = $action($this->buildRequest('publish'), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testPublishActivatesWhenTransitionIsEnabled(): void
+    {
+        $invoice = $this->buildInvoice(RecurringInvoiceStatus::Draft);
+
+        $form = $this->buildSubmittedForm();
+
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $formFactory->method('create')->willReturn($form);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_ACTIVATE)
+            ->willReturn(true);
+        $workflow->expects($this->once())
+            ->method('apply')
+            ->with($invoice, Graph::TRANSITION_ACTIVATE);
+
+        $em = $this->createMock(ObjectManager::class);
+        $em->expects($this->once())->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/invoices/recurring/view/123');
+
+        $action = $this->buildAction($formFactory, $router, $workflow, $doctrine);
+        $response = $action($this->buildRequest('publish'), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testSaveWithoutPublishSkipsWorkflow(): void
+    {
+        $invoice = $this->buildInvoice(RecurringInvoiceStatus::Draft);
+
+        $form = $this->buildSubmittedForm();
+
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $formFactory->method('create')->willReturn($form);
+
+        $workflow = $this->createMock(WorkflowInterface::class);
+        $workflow->expects($this->never())->method('can');
+        $workflow->expects($this->never())->method('apply');
+
+        $em = $this->createMock(ObjectManager::class);
+        $em->expects($this->once())->method('flush');
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/invoices/recurring/view/123');
+
+        $action = $this->buildAction($formFactory, $router, $workflow, $doctrine);
+        $response = $action($this->buildRequest('draft'), $invoice);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+}

--- a/src/InvoiceBundle/Tests/Action/EditRecurringTest.php
+++ b/src/InvoiceBundle/Tests/Action/EditRecurringTest.php
@@ -40,12 +40,10 @@ final class EditRecurringTest extends TestCase
         WorkflowInterface $workflow,
         ManagerRegistry $doctrine,
     ): EditRecurring {
-        $totalCalculator = $this->createMock(TotalCalculator::class);
-
         $featureGate = $this->createMock(FeatureGate::class);
         $featureGate->method('isEnabled')->willReturn(true);
 
-        return new EditRecurring($formFactory, $router, $workflow, $doctrine, $totalCalculator, $featureGate);
+        return new EditRecurring($formFactory, $router, $workflow, $doctrine, $this->createStub(TotalCalculator::class), $featureGate);
     }
 
     private function buildInvoice(RecurringInvoiceStatus $status): RecurringInvoice
@@ -60,6 +58,9 @@ final class EditRecurringTest extends TestCase
         return $invoice;
     }
 
+    /**
+     * @return FormInterface<mixed>
+     */
     private function buildSubmittedForm(): FormInterface
     {
         $form = $this->createMock(FormInterface::class);
@@ -73,7 +74,7 @@ final class EditRecurringTest extends TestCase
     private function buildRequest(string $saveAction): Request
     {
         $session = new Session(new MockArraySessionStorage());
-        $request = Request::create('/', 'POST', ['save' => $saveAction]);
+        $request = Request::create('/', Request::METHOD_POST, ['save' => $saveAction]);
         $request->setSession($session);
 
         return $request;


### PR DESCRIPTION
Closes #2454

## Root cause

When a user clicks "Publish" on a recurring invoice that is already in the `Active` state (or any state from which the `activate` transition is not valid), `CreateRecurring::__invoke()` and `EditRecurring::__invoke()` called `$recurringInvoiceStateMachine->apply($invoice, TRANSITION_ACTIVATE)` unconditionally. This throws:

```
Symfony\Component\Workflow\Exception\NotEnabledTransitionException:
Cannot apply transition "activate" on workflow "recurring_invoice".
```

The `activate` transition is only valid from `New` or `Draft` states. Reaching an already-`Active` invoice through either action (e.g. the invoice was already activated and the user re-submits with "Publish") causes the crash captured in Sentry SOLIDINVOICE-94.

The identical pattern was already fixed for the regular invoice's `accept` transition in PR #2408.

## Fix

Added a `->can()` guard before each `->apply(TRANSITION_ACTIVATE)` call in both actions:

```php
if ('publish' === $action && $this->recurringInvoiceStateMachine->can($invoice, Graph::TRANSITION_ACTIVATE)) {
    $this->recurringInvoiceStateMachine->apply($invoice, Graph::TRANSITION_ACTIVATE);
}
```

This is the same defensive pattern used throughout the rest of the workflow codebase.

## Test approach

Added two new test classes covering both affected actions:

- **`CreateRecurringTest`**: 
  - `testPublishDoesNotActivateWhenTransitionNotEnabled` — `can()` returns `false`; asserts `apply(TRANSITION_NEW)` is called (for new invoice) but `apply(TRANSITION_ACTIVATE)` is never called.
  - `testPublishActivatesWhenTransitionIsEnabled` — `can()` returns `true`; asserts both `apply(TRANSITION_NEW)` and `apply(TRANSITION_ACTIVATE)` are called in order.

- **`EditRecurringTest`**:
  - `testPublishDoesNotActivateWhenTransitionNotEnabled` — already-`Active` invoice; `apply()` is never called.
  - `testPublishActivatesWhenTransitionIsEnabled` — `Draft` invoice; `apply(TRANSITION_ACTIVATE)` is called.
  - `testSaveWithoutPublishSkipsWorkflow` — save without publish; `can()` and `apply()` are never called.

All 5 tests pass. ECS and PHPStan report no issues on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmwjiiteafAPKzsE1p5WGT)_