### PR TITLE
Add SaaS upgrade-funnel telemetry events

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3135,25 +3135,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -3162,8 +3163,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -3241,7 +3243,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -3257,28 +3259,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -3324,7 +3327,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -3340,20 +3343,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -3443,7 +3446,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -3459,7 +3462,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "illuminate/collections",
@@ -15787,16 +15790,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -15848,7 +15851,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -15868,20 +15871,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -15928,7 +15931,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -15948,7 +15951,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -19508,16 +19511,16 @@
         },
         {
             "name": "symfony/ux-icons",
-            "version": "v2.36.0",
+            "version": "v2.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-icons.git",
-                "reference": "f413a434caeaab4b237d6970d424f125e2bc41cf"
+                "reference": "567f33ddffc25504788abc61977565381e424ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-icons/zipball/f413a434caeaab4b237d6970d424f125e2bc41cf",
-                "reference": "f413a434caeaab4b237d6970d424f125e2bc41cf",
+                "url": "https://api.github.com/repos/symfony/ux-icons/zipball/567f33ddffc25504788abc61977565381e424ada",
+                "reference": "567f33ddffc25504788abc61977565381e424ada",
                 "shasum": ""
             },
             "require": {
@@ -19577,7 +19580,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/symfony/ux-icons/tree/v2.36.0"
+                "source": "https://github.com/symfony/ux-icons/tree/v2.36.1"
             },
             "funding": [
                 {
@@ -19597,7 +19600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-03T05:13:59+00:00"
+            "time": "2026-06-16T05:43:46+00:00"
         },
         {
             "name": "symfony/ux-live-component",
@@ -24673,18 +24676,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "89aea44a53fbe571a89140af23654bd1c4d85bf6"
+                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/89aea44a53fbe571a89140af23654bd1c4d85bf6",
-                "reference": "89aea44a53fbe571a89140af23654bd1c4d85bf6",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/55f7461997e52f12c93d307ccdcb0ee8e89f336a",
+                "reference": "55f7461997e52f12c93d307ccdcb0ee8e89f336a",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adaptcms/adaptcms": "<=1.3",
-                "admidio/admidio": "<=5.0.8",
+                "admidio/admidio": "<=5.0.9",
                 "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
@@ -24733,7 +24736,7 @@
                 "auth0/login": "<=7.20",
                 "auth0/symfony": "<=5.7",
                 "auth0/wordpress": "<=5.5",
-                "automad/automad": "<2.0.0.0-alpha5",
+                "automad/automad": "<=2.0.0.0-beta27",
                 "automattic/jetpack": "<9.8",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": "<=3.371.3",
@@ -24741,7 +24744,7 @@
                 "azuracast/azuracast": "<=0.23.5",
                 "b13/seo_basics": "<0.8.2",
                 "backdrop/backdrop": "<=1.32",
-                "backpack/crud": "<3.4.9",
+                "backpack/crud": "<4.0.63|>=4.1,<4.1.69|>=5,<5.0.13",
                 "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
                 "bacula-web/bacula-web": "<9.7.1",
                 "badaso/core": "<=2.9.11",
@@ -24758,6 +24761,7 @@
                 "bedita/bedita": "<4",
                 "bednee/cooluri": "<1.0.30",
                 "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billabear/billabear": "<=2025.01.03",
                 "billz/raspap-webgui": "<3.3.6",
                 "binarytorch/larecipe": "<2.8.1",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
@@ -24778,13 +24782,14 @@
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cadmium-org/cadmium-cms": "<=0.4.9",
+                "cakephp/authentication": "<3.3.6|>=4,<4.1.1",
                 "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|>=5.2.10,<5.2.12|==5.3",
                 "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
                 "cardgate/magento2": "<2.0.33",
                 "cardgate/woocommerce": "<=3.1.15",
-                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cart2quote/module-quotation": ">=4.1.6,<4.4.6|>=5,<5.4.4",
                 "cart2quote/module-quotation-encoded": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<=2.1.6",
+                "cartalyst/sentry": "<2.1.7",
                 "catfan/medoo": "<1.7.5",
                 "causal/oidc": "<4",
                 "cecil/cecil": "<7.47.1",
@@ -24802,7 +24807,7 @@
                 "code16/sharp": "<9.22",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
-                "codeigniter4/framework": "<4.6.2",
+                "codeigniter4/framework": "<4.7.2",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
                 "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
@@ -24822,12 +24827,13 @@
                 "coreshop/core-shop": "<4.1.9|==5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
+                "cotonti/cotonti": "<=1",
                 "couleurcitron/tarteaucitron-wp": "<0.3",
                 "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
                 "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
                 "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
-                "craftcms/cms": "<4.17.12|>=5,<5.9.18",
-                "craftcms/commerce": ">=4,<4.11|>=5,<5.6",
+                "craftcms/cms": "<4.18|>=5,<5.10",
+                "craftcms/commerce": ">=4,<=4.11.1|>=5,<=5.6.4",
                 "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
                 "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
                 "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
@@ -24882,7 +24888,7 @@
                 "drupal/commerce_alphabank_redirect": "<1.0.3",
                 "drupal/commerce_eurobank_redirect": "<2.1.1",
                 "drupal/config_split": "<1.10|>=2,<2.0.2",
-                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.4.9|>=10.5,<10.5.6|>=11,<11.1.9|>=11.2,<11.2.8",
+                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.5.10|>=10.6,<10.6.9|>=11,<11.2.12|>=11.3,<11.3.10",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
                 "drupal/currency": "<3.5",
                 "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
@@ -24909,6 +24915,7 @@
                 "drupal/umami_analytics": "<1.0.1",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.10|>=5,<5.0.13",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
@@ -24924,6 +24931,7 @@
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
                 "evolutioncms/evolution": "<=3.2.3",
+                "evoweb/sf-register": "<13.2.4|>=14,<14.0.2",
                 "exceedone/exment": "<4.4.3|>=5,<5.0.3",
                 "exceedone/laravel-admin": "<2.2.3|==3",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1-dev",
@@ -24951,10 +24959,11 @@
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
-                "filament/actions": ">=3.2,<3.2.123",
+                "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
                 "filament/filament": ">=4,<4.3.1",
+                "filament/forms": ">=3,<=3.3.52",
                 "filament/infolists": ">=3,<3.2.115",
-                "filament/tables": ">=3,<3.2.115|>=4,<4.8.5|>=5,<5.3.5",
+                "filament/tables": ">=3,<=3.3.50|>=4,<4.8.5|>=5,<5.3.5",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -24988,21 +24997,22 @@
                 "friendsofsymfony1/symfony1": ">=1.1,<1.5.19",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
+                "friendsoftypo3/tt-address": "<8.1.2|>=9,<9.1.1|>=10,<10.0.1",
                 "froala/wysiwyg-editor": "<=4.3",
                 "frosh/adminer-platform": "<2.2.1",
-                "froxlor/froxlor": "<2.3.6",
+                "froxlor/froxlor": "<2.3.7",
                 "frozennode/administrator": "<=5.0.12",
                 "fuel/core": "<1.8.1",
                 "funadmin/funadmin": "<=7.1.0.0-RC6",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
-                "georgringer/news": "<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
+                "georgringer/news": "<10.0.4|>=11,<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
                 "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<=2.3.3",
-                "getgrav/grav": "<=2.0.0.0-RC1",
+                "getgrav/grav": "<=2.0.0.0-RC8",
                 "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
                 "getgrav/grav-plugin-form": "<9.1",
-                "getkirby/cms": "<4.9|>=5,<5.4",
+                "getkirby/cms": "<=4.9.3|>=5,<=5.4.3",
                 "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
@@ -25017,11 +25027,12 @@
                 "gp247/core": "<1.1.24",
                 "gree/jose": "<2.2.1",
                 "gregwar/rst": "<1.0.3",
-                "grumpydictator/firefly-iii": "<6.1.17|>=6.4.23,<=6.5",
+                "grumpydictator/firefly-iii": "<=6.6.2",
                 "gugoan/economizzer": "<=0.9.0.0-beta1",
-                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/guzzle": "<7.12.1",
+                "guzzlehttp/guzzle-services": "<1.5.4",
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
-                "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
+                "guzzlehttp/psr7": "<2.12.1",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
                 "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
@@ -25050,6 +25061,7 @@
                 "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<6.18.31|>=7,<7.22.4",
                 "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
                 "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/mail": ">=9,<12.60|>=13,<13.10",
                 "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "imdbphp/imdbphp": "<=5.1.1",
                 "impresscms/impresscms": "<=1.4.5",
@@ -25063,7 +25075,7 @@
                 "inter-mediator/inter-mediator": "==5.5",
                 "intercom/intercom-php": "==5.0.2",
                 "invoiceninja/invoiceninja": "<5.13.4",
-                "ipl/web": "<=0.13",
+                "ipl/web": "<=0.10.2|>=0.11,<=0.13",
                 "islandora/crayfish": "<4.1",
                 "islandora/islandora": ">=2,<2.4.1",
                 "ivankristianto/phpwhois": "<=4.3",
@@ -25075,6 +25087,7 @@
                 "jasig/phpcas": "<1.3.3",
                 "jbartels/wec-map": "<3.0.3",
                 "jcbrand/converse.js": "<3.3.3",
+                "jleehr/canto-saas-api": "<=2",
                 "joedolson/my-calendar": "<3.7.7",
                 "joelbutcher/socialstream": "<5.6|>=6,<6.2",
                 "johnbillion/query-monitor": "<3.20.4",
@@ -25118,7 +25131,7 @@
                 "lara-zeus/artemis": ">=1,<=1.0.6",
                 "lara-zeus/dynamic-dashboard": ">=3,<=3.0.1",
                 "laravel/fortify": "<1.11.1",
-                "laravel/framework": "<10.48.29|>=11,<11.44.1|>=12,<12.1.1",
+                "laravel/framework": "<12.61.1|>=13,<13.12",
                 "laravel/laravel": ">=5.4,<5.4.22",
                 "laravel/passport": ">=13,<13.7.1",
                 "laravel/pulse": "<1.3.1",
@@ -25196,6 +25209,7 @@
                 "miraheze/ts-portal": "<=33",
                 "mittwald/typo3_forum": "<1.2.1",
                 "mix/mix": ">=2,<=2.2.17",
+                "mmc/ceselector": "<3.0.3|>=4,<4.0.2|>=5,<5.0.1|>=6,<6.0.1",
                 "mobiledetect/mobiledetectlib": "<2.8.32",
                 "modx/revolution": "<=3.1",
                 "mojo42/jirafeau": "<4.4",
@@ -25208,6 +25222,7 @@
                 "movim/moxl": ">=0.8,<=0.10",
                 "movingbytes/social-network": "<=1.2.1",
                 "mpdf/mpdf": "<=7.1.7",
+                "mtdowling/jmespath.php": "<2.9.1",
                 "munkireport/comment": "<4",
                 "munkireport/managedinstalls": "<2.6",
                 "munkireport/munki_facts": "<1.5",
@@ -25277,6 +25292,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
+                "paymenter/paymenter": "<1.2.11",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -25289,11 +25305,12 @@
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
                 "ph7software/ph7builder": "<=17.9.1",
-                "phanan/koel": "<5.1.4",
+                "phanan/koel": "<=9.3.4",
+                "pheditor/pheditor": ">=2.0.1,<=2.0.3",
                 "phenx/php-svg-lib": "<0.5.2",
                 "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
                 "php-mod/curl": "<2.3.2",
-                "phpbb/phpbb": "<3.3.11",
+                "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
@@ -25303,9 +25320,9 @@
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<=1.30.3|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
+                "phpoffice/phpspreadsheet": "<=1.30.4|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
                 "phppgadmin/phppgadmin": "<=7.13",
-                "phpseclib/phpseclib": "<=2.0.53|>=3,<=3.0.51",
+                "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
                 "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
@@ -25314,14 +25331,14 @@
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "phraseanet/phraseanet": "==4.0.3",
                 "pi/pi": "<=2.5",
-                "pimcore/admin-ui-classic-bundle": "<=1.7.15|>=2.0.0.0-RC1-dev,<=2.2.2",
+                "pimcore/admin-ui-classic-bundle": "<=2.3.5",
                 "pimcore/customer-management-framework-bundle": "<4.2.1",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=11.5.14.1|>=12,<12.3.3|==12.3.3",
+                "pimcore/pimcore": "<=12.3.8",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
@@ -25329,6 +25346,7 @@
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<5.42.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
+                "poweradmin/poweradmin": "<4.2.4|>=4.3,<4.3.3",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockreassurance": "<=5.1.3",
@@ -25344,10 +25362,10 @@
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
                 "processwire/processwire": "<=3.0.255",
-                "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
-                "propel/propel1": ">=1,<=1.7.1",
+                "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
+                "propel/propel1": ">=1,<1.7.2",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
-                "pterodactyl/panel": "<1.12.1",
+                "pterodactyl/panel": "<1.12.3",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
@@ -25395,10 +25413,10 @@
                 "sheng/yiicms": "<1.2.1",
                 "shopper/cart": "<2.8",
                 "shopper/framework": "<2.8",
-                "shopware/core": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
-                "shopware/platform": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
+                "shopware/core": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
+                "shopware/platform": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<=5.7.17|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
+                "shopware/shopware": "<=6.3.5.2|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
                 "shopware/storefront": "<6.6.10.10-dev|>=6.7,<6.7.5.1-dev",
                 "shopxo/shopxo": "<=6.4",
                 "showdoc/showdoc": "<3.8.1",
@@ -25408,7 +25426,7 @@
                 "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
                 "silverstripe/cms": "<4.11.3",
                 "silverstripe/comments": ">=1.3,<3.1.1",
-                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
                 "silverstripe/framework": "<5.3.23",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
@@ -25448,9 +25466,11 @@
                 "soosyze/soosyze": "<=2",
                 "spatie/browsershot": "<5.0.5",
                 "spatie/image-optimizer": "<1.7.3",
+                "spatie/schema-org": ">=3.23.1,<3.23.2|>=4,<4.0.2",
                 "spencer14420/sp-php-email-handler": "<1",
                 "spipu/html2pdf": "<5.2.8",
                 "spiral/roadrunner": "<2025.1",
+                "spomky-labs/otphp": "<11.4.3",
                 "spoon/library": "<1.4.1",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
@@ -25484,51 +25504,55 @@
                 "symbiote/silverstripe-seed": "<6.0.3",
                 "symbiote/silverstripe-versionedfiles": "<=2.0.3",
                 "symfont/process": ">=0",
-                "symfony/cache": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/cache": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/dom-crawler": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/dom-crawler": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
-                "symfony/html-sanitizer": ">=6.1,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
-                "symfony/http-client": ">=4.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
-                "symfony/http-foundation": "<5.4.50|>=6,<6.4.29|>=7,<7.3.7",
+                "symfony/html-sanitizer": ">=6.1,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/http-client": ">=4.3,<5.4.53|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/http-foundation": "<5.4.50|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6|>=7.4,<7.4.12|>=8,<8.0.12",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/json-path": ">=7.3,<7.4.12|>=8,<8.0.12",
                 "symfony/lox24-notifier": ">=7.1,<7.4.12|>=8,<8.0.12",
-                "symfony/mailer": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailer": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/mailjet-mailer": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailomat-mailer": ">=7.2,<7.4.13|>=8,<8.0.13",
                 "symfony/mailtrap-mailer": ">=7.2,<7.4.12|>=8,<8.0.12",
                 "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
-                "symfony/mime": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
-                "symfony/monolog-bridge": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mime": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/monolog-bridge": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill": ">=1,<1.10|>=1.17.1,<1.38.1",
+                "symfony/polyfill-intl-idn": ">=1.17.1,<1.38.1",
                 "symfony/polyfill-php55": ">=1,<1.10",
                 "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
                 "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/routing": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/routing": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/runtime": ">=5.3,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
                 "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
-                "symfony/security-http": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/security-http": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
-                "symfony/symfony": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/symfony": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
                 "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
-                "symfony/ux-autocomplete": "<2.11.2",
-                "symfony/ux-live-component": "<2.25.1",
+                "symfony/ux-autocomplete": "<2.36|>=3,<3.1",
+                "symfony/ux-icons": ">=2.17,<2.36.1|>=3,<3.2",
+                "symfony/ux-live-component": "<2.36|>=3,<3.1",
+                "symfony/ux-toolkit": ">=2.32,<2.36.1|>=3,<3.2",
                 "symfony/ux-twig-component": "<2.25.1",
                 "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4|>=7.2.9,<7.4.12|>=8,<8.0.12",
                 "symfony/webhook": ">=6.3,<6.3.8",
-                "symfony/yaml": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/yaml": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symphonycms/symphony-2": "<2.6.4",
                 "t3/dce": "<0.11.5|>=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
@@ -25545,16 +25569,17 @@
                 "thorsten/phpmyfaq": "<4.1.3",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
-                "tinymce/tinymce": "<7.2",
+                "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
                 "tinymighty/wiki-seo": "<1.2.2",
                 "titon/framework": "<9.9.99",
                 "tltneon/lgsl": "<7",
                 "tobiasbg/tablepress": "<=2.0.0.0-RC1",
+                "tomasnorre/crawler": "<11.0.13|>=12,<12.0.11",
                 "topthink/framework": "<6.0.17|>=6.1,<=8.0.4",
                 "topthink/think": "<=6.1.1",
                 "topthink/thinkphp": "<=3.2.3|>=6.1.3,<=8.0.4",
                 "torrentpier/torrentpier": "<=2.8.8",
-                "tpwd/ke_search": "<4.0.3|>=4.1,<4.6.6|>=5,<5.0.2",
+                "tpwd/ke_search": "<5.6.2|>=6,<6.6.1|>=7,<7.0.1",
                 "tribalsystems/zenario": "<=9.7.61188",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "ttskch/pagination-service-provider": "<1",
@@ -25562,25 +25587,26 @@
                 "twig/cssinliner-extra": "<3.26",
                 "twig/intl-extra": "<3.26",
                 "twig/markdown-extra": "<3.26",
-                "twig/twig": "<3.26",
+                "twig/twig": "<3.27",
                 "typicms/core": "<16.1.7",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
-                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1|==14.2",
+                "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
-                "typo3/cms-core": "<=8.7.56|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-felogin": ">=4.2,<4.2.3",
+                "typo3/cms-filelist": ">=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1",
-                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-form": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
-                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-install": "<4.1.14|>=4.2,<4.2.16|>=4.3,<4.3.9|>=4.4,<4.4.5|>=12.2,<12.4.8|==13.4.2",
                 "typo3/cms-lowlevel": ">=11,<=11.5.41",
                 "typo3/cms-recordlist": ">=11,<11.5.48",
-                "typo3/cms-recycler": ">=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-recycler": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-redirects": ">=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
                 "typo3/cms-rte-ckeditor": ">=9.5,<9.5.42|>=10,<10.4.39|>=11,<11.5.30",
                 "typo3/cms-scheduler": ">=11,<=11.5.41",
@@ -25588,7 +25614,7 @@
                 "typo3/cms-webhooks": ">=12,<=12.4.30|>=13,<=13.4.11",
                 "typo3/cms-workspaces": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
-                "typo3/html-sanitizer": ">=1,<=1.5.2|>=2,<=2.1.3",
+                "typo3/html-sanitizer": "<2.3.2",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
                 "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
                 "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
@@ -25604,7 +25630,7 @@
                 "uvdesk/core-framework": "<=1.1.1",
                 "vanilla/safecurl": "<0.9.2",
                 "verbb/comments": "<1.5.5",
-                "verbb/formie": "<2.2.20|>=3.0.0.0-beta1,<3.1.24",
+                "verbb/formie": "<2.2.21|>=3,<3.1.26",
                 "verbb/image-resizer": "<2.0.9",
                 "verbb/knock-knock": "<1.2.8",
                 "verot/class.upload.php": "<=2.1.6",
@@ -25622,6 +25648,9 @@
                 "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
                 "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
                 "web-feet/coastercms": "==5.5",
+                "web-token/jwt-experimental": "<=4.1.6",
+                "web-token/jwt-framework": "<=4.2.99",
+                "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
                 "web-tp3/wec_map": "<3.0.3",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
@@ -25747,7 +25776,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-22T16:47:49+00:00"
+            "time": "2026-06-22T17:34:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/packages/doctrine_migrations.php
+++ b/config/packages/doctrine_migrations.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use Doctrine\Migrations\Version\Comparator;
+use SolidInvoice\CoreBundle\Doctrine\Migrations\NaturalVersionComparator;
 use Symfony\Config\DoctrineMigrationsConfig;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
@@ -22,4 +24,6 @@ return static function (DoctrineMigrationsConfig $config): void {
         ->tableStorage()
         ->tableName('migration_versions')
     ;
+
+    $config->services(Comparator::class, NaturalVersionComparator::class);
 };

--- a/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
+++ b/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
@@ -7,15 +7,17 @@
         {{ 'client.view.actions.add_credit'|trans }}
     </button>
 
+    {{ form_start(form, {attr: {'data-action': 'live#action:prevent', 'data-live-action-param': 'save'}}) }}
     <twig:Ui:Modal id="add-client-credit" title="{{ 'client.modal.add_credit'|trans }}">
-        {{ form(form) }}
+        {{ form_row(form) }}
 
         <twig:block name="footer">
             <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
-            <button type="button" class="btn btn-primary" data-action="live#action:prevent" data-live-action-param="save">
+            <button type="submit" class="btn btn-primary">
                 {{ ux_icon('tabler:device-floppy', {width: 16, height: 16}) }}
                 {{ 'Save'|trans }}
             </button>
         </twig:block>
     </twig:Ui:Modal>
+    {{ form_end(form) }}
 </div>

--- a/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
+++ b/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Twig\Components;
+
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Twig\Components\ClientCredit;
+use SolidInvoice\CoreBundle\Test\LiveComponentTest;
+use Symfony\Component\Uid\Ulid;
+use Zenstruck\Foundry\Test\Factories;
+
+#[CoversClass(ClientCredit::class)]
+final class ClientCreditTest extends LiveComponentTest
+{
+    use Factories;
+
+    public function testFormWrapsModal(): void
+    {
+        $client = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ])->_real();
+
+        $html = $this
+            ->createLiveComponent(
+                name: ClientCredit::class,
+                data: ['client' => $client],
+                client: $this->client,
+            )
+            ->actingAs($this->getUser())
+            ->render()
+            ->toString();
+
+        // The <form> element must carry data-action so that the submit event is
+        // handled by the LiveComponent rather than causing a plain POST.
+        // Before the fix, {{ form(form) }} was used inside the modal body which
+        // rendered a self-contained <form> with no data-action; the save button
+        // (type="button") sat in the modal footer outside the form element and
+        // could not submit it. After the fix, form_start() wraps the modal so
+        // the form element itself has data-action="live#action:prevent".
+        self::assertMatchesRegularExpression(
+            '/<form\b[^>]+\bdata-action="live#action:prevent"/',
+            $html,
+            'The <form> element must have data-action="live#action:prevent" to trigger the LiveComponent save action',
+        );
+
+        // The save button must be type="submit" (inside the form) so that
+        // pressing Enter or clicking it submits the form via the live action.
+        // Before the fix it was type="button" and was outside the <form> element.
+        self::assertStringContainsString(
+            'type="submit"',
+            $html,
+            'The save button must be type="submit" inside the form',
+        );
+    }
+
+    public function testSaveAddsCredit(): void
+    {
+        $client = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ])->_real();
+
+        $clientId = $client->getId();
+        self::assertInstanceOf(Ulid::class, $clientId);
+
+        $this
+            ->createLiveComponent(
+                name: ClientCredit::class,
+                data: ['client' => $client],
+                client: $this->client,
+            )
+            ->actingAs($this->getUser())
+            // Simulate the user entering $10.00 in the amount field.
+            // ViewTransformer::reverseTransform(10) = BigDecimal::of(1000) cents.
+            ->set('formData', ['amount' => 10])
+            ->call('save');
+
+        // Fetch fresh data from the database to verify the credit was persisted.
+        self::getContainer()->get('doctrine')->getManager()->clear();
+
+        $updatedClient = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->find(Client::class, $clientId);
+
+        self::assertNotNull($updatedClient);
+
+        $creditValue = $updatedClient->getCredit()->getValue();
+
+        self::assertTrue(
+            BigDecimal::of(1000)->isEqualTo($creditValue),
+            sprintf('Expected credit of 1000 cents ($10.00), got %s', $creditValue),
+        );
+    }
+}

--- a/src/ClientBundle/Twig/Components/ClientCredit.php
+++ b/src/ClientBundle/Twig/Components/ClientCredit.php
@@ -25,6 +25,9 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
+/**
+ * @see \SolidInvoice\ClientBundle\Tests\Twig\Components\ClientCreditTest
+ */
 #[AsLiveComponent]
 final class ClientCredit extends AbstractController
 {

--- a/src/CoreBundle/Doctrine/Migrations/NaturalVersionComparator.php
+++ b/src/CoreBundle/Doctrine/Migrations/NaturalVersionComparator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Doctrine\Migrations;
+
+use Doctrine\Migrations\Version\Comparator;
+use Doctrine\Migrations\Version\Version;
+use function strnatcmp;
+
+final class NaturalVersionComparator implements Comparator
+{
+    public function compare(Version $a, Version $b): int
+    {
+        return strnatcmp((string) $a, (string) $b);
+    }
+}

--- a/src/CoreBundle/Form/Type/CustomFieldValueCollectionType.php
+++ b/src/CoreBundle/Form/Type/CustomFieldValueCollectionType.php
@@ -112,8 +112,8 @@ final class CustomFieldValueCollectionType extends AbstractType
 
             // An entity is "persisted" (has a stable Doctrine-assigned ID) only when it
             // is already managed by the UnitOfWork. For new (unpersisted) entities,
-            // Doctrine will overwrite any constructor-set ID on first persist, so we must
-            // defer targetId assignment until after postPersist.
+            // Doctrine's UlidGenerator overwrites any constructor-set ID on first persist,
+            // so we must defer targetId assignment until after postPersist fires.
             $parentIsManaged = $parentId instanceof Ulid && $this->em->contains($parent);
 
             /** @var list<CustomFieldValue> $pendingValues */
@@ -157,12 +157,13 @@ final class CustomFieldValueCollectionType extends AbstractType
 
             if ($pendingValues !== []) {
                 $em = $this->em;
-                $listener = null;
-                $listenerObj = new class($parent, $pendingValues, $em, $listener) {
+                $listenerObj = new class($parent, $pendingValues, $em) {
                     /**
                      * @var list<CustomFieldValue>
                      */
                     private array $toFlush = [];
+
+                    private ?object $self = null;
 
                     /**
                      * @param list<CustomFieldValue> $pending
@@ -171,8 +172,12 @@ final class CustomFieldValueCollectionType extends AbstractType
                         private readonly object $parent,
                         private readonly array $pending,
                         private readonly EntityManagerInterface $em,
-                        private mixed &$selfRef,
                     ) {
+                    }
+
+                    public function setSelf(object $self): void
+                    {
+                        $this->self = $self;
                     }
 
                     public function postPersist(PostPersistEventArgs $args): void
@@ -199,18 +204,17 @@ final class CustomFieldValueCollectionType extends AbstractType
                             return;
                         }
 
-                        $toFlush = $this->toFlush;
                         $this->toFlush = [];
 
                         // Unregister before flushing to prevent re-entry.
-                        if ($this->selfRef !== null) {
-                            $this->em->getEventManager()->removeEventListener(['postPersist', 'postFlush'], $this->selfRef);
+                        if ($this->self !== null) {
+                            $this->em->getEventManager()->removeEventListener(['postPersist', 'postFlush'], $this->self);
                         }
 
                         $this->em->flush();
                     }
                 };
-                $listener = $listenerObj;
+                $listenerObj->setSelf($listenerObj);
                 $this->em->getEventManager()->addEventListener(['postPersist', 'postFlush'], $listenerObj);
             }
         });

--- a/src/CoreBundle/Telemetry/TelemetryEvent.php
+++ b/src/CoreBundle/Telemetry/TelemetryEvent.php
@@ -30,4 +30,13 @@ enum TelemetryEvent: string
     case RecurringInvoiceCreated = 'recurring_invoice_created';
     case QuoteCreated = 'quote_created';
     case PaymentReceived = 'payment_received';
+
+    // SaaS (hosted) upgrade-funnel events. Emitted only by SaasBundle, which is
+    // registered only when SOLIDINVOICE_PLATFORM=saas, so these never fire on
+    // self-hosted installations. See docs/superpowers/specs/2026-06-22-saas-conversion-telemetry-design.md
+    case SaasPricingPageViewed = 'saas_pricing_page_viewed';
+    case SaasPlanSelected = 'saas_plan_selected';
+    case SaasCheckoutStarted = 'saas_checkout_started';
+    case SaasCheckoutFailed = 'saas_checkout_failed';
+    case SaasSubscriptionActivated = 'saas_subscription_activated';
 }

--- a/src/SaasBundle/Action/ChoosePlanAction.php
+++ b/src/SaasBundle/Action/ChoosePlanAction.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\SaasBundle\Action;
 
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
@@ -25,6 +27,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Ulid;
+use function strtolower;
 
 final class ChoosePlanAction extends AbstractController
 {
@@ -42,6 +45,7 @@ final class ChoosePlanAction extends AbstractController
         private readonly SubscriptionProviderInterface $subscriptionProvider,
         private readonly CompanyRepository $companyRepository,
         private readonly CompanySelector $companySelector,
+        private readonly Telemetry $telemetry,
     ) {
     }
 
@@ -73,6 +77,11 @@ final class ChoosePlanAction extends AbstractController
 
             return $this->redirectToRoute('saas_subscription_plans');
         }
+
+        $this->telemetry->event(TelemetryEvent::SaasPlanSelected, [
+            'plan' => strtolower($plan->getName()),
+            'is_paid' => ! $plan->isFree(),
+        ]);
 
         // Free plan: no Lemon Squeezy round-trip; safe to commit locally now.
         if ($plan->isFree()) {

--- a/src/SaasBundle/Action/ChoosePlanAction.php
+++ b/src/SaasBundle/Action/ChoosePlanAction.php
@@ -29,6 +29,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Ulid;
 use function strtolower;
 
+/**
+ * @see \SolidInvoice\SaasBundle\Tests\Action\ChoosePlanActionTest
+ */
 final class ChoosePlanAction extends AbstractController
 {
     /**

--- a/src/SaasBundle/Action/SelectPlanAction.php
+++ b/src/SaasBundle/Action/SelectPlanAction.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\SaasBundle\Action;
 
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
@@ -30,6 +32,7 @@ final class SelectPlanAction extends AbstractController
         private readonly SubscriptionProviderInterface $subscriptionProvider,
         private readonly CompanyRepository $companyRepository,
         private readonly CompanySelector $companySelector,
+        private readonly Telemetry $telemetry,
     ) {
     }
 
@@ -52,6 +55,8 @@ final class SelectPlanAction extends AbstractController
         if (count($plans) === 1) {
             return $this->redirectToRoute('saas_subscription_checkout');
         }
+
+        $this->telemetry->event(TelemetryEvent::SaasPricingPageViewed);
 
         return $this->render('@SolidInvoiceSaas/subscription/pricing.html.twig', [
             'plans' => $plans,

--- a/src/SaasBundle/Action/SelectPlanAction.php
+++ b/src/SaasBundle/Action/SelectPlanAction.php
@@ -25,6 +25,9 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Ulid;
 
+/**
+ * @see \SolidInvoice\SaasBundle\Tests\Action\SelectPlanActionTest
+ */
 final class SelectPlanAction extends AbstractController
 {
     public function __construct(

--- a/src/SaasBundle/Controller/SubscribeController.php
+++ b/src/SaasBundle/Controller/SubscribeController.php
@@ -16,6 +16,8 @@ namespace SolidInvoice\SaasBundle\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
 use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
@@ -29,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use function strtolower;
 
 /**
  * @see \SolidInvoice\SaasBundle\Tests\Controller\SubscribeControllerTest
@@ -41,6 +44,7 @@ class SubscribeController extends AbstractController
         private readonly CompanySelectorInterface $companySelector,
         private readonly PlanRepositoryInterface $planRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly Telemetry $telemetry,
     ) {
     }
 
@@ -79,10 +83,16 @@ class SubscribeController extends AbstractController
             }
         }
 
+        // Capture the plan the user is checking out (the in-memory swapped
+        // target when a pending plan id was supplied) before the `finally`
+        // block refreshes the entity and discards the swap.
+        $planName = strtolower($subscription->getPlan()->getName());
+
         try {
             $checkoutUrl = $this->subscriptionManager
                 ->getCheckoutUrl($subscription, $options);
         } catch (HttpExceptionInterface | TransportExceptionInterface) {
+            $this->telemetry->event(TelemetryEvent::SaasCheckoutFailed, ['plan' => $planName]);
             $this->addFlash('error', 'Unable to create checkout session. Please try again later.');
 
             return $this->redirectToRoute('billing_index');
@@ -95,6 +105,8 @@ class SubscribeController extends AbstractController
                 $this->entityManager->refresh($subscription);
             }
         }
+
+        $this->telemetry->event(TelemetryEvent::SaasCheckoutStarted, ['plan' => $planName]);
 
         return $this->redirect($checkoutUrl);
     }

--- a/src/SaasBundle/EventSubscriber/SubscriptionPlanSyncListener.php
+++ b/src/SaasBundle/EventSubscriber/SubscriptionPlanSyncListener.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace SolidInvoice\SaasBundle\EventSubscriber;
 
 use Psr\Log\LoggerInterface;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
 use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\Subscription as LemonSqueezySubscription;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
@@ -23,6 +25,7 @@ use SolidWorx\Platform\SaasBundle\Event\SubscriptionUpdatedEvent;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use function strtolower;
 
 /**
  * Listens to Lemon Squeezy `subscription_created` / `subscription_updated`
@@ -50,6 +53,7 @@ final readonly class SubscriptionPlanSyncListener
         private SubscriptionRepositoryInterface $subscriptionRepository,
         private PlanRepositoryInterface $planRepository,
         private LoggerInterface $logger,
+        private Telemetry $telemetry,
     ) {
     }
 
@@ -103,11 +107,22 @@ final readonly class SubscriptionPlanSyncListener
             return;
         }
 
+        // Capture whether this is a first conversion (free → paid) before the
+        // plan is overwritten, so the telemetry below counts genuine
+        // activations and not paid → paid upgrades (e.g. solo → business).
+        $isFirstConversion = $subscription->getPlan()->isFree() && ! $targetPlan->isFree();
+
         // Skip SubscriptionManager::changePlan() here: it guards against
         // mutating ACTIVE externally-billed subscriptions, which is *exactly*
         // the state this listener fires for. Lemon Squeezy is the authority
         // for the switch — we just record it.
         $subscription->setPlan($targetPlan);
         $this->subscriptionRepository->save($subscription);
+
+        if ($isFirstConversion) {
+            $this->telemetry->event(TelemetryEvent::SaasSubscriptionActivated, [
+                'plan' => strtolower($targetPlan->getName()),
+            ]);
+        }
     }
 }

--- a/src/SaasBundle/Tests/Action/ChoosePlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/ChoosePlanActionTest.php
@@ -96,7 +96,7 @@ final class ChoosePlanActionTest extends TestCase
         // changePlan()/activate() (free-plan path) just persist via the mocked
         // repository.
         $subscriptionManager = new SubscriptionManager(
-            $this->createMock(SubscriptionRepositoryInterface::class),
+            $this->createStub(SubscriptionRepositoryInterface::class),
             $this->createStub(PlanRepositoryInterface::class),
             $this->createStub(PaymentIntegrationInterface::class),
         );
@@ -130,6 +130,7 @@ final class ChoosePlanActionTest extends TestCase
         $container->set('security.csrf.token_manager', $csrfTokenManager);
         $container->set('router', $router);
         $container->set('request_stack', $requestStack);
+
         $action->setContainer($container);
 
         return [$action, $bus];
@@ -137,7 +138,7 @@ final class ChoosePlanActionTest extends TestCase
 
     private function makeRequest(string $planId): Request
     {
-        $request = Request::create('/billing/subscription/plans/choose', 'POST', [
+        $request = Request::create('/billing/subscription/plans/choose', Request::METHOD_POST, [
             '_token' => 'token',
             'plan' => $planId,
         ]);

--- a/src/SaasBundle/Tests/Action/ChoosePlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/ChoosePlanActionTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Action;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\ConfigWriter;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
+use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(ChoosePlanAction::class)]
+final class ChoosePlanActionTest extends TestCase
+{
+    public function testEmitsPlanSelectedTelemetryForPaidPlan(): void
+    {
+        $bus = new CollectingMessageBus();
+
+        $plan = $this->makePlan('Solo', 'solo-monthly', 900);
+
+        [$action, $bus] = $this->buildAction($bus, $plan);
+
+        $action($this->makeRequest('solo-monthly'));
+
+        self::assertCount(1, $bus->messages);
+        self::assertSame('event', $bus->messages[0]->type);
+        self::assertSame('saas_plan_selected', $bus->messages[0]->payload['event']);
+        self::assertSame('solo', $bus->messages[0]->payload['properties']['plan']);
+        self::assertTrue($bus->messages[0]->payload['properties']['is_paid']);
+    }
+
+    public function testEmitsPlanSelectedTelemetryForFreePlan(): void
+    {
+        $bus = new CollectingMessageBus();
+
+        $plan = $this->makePlan('Free', '0', 0);
+
+        [$action, $bus] = $this->buildAction($bus, $plan);
+
+        $action($this->makeRequest('0'));
+
+        self::assertCount(1, $bus->messages);
+        self::assertSame('saas_plan_selected', $bus->messages[0]->payload['event']);
+        self::assertSame('free', $bus->messages[0]->payload['properties']['plan']);
+        self::assertFalse($bus->messages[0]->payload['properties']['is_paid']);
+    }
+
+    /**
+     * @return array{0: ChoosePlanAction, 1: CollectingMessageBus}
+     */
+    private function buildAction(CollectingMessageBus $bus, Plan $plan): array
+    {
+        $subscription = new Subscription();
+        $subscription->setPlan($this->makePlan('Existing', 'existing-monthly', 900));
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->willReturn($plan);
+
+        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->method('getSubscriptionFor')->willReturn($subscription);
+
+        // SubscriptionManager is final readonly; build a real one whose
+        // changePlan()/activate() (free-plan path) just persist via the mocked
+        // repository.
+        $subscriptionManager = new SubscriptionManager(
+            $this->createMock(SubscriptionRepositoryInterface::class),
+            $this->createStub(PlanRepositoryInterface::class),
+            $this->createStub(PaymentIntegrationInterface::class),
+        );
+
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository->method('find')->willReturn(new Company());
+
+        // CompanySelector is final; use a real instance with a company id set.
+        $companySelector = new CompanySelector($this->createStub(ManagerRegistry::class));
+        new ReflectionProperty(CompanySelector::class, 'companyId')->setValue($companySelector, new Ulid());
+
+        $action = new ChoosePlanAction(
+            $planRepository,
+            $subscriptionManager,
+            $subscriptionProvider,
+            $companyRepository,
+            $companySelector,
+            $this->makeTelemetry($bus),
+        );
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->method('isTokenValid')->willReturn(true);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/redirect');
+
+        $request = $this->makeRequest('');
+        $requestStack = new RequestStack([$request]);
+
+        $container = new Container();
+        $container->set('security.csrf.token_manager', $csrfTokenManager);
+        $container->set('router', $router);
+        $container->set('request_stack', $requestStack);
+        $action->setContainer($container);
+
+        return [$action, $bus];
+    }
+
+    private function makeRequest(string $planId): Request
+    {
+        $request = Request::create('/billing/subscription/plans/choose', 'POST', [
+            '_token' => 'token',
+            'plan' => $planId,
+        ]);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return $request;
+    }
+
+    private function makePlan(string $name, string $planId, int $price): Plan
+    {
+        return new Plan()
+            ->setName($name)
+            ->setPlanId($planId)
+            ->setPrice($price)
+            ->setActive(true);
+    }
+
+    private function makeTelemetry(CollectingMessageBus $bus): Telemetry
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('generateKeys')->willReturn(true);
+
+        return new Telemetry(
+            $bus,
+            new ConfigWriter($vault, '/tmp/solidinvoice-test-config'),
+            DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]),
+            'build-123',
+            true,
+            'manual',
+            false,
+            'en',
+            null,
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
@@ -68,6 +68,7 @@ final class SelectPlanActionTest extends TestCase
 
         $container = new Container();
         $container->set('twig', $twig);
+
         $action->setContainer($container);
 
         $action();

--- a/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Action;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\ConfigWriter;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
+use SolidInvoice\SaasBundle\Action\SelectPlanAction;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Component\DependencyInjection\Container;
+use Twig\Environment;
+
+#[CoversClass(SelectPlanAction::class)]
+final class SelectPlanActionTest extends TestCase
+{
+    public function testEmitsPricingPageViewedTelemetryWhenPricingPageRenders(): void
+    {
+        $bus = new CollectingMessageBus();
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('findAllOrdered')->willReturn([
+            $this->makePlan('Free'),
+            $this->makePlan('Solo'),
+        ]);
+
+        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->method('getSubscriptionFor')->willReturn(null);
+
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository->method('find')->willReturn(new Company());
+
+        // CompanySelector is final; a real instance with no selected company
+        // returns null from getCompany(), which short-circuits subscription
+        // lookup and lets the action fall through to the pricing render.
+        $companySelector = new CompanySelector($this->createStub(ManagerRegistry::class));
+
+        $action = new SelectPlanAction(
+            $planRepository,
+            $subscriptionProvider,
+            $companyRepository,
+            $companySelector,
+            $this->makeTelemetry($bus),
+        );
+
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturn('<html></html>');
+
+        $container = new Container();
+        $container->set('twig', $twig);
+        $action->setContainer($container);
+
+        $action();
+
+        self::assertCount(1, $bus->messages);
+        self::assertSame('event', $bus->messages[0]->type);
+        self::assertSame('saas_pricing_page_viewed', $bus->messages[0]->payload['event']);
+    }
+
+    private function makePlan(string $name): Plan
+    {
+        return new Plan()->setName($name);
+    }
+
+    private function makeTelemetry(CollectingMessageBus $bus): Telemetry
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('generateKeys')->willReturn(true);
+
+        return new Telemetry(
+            $bus,
+            new ConfigWriter($vault, '/tmp/solidinvoice-test-config'),
+            DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]),
+            'build-123',
+            true,
+            'manual',
+            false,
+            'en',
+            null,
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
+++ b/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
@@ -13,14 +13,18 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Tests\Controller;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
+use SolidInvoice\CoreBundle\ConfigWriter;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
 use SolidInvoice\SaasBundle\Controller\SubscribeController;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
@@ -30,6 +34,7 @@ use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
 use Stringable;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -48,16 +53,27 @@ use Throwable;
 #[CoversClass(SubscribeController::class)]
 final class SubscribeControllerTest extends TestCase
 {
+    private CollectingMessageBus $bus;
+
+    protected function setUp(): void
+    {
+        $this->bus = new CollectingMessageBus();
+    }
+
     public function testTransportExceptionRedirectsToOverviewWithErrorFlash(): void
     {
         $exception = new TransportException('HTTP/2 404 returned for "https://api.lemonsqueezy.com/v1/checkouts"');
 
-        $response = $this->invokeControllerWithCheckoutException($exception);
+        $response = $this->invokeController($exception);
 
         self::assertInstanceOf(RedirectResponse::class, $response[0]);
         self::assertSame('/billing/', $response[0]->getTargetUrl());
         self::assertArrayHasKey('error', $response[1]);
         self::assertNotEmpty($response[1]['error']);
+
+        self::assertCount(1, $this->bus->messages);
+        self::assertSame('saas_checkout_failed', $this->bus->messages[0]->payload['event']);
+        self::assertSame('pro', $this->bus->messages[0]->payload['properties']['plan']);
     }
 
     public function testHttpClientExceptionRedirectsToOverviewWithErrorFlash(): void
@@ -69,21 +85,42 @@ final class SubscribeControllerTest extends TestCase
             }
         };
 
-        $response = $this->invokeControllerWithCheckoutException($exception);
+        $response = $this->invokeController($exception);
 
         self::assertInstanceOf(RedirectResponse::class, $response[0]);
         self::assertSame('/billing/', $response[0]->getTargetUrl());
         self::assertArrayHasKey('error', $response[1]);
         self::assertNotEmpty($response[1]['error']);
+
+        self::assertCount(1, $this->bus->messages);
+        self::assertSame('saas_checkout_failed', $this->bus->messages[0]->payload['event']);
+    }
+
+    public function testSuccessfulCheckoutEmitsCheckoutStartedTelemetryAndRedirects(): void
+    {
+        $response = $this->invokeController(null);
+
+        self::assertInstanceOf(RedirectResponse::class, $response[0]);
+        self::assertSame('https://checkout.lemonsqueezy.com/buy/abc', $response[0]->getTargetUrl());
+
+        self::assertCount(1, $this->bus->messages);
+        self::assertSame('event', $this->bus->messages[0]->type);
+        self::assertSame('saas_checkout_started', $this->bus->messages[0]->payload['event']);
+        self::assertSame('pro', $this->bus->messages[0]->payload['properties']['plan']);
     }
 
     /**
      * @return array{0: RedirectResponse, 1: array<string, list<string|Stringable>>}
      */
-    private function invokeControllerWithCheckoutException(Throwable $exception): array
+    private function invokeController(?Throwable $exception): array
     {
         $paymentIntegration = $this->createMock(PaymentIntegrationInterface::class);
-        $paymentIntegration->method('checkout')->willThrowException($exception);
+
+        if ($exception instanceof Throwable) {
+            $paymentIntegration->method('checkout')->willThrowException($exception);
+        } else {
+            $paymentIntegration->method('checkout')->willReturn('https://checkout.lemonsqueezy.com/buy/abc');
+        }
 
         $plan = new Plan();
         $plan->setName('Pro');
@@ -114,6 +151,7 @@ final class SubscribeControllerTest extends TestCase
             $companySelector,
             $this->createStub(PlanRepositoryInterface::class),
             $this->createStub(EntityManagerInterface::class),
+            $this->makeTelemetry(),
         );
 
         $session = new Session(new MockArraySessionStorage());
@@ -145,5 +183,23 @@ final class SubscribeControllerTest extends TestCase
         $response = $controller(new Request());
 
         return [$response, $session->getFlashBag()->all()];
+    }
+
+    private function makeTelemetry(): Telemetry
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('generateKeys')->willReturn(true);
+
+        return new Telemetry(
+            $this->bus,
+            new ConfigWriter($vault, '/tmp/solidinvoice-test-config'),
+            DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]),
+            'build-123',
+            true,
+            'manual',
+            false,
+            'en',
+            null,
+        );
     }
 }

--- a/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
@@ -161,7 +161,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $subscriptionRepository->method('findOneBy')->willReturn($subscription);
 
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
-        $planRepository->method('find')->with('12345')->willReturn($newPlan);
+        $planRepository->expects(self::once())->method('find')->with('12345')->willReturn($newPlan);
 
         $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
@@ -183,7 +183,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $subscriptionRepository->method('findOneBy')->willReturn($subscription);
 
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
-        $planRepository->method('find')->with('67890')->willReturn($newPlan);
+        $planRepository->expects(self::once())->method('find')->with('67890')->willReturn($newPlan);
 
         $listener = $this->makeListener($subscriptionRepository, $planRepository);
 

--- a/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/SubscriptionPlanSyncListenerTest.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Tests\EventSubscriber;
 
+use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use ReflectionProperty;
+use SolidInvoice\CoreBundle\ConfigWriter;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
 use SolidInvoice\SaasBundle\EventSubscriber\SubscriptionPlanSyncListener;
 use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\Subscription as LemonSqueezySubscription;
 use SolidWorx\Platform\SaasBundle\Dto\LemonSqueezy\SubscriptionAttributes;
@@ -26,11 +30,19 @@ use SolidWorx\Platform\SaasBundle\Event\SubscriptionCreatedEvent;
 use SolidWorx\Platform\SaasBundle\Event\SubscriptionUpdatedEvent;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
 use Symfony\Component\Uid\Ulid;
 
 #[CoversClass(SubscriptionPlanSyncListener::class)]
 final class SubscriptionPlanSyncListenerTest extends TestCase
 {
+    private CollectingMessageBus $bus;
+
+    protected function setUp(): void
+    {
+        $this->bus = new CollectingMessageBus();
+    }
+
     public function testCommitsPlanChangeWhenVariantIdDiffersOnCreation(): void
     {
         $currentPlan = $this->makePlan('Free', '0');
@@ -46,11 +58,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
         $planRepository->expects(self::once())->method('find')->with('12345')->willReturn($newPlan);
 
-        $listener = new SubscriptionPlanSyncListener(
-            $subscriptionRepository,
-            $planRepository,
-            new NullLogger(),
-        );
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
         $listener->onSubscriptionCreated($this->makeCreatedEvent($subscription->getId(), 12345));
 
@@ -70,11 +78,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
         $planRepository->expects(self::once())->method('find')->with('67890')->willReturn($newPlan);
 
-        $listener = new SubscriptionPlanSyncListener(
-            $subscriptionRepository,
-            $planRepository,
-            new NullLogger(),
-        );
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
         $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 67890));
 
@@ -93,11 +97,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
         $planRepository->expects(self::never())->method('find');
 
-        $listener = new SubscriptionPlanSyncListener(
-            $subscriptionRepository,
-            $planRepository,
-            new NullLogger(),
-        );
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
         $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 12345));
 
@@ -112,11 +112,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
 
         $planRepository = $this->createStub(PlanRepositoryInterface::class);
 
-        $listener = new SubscriptionPlanSyncListener(
-            $subscriptionRepository,
-            $planRepository,
-            new NullLogger(),
-        );
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
         // No DTO attached — listener should short-circuit.
         $listener->onSubscriptionUpdated(new SubscriptionUpdatedEvent(new Ulid(), 'lemon-1234', null));
@@ -134,11 +130,7 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
         $planRepository->expects(self::once())->method('find')->with('99999')->willReturn(null);
 
-        $listener = new SubscriptionPlanSyncListener(
-            $subscriptionRepository,
-            $planRepository,
-            new NullLogger(),
-        );
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
 
         $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 99999));
 
@@ -154,13 +146,80 @@ final class SubscriptionPlanSyncListenerTest extends TestCase
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
         $planRepository->expects(self::never())->method('find');
 
-        $listener = new SubscriptionPlanSyncListener(
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent(new Ulid(), 12345));
+    }
+
+    public function testEmitsActivationTelemetryOnFreeToPaidConversion(): void
+    {
+        $currentPlan = $this->makePlan('Free', '0');
+        $newPlan = $this->makePlan('Solo', '12345');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->with('12345')->willReturn($newPlan);
+
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
+
+        $listener->onSubscriptionCreated($this->makeCreatedEvent($subscription->getId(), 12345));
+
+        self::assertCount(1, $this->bus->messages);
+        self::assertSame('event', $this->bus->messages[0]->type);
+        self::assertSame('saas_subscription_activated', $this->bus->messages[0]->payload['event']);
+        self::assertSame('solo', $this->bus->messages[0]->payload['properties']['plan']);
+    }
+
+    public function testDoesNotEmitActivationTelemetryOnPaidToPaidUpgrade(): void
+    {
+        $currentPlan = $this->makePlan('Solo', '12345');
+        $newPlan = $this->makePlan('Business', '67890');
+        $subscription = $this->makeSubscription($currentPlan);
+
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('findOneBy')->willReturn($subscription);
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->with('67890')->willReturn($newPlan);
+
+        $listener = $this->makeListener($subscriptionRepository, $planRepository);
+
+        $listener->onSubscriptionUpdated($this->makeUpdatedEvent($subscription->getId(), 67890));
+
+        self::assertSame([], $this->bus->messages);
+    }
+
+    private function makeListener(
+        SubscriptionRepositoryInterface $subscriptionRepository,
+        PlanRepositoryInterface $planRepository,
+    ): SubscriptionPlanSyncListener {
+        return new SubscriptionPlanSyncListener(
             $subscriptionRepository,
             $planRepository,
             new NullLogger(),
+            $this->makeTelemetry(),
         );
+    }
 
-        $listener->onSubscriptionUpdated($this->makeUpdatedEvent(new Ulid(), 12345));
+    private function makeTelemetry(): Telemetry
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('generateKeys')->willReturn(true);
+
+        return new Telemetry(
+            $this->bus,
+            new ConfigWriter($vault, '/tmp/solidinvoice-test-config'),
+            DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]),
+            'build-123',
+            true,
+            'manual',
+            false,
+            'en',
+            null,
+        );
     }
 
     private function makePlan(string $name, string $planId): Plan


### PR DESCRIPTION
## What

Adds telemetry for the hosted (SaaS) upgrade funnel so we can see where prospective subscribers fall off — in particular, how many users reach the Lemon Squeezy checkout/payment page but never complete a subscription.

Five new events flow through the **existing** `CoreBundle/Telemetry` pipeline (Messenger → SolidWorx Insights). No new infrastructure, aggregate counts only, **no PII**. The firing code lives in `SaasBundle` (registered only when `SOLIDINVOICE_PLATFORM=saas`), so these events exist **only on the hosted version**.

| Event | Fires when |
|---|---|
| `saas_pricing_page_viewed` | The pricing/plans page renders (`SelectPlanAction`) |
| `saas_plan_selected` (`plan`, `is_paid`) | A plan is chosen (`ChoosePlanAction`) |
| `saas_checkout_started` (`plan`) | The Lemon Squeezy checkout URL is generated and the user is redirected (`SubscribeController`) |
| `saas_checkout_failed` (`plan`) | The Lemon Squeezy call errors and the payment page is never reached |
| `saas_subscription_activated` (`plan`) | A webhook confirms a **free→paid** transition (`SubscriptionPlanSyncListener`) — true conversions only |

The gap between `saas_checkout_started` and `saas_subscription_activated` is exactly the "thinking about upgrading but never completing" drop-off this is meant to quantify.

## Why

We weren't seeing subscriptions activate on the hosted version, with no visibility into whether nobody attempts to upgrade or whether people attempt but drop off before paying. These events make the funnel measurable end to end.

## Notes

- The `plan` property carries the lowercased plan **name** (`solo`/`business`/`agency`), not the plan id — in production `Plan::getPlanId()` is the numeric Lemon Squeezy variant id (only dev fixtures use readable ids like `solo-monthly`).
- `saas_subscription_activated` only fires on free→paid commits, so paid→paid upgrades (e.g. solo→business) aren't counted as activations.
- Churn/lifecycle events (cancellation, trial expiry, downgrades, etc.) were intentionally left out of this PR and can be added later following the same pattern.

## Testing

- New/updated unit tests cover all five events (free→paid activation fires, paid→paid does not; checkout success vs failure). Full CoreBundle telemetry + SaaS action/controller/subscriber suites pass (59 tests).
- ECS passes.
- _PHPStan was not runnable in the dev sandbox (it fatals while loading the project autoload bootstrap, including on unchanged files) — relying on CI for static analysis._