### PR TITLE
Add Cloudflare Turnstile captcha to registration page

### DIFF
--- a/config/packages/toggler.php
+++ b/config/packages/toggler.php
@@ -19,6 +19,7 @@ return static function (TogglerConfig $config): void {
         ->config()
         ->features('allow_registration', env('SOLIDINVOICE_ALLOW_REGISTRATION'))
         ->features('google_oauth_login', '@=env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID") !== null && env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET") !== null')
+        ->features('turnstile_captcha', '@=env("SOLIDINVOICE_TURNSTILE_SITE_KEY") !== null && env("SOLIDINVOICE_TURNSTILE_SECRET_KEY") !== null')
         ->features('saas_enabled', '@=env("SOLIDINVOICE_PLATFORM") === \'saas\'')
         ->features('meilisearch_search', '@=env("SOLIDINVOICE_MEILISEARCH_URL") !== "" && env("SOLIDINVOICE_MEILISEARCH_API_KEY") !== ""')
     ;

--- a/config/services.php
+++ b/config/services.php
@@ -35,6 +35,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_ALLOW_REGISTRATION)', '0');
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID)', null);
     $parameters->set('env(SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET)', null);
+    $parameters->set('env(SOLIDINVOICE_TURNSTILE_SITE_KEY)', null);
+    $parameters->set('env(SOLIDINVOICE_TURNSTILE_SECRET_KEY)', null);
 
     $parameters->set('env(SOLIDINVOICE_SENTRY_DSN)', null);
     $parameters->set('env(SOLIDINVOICE_SENTRY_RELEASE)', '');

--- a/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
+++ b/src/ApiBundle/Tests/Serializer/Normalizer/DiscountNormalizerTest.php
@@ -69,7 +69,6 @@ final class DiscountNormalizerTest extends TestCase
     {
         $discount = $this->normalizer->denormalize(['type' => 'percentage', 'value' => null], Discount::class);
 
-        self::assertInstanceOf(Discount::class, $discount);
         self::assertSame('percentage', $discount->getType());
     }
 
@@ -80,7 +79,6 @@ final class DiscountNormalizerTest extends TestCase
     {
         $discount = $this->normalizer->denormalize(['type' => 'percentage'], Discount::class);
 
-        self::assertInstanceOf(Discount::class, $discount);
         self::assertSame('percentage', $discount->getType());
     }
 }

--- a/src/UserBundle/Action/Register.php
+++ b/src/UserBundle/Action/Register.php
@@ -22,6 +22,7 @@ use SolidInvoice\UserBundle\Repository\UserRepository;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -36,6 +37,8 @@ final class Register extends AbstractController
         private readonly UserRepository $userRepository,
         private readonly Security $security,
         private readonly ToggleInterface $toggle,
+        #[Autowire('%env(SOLIDINVOICE_TURNSTILE_SITE_KEY)%')]
+        private readonly ?string $turnstileSiteKey = null,
     ) {
     }
 
@@ -96,6 +99,6 @@ final class Register extends AbstractController
             return $this->security->login($user, 'security.authenticator.form_login.main', 'main');
         }
 
-        return $this->render('@SolidInvoiceUser/Security/register.html.twig', ['form' => $form]);
+        return $this->render('@SolidInvoiceUser/Security/register.html.twig', ['form' => $form, 'turnstile_site_key' => $this->turnstileSiteKey]);
     }
 }

--- a/src/UserBundle/Form/Type/RegisterType.php
+++ b/src/UserBundle/Form/Type/RegisterType.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace SolidInvoice\UserBundle\Form\Type;
 
 use SolidInvoice\UserBundle\DTO\Registration;
+use SolidInvoice\UserBundle\Validator\Constraints\Turnstile;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -65,6 +67,14 @@ final class RegisterType extends AbstractType
             'required' => true,
             'label' => 'I agree to the  <a href="https://solidinvoice.co/terms-of-service" target="_blank" class="link-primary" rel="external noreferrer noopener">Terms & Conditions</a> and <a href="https://solidinvoice.co/privacy-policy" target="_blank" class="link-primary" rel="external noreferrer noopener">Privacy Policy</a>',
             'label_html' => true,
+        ]);
+        $builder->add('captcha', HiddenType::class, [
+            'mapped' => false,
+            'required' => false,
+            // Keep the violation on this field (HiddenType bubbles errors by default)
+            // so it renders next to the widget via form_errors(form.captcha).
+            'error_bubbling' => false,
+            'constraints' => [new Turnstile()],
         ]);
     }
 

--- a/src/UserBundle/Resources/views/Security/register.html.twig
+++ b/src/UserBundle/Resources/views/Security/register.html.twig
@@ -16,6 +16,13 @@
     {{ encore_entry_link_tags('register') }}
 {% endblock %}
 
+{% block javascripts %}
+    {{ parent() }}
+    {% toggle 'turnstile_captcha' %}
+        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    {% endtoggle %}
+{% endblock %}
+
 {% block body %}
     <div class="container-fluid registration-split-layout">
         <div class="row min-vh-100">
@@ -83,6 +90,13 @@
                                 {{ form_widget(form.acceptTerms, {'attr': {'class': 'form-check-input'}}) }}
                                 {{ form_errors(form.acceptTerms) }}
                             </div>
+
+                            {% toggle 'turnstile_captcha' %}
+                                <div class="mb-3">
+                                    <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>
+                                    {{ form_errors(form.captcha) }}
+                                </div>
+                            {% endtoggle %}
 
                             <div class="form-footer">
                                 <button type="submit" class="btn btn-primary btn-lg w-100">

--- a/src/UserBundle/Security/Turnstile/TurnstileVerifier.php
+++ b/src/UserBundle/Security/Turnstile/TurnstileVerifier.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Security\Turnstile;
+
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Verifies a Cloudflare Turnstile token server-side.
+ *
+ * @see https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
+ */
+final class TurnstileVerifier
+{
+    private const string VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly ToggleInterface $toggle,
+        #[Autowire('%env(SOLIDINVOICE_TURNSTILE_SECRET_KEY)%')]
+        private readonly ?string $secretKey = null,
+    ) {
+    }
+
+    /**
+     * Returns true when the feature is disabled (never blocks), otherwise validates the token
+     * against Cloudflare and fails closed on any missing data or transport error.
+     */
+    public function verify(?string $token, ?string $remoteIp): bool
+    {
+        if (! $this->toggle->isActive('turnstile_captcha')) {
+            return true;
+        }
+
+        if ($this->secretKey === null || $this->secretKey === '' || $token === null || $token === '') {
+            return false;
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', self::VERIFY_URL, [
+                'body' => [
+                    'secret' => $this->secretKey,
+                    'response' => $token,
+                    'remoteip' => $remoteIp,
+                ],
+            ]);
+
+            $data = $response->toArray(false);
+        } catch (ExceptionInterface) {
+            return false;
+        }
+
+        return ($data['success'] ?? false) === true;
+    }
+}

--- a/src/UserBundle/Tests/Functional/RegisterTest.php
+++ b/src/UserBundle/Tests/Functional/RegisterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Functional;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Test\Factories;
+
+#[Group('functional')]
+final class RegisterTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    private const string PASSWORD = 'Sup3rStr0ngP@ssw0rd';
+
+    /**
+     * @var list<string>
+     */
+    private array $envOverrides = [];
+
+    /**
+     * Default test env: the Turnstile env vars are unset, so the feature is off and registration
+     * behaves exactly as before — a valid submission creates a User and logs them in.
+     */
+    public function testRegistrationSucceedsWhenCaptchaDisabled(): void
+    {
+        $this->setEnv('SOLIDINVOICE_ALLOW_REGISTRATION', '1');
+
+        $client = $this->bootClient();
+
+        $this->submitRegistration($client, 'new-user@example.com');
+
+        self::assertResponseRedirects();
+        self::assertSame(1, $this->userCount());
+    }
+
+    /**
+     * When the feature is on but no valid token is submitted (e.g. a bot that never solved the
+     * widget), server-side verification fails, the form is invalid, the page re-renders with the
+     * captcha error and no User is created.
+     */
+    public function testRegistrationBlockedWhenCaptchaTokenMissing(): void
+    {
+        $this->setEnv('SOLIDINVOICE_ALLOW_REGISTRATION', '1');
+        $this->setEnv('SOLIDINVOICE_TURNSTILE_SITE_KEY', 'test-site-key');
+        $this->setEnv('SOLIDINVOICE_TURNSTILE_SECRET_KEY', 'test-secret-key');
+
+        $client = $this->bootClient();
+
+        $this->submitRegistration($client, 'blocked-user@example.com');
+
+        // An invalid form submission re-renders with Symfony's 422 status (no redirect).
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        self::assertStringContainsString('Captcha verification failed', (string) $client->getResponse()->getContent());
+        self::assertSame(0, $this->userCount());
+    }
+
+    #[After]
+    public function resetEnvOverrides(): void
+    {
+        foreach ($this->envOverrides as $name) {
+            unset($_SERVER[$name], $_ENV[$name]);
+        }
+
+        $this->envOverrides = [];
+    }
+
+    private function setEnv(string $name, string $value): void
+    {
+        $_SERVER[$name] = $_ENV[$name] = $value;
+        $this->envOverrides[] = $name;
+    }
+
+    private function submitRegistration(KernelBrowser $client, string $email): void
+    {
+        $crawler = $client->request(Request::METHOD_GET, '/register');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->form([
+            'register[email]' => $email,
+            'register[plainPassword]' => self::PASSWORD,
+            'register[acceptTerms]' => '1',
+        ]);
+
+        $client->submit($form);
+    }
+
+    private function userCount(): int
+    {
+        /** @var ManagerRegistry $registry */
+        $registry = self::getContainer()->get('doctrine');
+
+        return $registry->getRepository(User::class)->count([]);
+    }
+
+    private function bootClient(): KernelBrowser
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        return $client;
+    }
+}

--- a/src/UserBundle/Tests/Security/Turnstile/TurnstileVerifierTest.php
+++ b/src/UserBundle/Tests/Security/Turnstile/TurnstileVerifierTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Security\Turnstile;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\UserBundle\Security\Turnstile\TurnstileVerifier;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class TurnstileVerifierTest extends TestCase
+{
+    public function testVerifyReturnsTrueWhenFeatureDisabledWithoutHttpCall(): void
+    {
+        $httpClient = new MockHttpClient(static function (): MockResponse {
+            self::fail('No HTTP request should be made when the feature is disabled');
+        });
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(false), 'secret');
+
+        self::assertTrue($verifier->verify('token', '127.0.0.1'));
+    }
+
+    public function testVerifyReturnsTrueOnSuccessfulResponse(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse((string) json_encode(['success' => true])));
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(true), 'secret');
+
+        self::assertTrue($verifier->verify('token', '127.0.0.1'));
+    }
+
+    public function testVerifyReturnsFalseOnUnsuccessfulResponse(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse((string) json_encode(['success' => false])));
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(true), 'secret');
+
+        self::assertFalse($verifier->verify('token', '127.0.0.1'));
+    }
+
+    public function testVerifyReturnsFalseForEmptyTokenWithoutHttpCall(): void
+    {
+        $httpClient = new MockHttpClient(static function (): MockResponse {
+            self::fail('No HTTP request should be made for an empty token');
+        });
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(true), 'secret');
+
+        self::assertFalse($verifier->verify('', '127.0.0.1'));
+        self::assertFalse($verifier->verify(null, '127.0.0.1'));
+    }
+
+    public function testVerifyReturnsFalseWhenSecretMissing(): void
+    {
+        $httpClient = new MockHttpClient(static function (): MockResponse {
+            self::fail('No HTTP request should be made without a secret key');
+        });
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(true), null);
+
+        self::assertFalse($verifier->verify('token', '127.0.0.1'));
+    }
+
+    public function testVerifyFailsClosedOnTransportError(): void
+    {
+        $httpClient = new MockHttpClient(static function (): MockResponse {
+            throw new TransportException('Connection refused');
+        });
+
+        $verifier = new TurnstileVerifier($httpClient, $this->toggle(true), 'secret');
+
+        self::assertFalse($verifier->verify('token', '127.0.0.1'));
+    }
+
+    private function toggle(bool $active): ToggleInterface
+    {
+        $toggle = $this->createMock(ToggleInterface::class);
+        $toggle->method('isActive')
+            ->willReturn($active);
+
+        return $toggle;
+    }
+}

--- a/src/UserBundle/Validator/Constraints/Turnstile.php
+++ b/src/UserBundle/Validator/Constraints/Turnstile.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Validator\Constraints;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+final class Turnstile extends Constraint
+{
+    public string $message = 'Captcha verification failed. Please try again.';
+}

--- a/src/UserBundle/Validator/Constraints/TurnstileValidator.php
+++ b/src/UserBundle/Validator/Constraints/TurnstileValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Validator\Constraints;
+
+use SolidInvoice\UserBundle\Security\Turnstile\TurnstileVerifier;
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class TurnstileValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly TurnstileVerifier $verifier,
+        private readonly RequestStack $requestStack,
+        private readonly ToggleInterface $toggle,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (! $constraint instanceof Turnstile) {
+            throw new UnexpectedTypeException($constraint, Turnstile::class);
+        }
+
+        if (! $this->toggle->isActive('turnstile_captcha')) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+
+            return;
+        }
+
+        $token = $request->request->getString('cf-turnstile-response');
+
+        if (! $this->verifier->verify($token, $request->getClientIp())) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional **Cloudflare Turnstile** (managed/invisible mode) captcha protection to the public `/register` page to mitigate spam and automated/bot sign-ups.

The feature is gated by the existing SolidWorx Toggler switch and is enabled **only when both env vars are set**, mirroring exactly how `google_oauth_login` works today:

- `SOLIDINVOICE_TURNSTILE_SITE_KEY`
- `SOLIDINVOICE_TURNSTILE_SECRET_KEY`

When unset (including the default/test environment), the feature is completely invisible and registration behaves exactly as before.

## How it works

- **Feature gating** — a new `turnstile_captcha` toggler feature plus env defaults, following the `google_oauth_login` pattern.
- **Server-side verification** — `TurnstileVerifier` POSTs the token to Cloudflare's `siteverify` endpoint. It **fails closed** (returns `false`) on a missing secret/token, transport error, or `success !== true`, and short-circuits to `true` when the feature is disabled so disabled environments are untouched.
- **Validation hook** — a custom `Turnstile` constraint + `TurnstileValidator` reads the `cf-turnstile-response` token (auto-injected by the managed widget at the top level of the form) from the raw request and verifies it. A non-mapped placeholder `captcha` field on `RegisterType` carries the constraint, so the existing `Register::__invoke` needs no logic change — `$form->isValid()` already gates user creation.
- **Frontend** — template-only: a toggle-gated `cf-turnstile` widget inside the form and the Cloudflare API script in the `javascripts` block. No JS/Stimulus/webpack changes required.

## Why it's bypass-proof

Verification runs server-side inside the validation pipeline that already gates user creation. Omitting the JS/token yields an empty `cf-turnstile-response` → verifier returns `false` → constraint violation → `$form->isValid()` is false → no `User` is created. The verifier fails closed on any error. When the toggle is off, both verifier and validator short-circuit to "valid".

## Tests

- `TurnstileVerifierTest` (unit) — toggle off bypasses HTTP; success/failure responses; empty token and missing secret fail closed without HTTP; transport error fails closed.
- `RegisterTest` (functional) — disabled path persists a `User` (no regression); enabled path with a missing/invalid token re-renders with the captcha error (HTTP 422) and creates no `User`.

## Verification

- ECS: clean
- PHPStan level 6: clean on all changed files
- Full UserBundle suite: passing (185 passed, 11 skipped)