### PR TITLE
Fix Add Credit button on client page not working

### DIFF
--- a/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
+++ b/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
@@ -7,15 +7,17 @@
         {{ 'client.view.actions.add_credit'|trans }}
     </button>
 
+    {{ form_start(form, {attr: {'data-action': 'live#action:prevent', 'data-live-action-param': 'save'}}) }}
     <twig:Ui:Modal id="add-client-credit" title="{{ 'client.modal.add_credit'|trans }}">
-        {{ form(form) }}
+        {{ form_row(form) }}
 
         <twig:block name="footer">
             <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
-            <button type="button" class="btn btn-primary" data-action="live#action:prevent" data-live-action-param="save">
+            <button type="submit" class="btn btn-primary">
                 {{ ux_icon('tabler:device-floppy', {width: 16, height: 16}) }}
                 {{ 'Save'|trans }}
             </button>
         </twig:block>
     </twig:Ui:Modal>
+    {{ form_end(form) }}
 </div>

--- a/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
+++ b/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Twig\Components;
+
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Twig\Components\ClientCredit;
+use SolidInvoice\CoreBundle\Test\LiveComponentTest;
+use Symfony\Component\Uid\Ulid;
+use Zenstruck\Foundry\Test\Factories;
+
+#[CoversClass(ClientCredit::class)]
+final class ClientCreditTest extends LiveComponentTest
+{
+    use Factories;
+
+    public function testFormWrapsModal(): void
+    {
+        $client = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ])->_real();
+
+        $html = $this
+            ->createLiveComponent(
+                name: ClientCredit::class,
+                data: ['client' => $client],
+                client: $this->client,
+            )
+            ->actingAs($this->getUser())
+            ->render()
+            ->toString();
+
+        // The <form> element must carry data-action so that the submit event is
+        // handled by the LiveComponent rather than causing a plain POST.
+        // Before the fix, {{ form(form) }} was used inside the modal body which
+        // rendered a self-contained <form> with no data-action; the save button
+        // (type="button") sat in the modal footer outside the form element and
+        // could not submit it. After the fix, form_start() wraps the modal so
+        // the form element itself has data-action="live#action:prevent".
+        self::assertMatchesRegularExpression(
+            '/<form\b[^>]+\bdata-action="live#action:prevent"/',
+            $html,
+            'The <form> element must have data-action="live#action:prevent" to trigger the LiveComponent save action',
+        );
+
+        // The save button must be type="submit" (inside the form) so that
+        // pressing Enter or clicking it submits the form via the live action.
+        // Before the fix it was type="button" and was outside the <form> element.
+        self::assertStringContainsString(
+            'type="submit"',
+            $html,
+            'The save button must be type="submit" inside the form',
+        );
+    }
+
+    public function testSaveAddsCredit(): void
+    {
+        $client = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ])->_real();
+
+        $clientId = $client->getId();
+        self::assertInstanceOf(Ulid::class, $clientId);
+
+        $this
+            ->createLiveComponent(
+                name: ClientCredit::class,
+                data: ['client' => $client],
+                client: $this->client,
+            )
+            ->actingAs($this->getUser())
+            // Simulate the user entering $10.00 in the amount field.
+            // ViewTransformer::reverseTransform(10) = BigDecimal::of(1000) cents.
+            ->set('formData', ['amount' => 10])
+            ->call('save');
+
+        // Fetch fresh data from the database to verify the credit was persisted.
+        self::getContainer()->get('doctrine')->getManager()->clear();
+
+        $updatedClient = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->find(Client::class, $clientId);
+
+        self::assertNotNull($updatedClient);
+
+        $creditValue = $updatedClient->getCredit()->getValue();
+
+        self::assertTrue(
+            BigDecimal::of(1000)->isEqualTo($creditValue),
+            sprintf('Expected credit of 1000 cents ($10.00), got %s', $creditValue),
+        );
+    }
+}

--- a/src/ClientBundle/Twig/Components/ClientCredit.php
+++ b/src/ClientBundle/Twig/Components/ClientCredit.php
@@ -25,6 +25,9 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
+/**
+ * @see \SolidInvoice\ClientBundle\Tests\Twig\Components\ClientCreditTest
+ */
 #[AsLiveComponent]
 final class ClientCredit extends AbstractController
 {


### PR DESCRIPTION
Closes #2506

## Root cause

`ClientCredit.html.twig` used `{{ form(form) }}` to render the credit form **inside the modal body**. This produces a self-contained `<form>…</form>` block in the modal body — but the Save button is rendered in the modal *footer* (via `<twig:block name="footer">`), which is **outside** that `<form>` element. As a result:

- Clicking **Save** (which was `type="button"`) fired a Stimulus live action, but the `<form>` element had no `data-action="live#action:prevent"` on it.
- Pressing **Enter** inside the amount field would submit the bare `<form>` to the current page URL instead of going through the LiveComponent endpoint.
- The form data could not be properly picked up by the LiveComponent action.

## Fix

Replace `{{ form(form) }}` with the `form_start()` / `form_end()` pattern already used consistently in every other modal form in the codebase (`AddressCollection`, `ContactCollection`):

- `form_start(form, {attr: {'data-action': 'live#action:prevent', 'data-live-action-param': 'save'}})` is placed **before** the modal, so the `<form>` element wraps the entire modal (including its footer).
- `form_row(form)` renders just the fields inside the modal body.
- The Save button becomes `type="submit"` — now properly inside the form.
- `form_end(form)` closes the form after the modal.

## Test approach

Added `ClientCreditTest` with two cases:

1. **`testFormWrapsModal`** — renders the component and asserts:
   - The `<form>` element has `data-action="live#action:prevent"` (fails before fix, passes after).
   - The Save button is `type="submit"` (fails before fix, passes after).

2. **`testSaveAddsCredit`** — simulates a user entering $10.00, calls the `save` live action, and verifies the client's credit is 1 000 cents ($10.00) in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4xa4mkC3YcmUn71T4FP7m)_