### PR TITLE
Fix "No payment methods available" crash returning 500 instead of redirect (#2455)

### DIFF
--- a/src/PaymentBundle/Action/Prepare.php
+++ b/src/PaymentBundle/Action/Prepare.php
@@ -17,7 +17,6 @@ use const FILTER_VALIDATE_BOOLEAN;
 use Brick\Math\BigNumber;
 use Brick\Math\RoundingMode;
 use Carbon\Carbon;
-use Exception;
 use Generator;
 use Payum\Core\Payum;
 use Payum\Core\Registry\RegistryInterface;
@@ -80,7 +79,6 @@ final class Prepare
 
     /**
      * @return array{form: FormView, invoice: Invoice, internal: array<int, string>}|Response|null
-     * @throws Exception
      */
     #[Template('@SolidInvoicePayment/Payment/create.html.twig')]
     public function __invoke(Request $request, string $uuid): array | Response | null
@@ -119,7 +117,22 @@ final class Prepare
         $this->companySelector->switchCompany($invoice->getCompany()->getId());
 
         if ($this->paymentMethodRepository->getTotalMethodsConfigured($isAuthenticated) < 1) {
-            throw new Exception('No payment methods available');
+            $route = $isAuthenticated
+                ? $this->router->generate('_invoices_view', ['id' => $invoice->getId()])
+                : $this->router->generate('_view_invoice_external', ['uuid' => $invoice->getUuid()]);
+
+            return new class($route) extends RedirectResponse implements FlashResponse {
+                public function __construct(
+                    string $route
+                ) {
+                    parent::__construct($route);
+                }
+
+                public function getFlash(): Generator
+                {
+                    yield self::FLASH_DANGER => 'payment.create.exception.no_payment_methods';
+                }
+            };
         }
 
         $preferredChoices = $this->paymentMethodRepository->findBy(['gatewayName' => 'credit']);

--- a/src/PaymentBundle/Action/Prepare.php
+++ b/src/PaymentBundle/Action/Prepare.php
@@ -55,7 +55,9 @@ use function filter_var;
 use function in_array;
 
 // @TODO: Refactor this class to make it cleaner
-
+/**
+ * @see \SolidInvoice\PaymentBundle\Tests\Action\PrepareTest
+ */
 final class Prepare
 {
     use SaveableTrait;

--- a/src/PaymentBundle/Action/Prepare.php
+++ b/src/PaymentBundle/Action/Prepare.php
@@ -119,17 +119,11 @@ final class Prepare
         $this->companySelector->switchCompany($invoice->getCompany()->getId());
 
         if ($this->paymentMethodRepository->getTotalMethodsConfigured($isAuthenticated) < 1) {
-            $route = $isAuthenticated
+            $url = $isAuthenticated
                 ? $this->router->generate('_invoices_view', ['id' => $invoice->getId()])
                 : $this->router->generate('_view_invoice_external', ['uuid' => $invoice->getUuid()]);
 
-            return new class($route) extends RedirectResponse implements FlashResponse {
-                public function __construct(
-                    string $route
-                ) {
-                    parent::__construct($route);
-                }
-
+            return new class($url) extends RedirectResponse implements FlashResponse {
                 public function getFlash(): Generator
                 {
                     yield self::FLASH_DANGER => 'payment.create.exception.no_payment_methods';

--- a/src/PaymentBundle/Resources/translations/messages.en.yml
+++ b/src/PaymentBundle/Resources/translations/messages.en.yml
@@ -14,6 +14,7 @@ payment:
             not_enough_credit: 'Not have enough credit available'
             amount_exceeds_balance: 'Amount captured exceeds outstanding balance'
             invoice_cannot_be_paid: 'This invoice cannot be paid'
+            no_payment_methods: 'No payment methods are currently available'
     invoice_summary: 'Invoice Summary'
     client: 'Client'
     invoice_details: 'Invoice Details'

--- a/src/PaymentBundle/Tests/Action/PrepareTest.php
+++ b/src/PaymentBundle/Tests/Action/PrepareTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\PaymentBundle\Tests\Action;
+
+use Payum\Core\Registry\RegistryInterface;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Response\FlashResponse;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Model\Graph;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
+use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
+use SolidInvoice\PaymentBundle\Action\Prepare;
+use SolidInvoice\PaymentBundle\Repository\PaymentMethodRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Workflow\WorkflowInterface;
+use Zenstruck\Foundry\Test\Factories;
+
+final class PrepareTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    private function buildAction(
+        PaymentMethodRepository $paymentMethodRepository,
+        InvoiceRepository $invoiceRepository,
+        WorkflowInterface $invoiceStateMachine,
+        AuthorizationCheckerInterface $authorizationChecker,
+        RouterInterface $router,
+    ): Prepare {
+        $action = new Prepare(
+            $invoiceStateMachine,
+            $paymentMethodRepository,
+            $authorizationChecker,
+            self::getContainer()->get(TokenStorageInterface::class),
+            self::getContainer()->get(FormFactoryInterface::class),
+            self::getContainer()->get(EventDispatcherInterface::class),
+            self::getContainer()->get(RegistryInterface::class),
+            $router,
+            self::getContainer()->get(CompanySelector::class),
+            $invoiceRepository,
+        );
+
+        $action->setDoctrine(self::getContainer()->get('doctrine'));
+
+        return $action;
+    }
+
+    public function testNoPaymentMethodsAvailableRedirectsAuthenticatedUserWithFlash(): void
+    {
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Pending,
+        ])->_real();
+
+        $invoiceRepository = $this->createMock(InvoiceRepository::class);
+        $invoiceRepository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($invoice);
+
+        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
+        $paymentMethodRepository->expects(self::once())
+            ->method('getTotalMethodsConfigured')
+            ->willReturn(0);
+
+        $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
+        $invoiceStateMachine->expects(self::once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_PAY)
+            ->willReturn(true);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects(self::once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/123');
+
+        $action = $this->buildAction(
+            $paymentMethodRepository,
+            $invoiceRepository,
+            $invoiceStateMachine,
+            $authorizationChecker,
+            $router,
+        );
+
+        $request = Request::create('/pay/' . (string) $invoice->getUuid());
+        $response = $action($request, (string) $invoice->getUuid());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/invoices/view/123', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_DANGER, $flashes);
+        self::assertSame('payment.create.exception.no_payment_methods', $flashes[FlashResponse::FLASH_DANGER]);
+    }
+
+    public function testNoPaymentMethodsAvailableRedirectsUnauthenticatedUserToExternalView(): void
+    {
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Pending,
+        ])->_real();
+
+        $invoiceRepository = $this->createMock(InvoiceRepository::class);
+        $invoiceRepository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($invoice);
+
+        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
+        $paymentMethodRepository->expects(self::once())
+            ->method('getTotalMethodsConfigured')
+            ->willReturn(0);
+
+        $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
+        $invoiceStateMachine->expects(self::once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_PAY)
+            ->willReturn(true);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects(self::once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(false);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_view_invoice_external', self::anything())
+            ->willReturn('/view/invoice/abc-123');
+
+        $action = $this->buildAction(
+            $paymentMethodRepository,
+            $invoiceRepository,
+            $invoiceStateMachine,
+            $authorizationChecker,
+            $router,
+        );
+
+        $request = Request::create('/pay/' . (string) $invoice->getUuid());
+        $response = $action($request, (string) $invoice->getUuid());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/view/invoice/abc-123', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_DANGER, $flashes);
+        self::assertSame('payment.create.exception.no_payment_methods', $flashes[FlashResponse::FLASH_DANGER]);
+    }
+
+    public function testInvoiceNotFoundThrowsNotFoundException(): void
+    {
+        $invoiceRepository = $this->createMock(InvoiceRepository::class);
+        $invoiceRepository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
+        $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $router = $this->createMock(RouterInterface::class);
+
+        $action = $this->buildAction(
+            $paymentMethodRepository,
+            $invoiceRepository,
+            $invoiceStateMachine,
+            $authorizationChecker,
+            $router,
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $action(Request::create('/pay/non-existent-uuid'), 'non-existent-uuid');
+    }
+
+    public function testInvoiceCannotBePaidRedirectsWithFlash(): void
+    {
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'client' => $client,
+            'status' => InvoiceStatus::Paid,
+        ])->_real();
+
+        $invoiceRepository = $this->createMock(InvoiceRepository::class);
+        $invoiceRepository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($invoice);
+
+        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
+
+        $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
+        $invoiceStateMachine->expects(self::once())
+            ->method('can')
+            ->with($invoice, Graph::TRANSITION_PAY)
+            ->willReturn(false);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects(self::once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('_invoices_view', self::anything())
+            ->willReturn('/invoices/view/456');
+
+        $action = $this->buildAction(
+            $paymentMethodRepository,
+            $invoiceRepository,
+            $invoiceStateMachine,
+            $authorizationChecker,
+            $router,
+        );
+
+        $request = Request::create('/pay/' . (string) $invoice->getUuid());
+        $response = $action($request, (string) $invoice->getUuid());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertInstanceOf(FlashResponse::class, $response);
+        self::assertSame('/invoices/view/456', $response->getTargetUrl());
+
+        $flashes = iterator_to_array($response->getFlash());
+        self::assertArrayHasKey(FlashResponse::FLASH_DANGER, $flashes);
+        self::assertSame('payment.create.exception.invoice_cannot_be_paid', $flashes[FlashResponse::FLASH_DANGER]);
+    }
+}

--- a/src/PaymentBundle/Tests/Action/PrepareTest.php
+++ b/src/PaymentBundle/Tests/Action/PrepareTest.php
@@ -195,10 +195,10 @@ final class PrepareTest extends KernelTestCase
             ->method('findOneBy')
             ->willReturn(null);
 
-        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
-        $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
-        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $router = $this->createMock(RouterInterface::class);
+        $paymentMethodRepository = $this->createStub(PaymentMethodRepository::class);
+        $invoiceStateMachine = $this->createStub(WorkflowInterface::class);
+        $authorizationChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $router = $this->createStub(RouterInterface::class);
 
         $action = $this->buildAction(
             $paymentMethodRepository,
@@ -231,7 +231,7 @@ final class PrepareTest extends KernelTestCase
             ->method('findOneBy')
             ->willReturn($invoice);
 
-        $paymentMethodRepository = $this->createMock(PaymentMethodRepository::class);
+        $paymentMethodRepository = $this->createStub(PaymentMethodRepository::class);
 
         $invoiceStateMachine = $this->createMock(WorkflowInterface::class);
         $invoiceStateMachine->expects(self::once())


### PR DESCRIPTION
Closes #2455

## Root cause

When a client opens the payment page for an invoice but no payment methods have been configured (or all are disabled), `Prepare::__invoke()` reached:

```php
if ($this->paymentMethodRepository->getTotalMethodsConfigured($isAuthenticated) < 1) {
    throw new Exception('No payment methods available');
}
```

This bare `Exception` propagated uncaught through the kernel and produced a 500 error page — the exact crash captured in Sentry **SOLIDINVOICE-6Q**.

A nearly identical guard already existed earlier in the same method for the "invoice cannot be paid" state, using a graceful `FlashResponse` redirect. The no-payment-methods path was simply missing the same treatment.

## Fix

Replace the `throw new Exception(...)` with the same `FlashResponse` redirect pattern already used for the `invoice_cannot_be_paid` case:

- Authenticated users are redirected to `_invoices_view` (the internal invoice detail page)
- Unauthenticated users are redirected to `_view_invoice_external` (the public invoice URL)
- Both paths yield a `FLASH_DANGER` flash with the key `payment.create.exception.no_payment_methods`

Also removes the now-unused `use Exception;` import and `@throws Exception` docblock annotation.

Added translation key `payment.create.exception.no_payment_methods: 'No payment methods are currently available'` to `messages.en.yml`.

## Test approach

Added `PrepareTest` with four cases:

1. **`testNoPaymentMethodsAvailableRedirectsAuthenticatedUserWithFlash`** — `getTotalMethodsConfigured()` returns 0, user is authenticated; asserts a `FlashResponse` redirect to `_invoices_view` with `FLASH_DANGER` = `payment.create.exception.no_payment_methods`. **Fails before fix (Exception thrown), passes after.**

2. **`testNoPaymentMethodsAvailableRedirectsUnauthenticatedUserToExternalView`** — same, but unauthenticated; asserts redirect to `_view_invoice_external`. **Fails before fix, passes after.**

3. **`testInvoiceNotFoundThrowsNotFoundException`** — `findOneBy()` returns `null`; asserts `NotFoundHttpException` is thrown (pre-existing behaviour, unchanged).

4. **`testInvoiceCannotBePaidRedirectsWithFlash`** — workflow `can()` returns `false`; asserts the existing `invoice_cannot_be_paid` redirect still works correctly.

All 4 tests pass. ECS and PHPStan report no issues on the changed files.

https://claude.ai/code/session_01JzQAdhZmfLCAmwg1wWV1oc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzQAdhZmfLCAmwg1wWV1oc)_