### PR TITLE
Require X-API-TOKEN header for API authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+### Changes
+
+* API authentication now uses the `X-API-TOKEN` header exclusively; the `?token=` query-string fallback has been removed
+
 3.0.0 / 2026-06-17
 -------------------
 

--- a/docs/docs/api/rest-api.md
+++ b/docs/docs/api/rest-api.md
@@ -83,8 +83,6 @@ curl -H "X-API-TOKEN: <your-token>" \
      https://your-instance.example/api/invoices
 ```
 
-A query-string fallback (`?token=<your-token>`) is also accepted for environments where setting headers is awkward, but the header is preferred — query strings end up in webserver access logs, browser history, and HTTP referrers.
-
 The API is **stateless** — there is no session, no CSRF token, and no login round-trip. Send the header on every request. Tokens are scoped to one user *and* one company; if your account belongs to multiple companies, generate a separate token per company by switching companies in the UI before creating the token.
 
 If a request lacks a valid token, the server responds with `401 Unauthorized` and a JSON body:

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -51,12 +51,12 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
 
     public function supports(Request $request): bool
     {
-        return $request->headers->has('X-API-TOKEN');
+        return null !== $this->extractToken($request);
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $apiToken = $request->headers->get('X-API-TOKEN');
+        $apiToken = $this->extractToken($request);
 
         $history = new ApiTokenHistory();
 
@@ -98,6 +98,13 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         return null;
     }
 
+    private function extractToken(Request $request): ?string
+    {
+        $apiToken = trim((string) $request->headers->get('X-API-TOKEN'));
+
+        return $apiToken === '' ? null : $apiToken;
+    }
+
     private function extractReason(AccessDecision $decision): string
     {
         $reasons = [];
@@ -124,11 +131,11 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
 
     public function authenticate(Request $request): Passport
     {
-        $apiToken = $request->headers->get('X-API-TOKEN');
+        $apiToken = $this->extractToken($request);
 
         if (null === $apiToken) {
-            // The token header was empty, authentication fails with HTTP Status
-            // Code 401 "Unauthorized"
+            // The token header was missing or empty, authentication fails with
+            // HTTP Status Code 401 "Unauthorized"
             throw new CustomUserMessageAuthenticationException('No API token provided');
         }
 

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -51,12 +51,12 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
 
     public function supports(Request $request): bool
     {
-        return $request->headers->has('X-API-TOKEN') || $request->query->has('token');
+        return $request->headers->has('X-API-TOKEN');
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $apiToken = $request->headers->get('X-API-TOKEN', $request->query->get('token'));
+        $apiToken = $request->headers->get('X-API-TOKEN');
 
         $history = new ApiTokenHistory();
 
@@ -124,7 +124,7 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
 
     public function authenticate(Request $request): Passport
     {
-        $apiToken = $request->headers->get('X-API-TOKEN', $request->query->get('token'));
+        $apiToken = $request->headers->get('X-API-TOKEN');
 
         if (null === $apiToken) {
             // The token header was empty, authentication fails with HTTP Status

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -37,6 +37,9 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @see \SolidInvoice\ApiBundle\Tests\Security\ApiTokenAuthenticatorTest
+ */
 class ApiTokenAuthenticator extends AbstractAuthenticator
 {
     public function __construct(

--- a/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
+++ b/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\Security;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SolidInvoice\ApiBundle\Security\ApiTokenAuthenticator;
+use SolidInvoice\ApiBundle\Security\Provider\ApiTokenUserProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+final class ApiTokenAuthenticatorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testSupportsWithoutHeader(): void
+    {
+        self::assertFalse($this->authenticator()->supports(new Request()));
+    }
+
+    #[DataProvider('emptyTokenProvider')]
+    public function testSupportsRejectsEmptyToken(string $token): void
+    {
+        self::assertFalse($this->authenticator()->supports($this->requestWithToken($token)));
+    }
+
+    public function testSupportsAcceptsNonEmptyToken(): void
+    {
+        self::assertTrue($this->authenticator()->supports($this->requestWithToken('a-valid-token')));
+    }
+
+    #[DataProvider('emptyTokenProvider')]
+    public function testAuthenticateRejectsEmptyToken(string $token): void
+    {
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('No API token provided');
+
+        $this->authenticator()->authenticate($this->requestWithToken($token));
+    }
+
+    public function testAuthenticateTrimsTokenBeforeLookup(): void
+    {
+        $userProvider = M::mock(ApiTokenUserProvider::class);
+        $userProvider->expects('getUsernameForToken')
+            ->with('a-valid-token')
+            ->andReturn('user@example.com');
+
+        $passport = $this->authenticator($userProvider)->authenticate($this->requestWithToken('  a-valid-token  '));
+
+        self::assertInstanceOf(SelfValidatingPassport::class, $passport);
+        self::assertSame('user@example.com', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function emptyTokenProvider(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace' => ['   '];
+    }
+
+    private function requestWithToken(string $token): Request
+    {
+        $request = new Request();
+        $request->headers->set('X-API-TOKEN', $token);
+
+        return $request;
+    }
+
+    /**
+     * The constructor pulls in several final, infrastructure-bound services that
+     * are not exercised by token extraction, so the instance is built without the
+     * constructor and only the user provider is injected when required.
+     */
+    private function authenticator(?ApiTokenUserProvider $userProvider = null): ApiTokenAuthenticator
+    {
+        $reflection = new ReflectionClass(ApiTokenAuthenticator::class);
+        $authenticator = $reflection->newInstanceWithoutConstructor();
+
+        if ($userProvider instanceof ApiTokenUserProvider) {
+            $reflection->getProperty('userProvider')->setValue($authenticator, $userProvider);
+        }
+
+        return $authenticator;
+    }
+}


### PR DESCRIPTION
## Summary

Standardizes REST API authentication on the `X-API-TOKEN` header. The previous `?token=` query-string fallback has been removed, so callers must now supply the token via the header exclusively.

## Changes

- `ApiTokenAuthenticator`: removed the query-string token fallback from `supports()`, `authenticate()`, and `onAuthenticationSuccess()` — the `X-API-TOKEN` header is now the only accepted source.
- Docs (`docs/docs/api/rest-api.md`): removed the paragraph documenting the `?token=` fallback.
- CHANGELOG: added an entry under *Unreleased*.

The OpenAPI/Swagger security scheme was already header-only, so no changes were needed there.

## Verification

- PHPStan: passed (0 errors)
- ECS: clean
- `SubscriptionGateTest` (API functional): 3/3 passed