### PR TITLE
Fix totp_secret column too short for scheb/2fa-totp v7+ secrets

### DIFF
--- a/migrations/Version30000_12.php
+++ b/migrations/Version30000_12.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Increases the totp_secret column length from 45 to 64.
+ *
+ * scheb/2fa-totp v7+ generates TOTP secrets via Base32(random_bytes(32)),
+ * which produces 52-character strings — exceeding the old 45-character limit.
+ */
+final class Version30000_12 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $usersTable = $schema->getTable('users');
+        $usersTable->modifyColumn('totp_secret', [
+            'length' => 64,
+            'notnull' => false,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $usersTable = $schema->getTable('users');
+        $usersTable->modifyColumn('totp_secret', [
+            'length' => 45,
+            'notnull' => false,
+        ]);
+    }
+}

--- a/src/UserBundle/Doctrine/Listener/TotpSecretColumnLengthListener.php
+++ b/src/UserBundle/Doctrine/Listener/TotpSecretColumnLengthListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Doctrine\Listener;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use SolidInvoice\UserBundle\Entity\User;
+
+/**
+ * Overrides the ORM column length for the totp_secret column on the User entity.
+ *
+ * The UserTwoFactor trait (from solidworx/platform) declares totp_secret with
+ * length 45, but scheb/2fa-totp v7+ generates 52-character Base32 secrets
+ * (Base32(random_bytes(32))). This listener raises the mapped length to 64 so
+ * that doctrine:schema:update and doctrine:migrations:diff agree with the DB
+ * column produced by migration Version30000_12.
+ */
+#[AsDoctrineListener(Events::loadClassMetadata)]
+final class TotpSecretColumnLengthListener
+{
+    public function loadClassMetadata(LoadClassMetadataEventArgs $event): void
+    {
+        $classMetadata = $event->getClassMetadata();
+
+        if ($classMetadata->getName() !== User::class) {
+            return;
+        }
+
+        if (isset($classMetadata->fieldMappings['totpSecret'])) {
+            $classMetadata->fieldMappings['totpSecret']['length'] = 64;
+        }
+    }
+}

--- a/src/UserBundle/Tests/Doctrine/Listener/TotpSecretColumnLengthListenerTest.php
+++ b/src/UserBundle/Tests/Doctrine/Listener/TotpSecretColumnLengthListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\UserBundle\Tests\Doctrine\Listener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\UserBundle\Doctrine\Listener\TotpSecretColumnLengthListener;
+use SolidInvoice\UserBundle\Entity\User;
+use stdClass;
+
+#[CoversClass(TotpSecretColumnLengthListener::class)]
+final class TotpSecretColumnLengthListenerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testOverridesTotpSecretColumnLengthForUserEntity(): void
+    {
+        $classMetadata = new ClassMetadata(User::class);
+        $classMetadata->fieldMappings['totpSecret'] = [
+            'fieldName' => 'totpSecret',
+            'type' => 'string',
+            'length' => 45,
+            'nullable' => true,
+            'columnName' => 'totp_secret',
+        ];
+
+        $event = new LoadClassMetadataEventArgs($classMetadata, M::mock(EntityManagerInterface::class));
+
+        (new TotpSecretColumnLengthListener())->loadClassMetadata($event);
+
+        // scheb/2fa-totp v7+ generates 52-char Base32 secrets; old limit was 45
+        self::assertGreaterThan(45, $classMetadata->fieldMappings['totpSecret']['length']);
+        self::assertGreaterThanOrEqual(52, $classMetadata->fieldMappings['totpSecret']['length']);
+    }
+
+    public function testDoesNotModifyFieldsForOtherEntities(): void
+    {
+        $classMetadata = new ClassMetadata(stdClass::class);
+        $classMetadata->fieldMappings['someField'] = [
+            'fieldName' => 'someField',
+            'type' => 'string',
+            'length' => 45,
+            'nullable' => true,
+            'columnName' => 'some_field',
+        ];
+
+        $event = new LoadClassMetadataEventArgs($classMetadata, M::mock(EntityManagerInterface::class));
+
+        (new TotpSecretColumnLengthListener())->loadClassMetadata($event);
+
+        // Only the User entity's totpSecret column is widened; other entities are untouched
+        self::assertArrayHasKey('someField', $classMetadata->fieldMappings);
+        self::assertArrayNotHasKey('totpSecret', $classMetadata->fieldMappings);
+    }
+
+    public function testDoesNotThrowWhenUserEntityHasNoTotpSecretField(): void
+    {
+        $classMetadata = new ClassMetadata(User::class);
+
+        $event = new LoadClassMetadataEventArgs($classMetadata, M::mock(EntityManagerInterface::class));
+
+        (new TotpSecretColumnLengthListener())->loadClassMetadata($event);
+
+        self::assertArrayNotHasKey('totpSecret', $classMetadata->fieldMappings);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2461

- `scheb/2fa-totp` v7+ generates TOTP secrets via `Base32::encodeUpperUnpadded(random_bytes(32))`, producing **52-character** strings
- The `totp_secret` column was created with `length: 45` (migration `Version20400_5`) and the ORM mapping in `solidworx/platform`'s `UserTwoFactor` trait also declares `length: 45`
- MySQL/MariaDB enforces VARCHAR length → `DriverException: Data too long for column 'totp_secret'` on the first TOTP enable attempt

## Fix

**Migration `Version30000_12`:** widens the `totp_secret` column from 45 → 64 chars (64 gives headroom beyond the current 52-char output).

**`TotpSecretColumnLengthListener`:** A Doctrine `loadClassMetadata` listener that overrides the ORM field mapping length to 64 at runtime. This is necessary because:
- The `UserTwoFactor` trait lives in `vendor/solidworx/platform` and cannot be modified
- Without the listener, `doctrine:schema:update` would recreate a 45-char column on fresh installs, and `doctrine:migrations:diff` would generate a regression migration shrinking the column back to 45
- The listener is auto-discovered via `#[AsDoctrineListener]` — no service registration needed

## Tests

Three unit tests for `TotpSecretColumnLengthListenerTest`:
1. **`testOverridesTotpSecretColumnLengthForUserEntity`** — verifies the column length is raised above 45 (≥ 52) for the `User` entity
2. **`testDoesNotModifyFieldsForOtherEntities`** — verifies other entities are not touched
3. **`testDoesNotThrowWhenUserEntityHasNoTotpSecretField`** — verifies graceful no-op when field is absent

All 3 tests pass. ECS and PHPStan (on the new files) pass cleanly.

## Test plan

- [ ] Run `bin/phpunit src/UserBundle/Tests/Doctrine/Listener/TotpSecretColumnLengthListenerTest.php` — 3 tests pass
- [ ] Run `bin/console doctrine:migrations:migrate` on an existing DB — migration widens column
- [ ] Enable TOTP 2FA for a user — secret saves without `Data too long` error
- [ ] Run `bin/console doctrine:migrations:diff` — no regression migration is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdYFW99LaAAidwN8y7kjRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdYFW99LaAAidwN8y7kjRH)_