### PR TITLE
Fix add-credit modal: form submit button was outside the form element

### DIFF
--- a/assets/icons/tabler/device-floppy.svg
+++ b/assets/icons/tabler/device-floppy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 4h10l4 4v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2"/><circle cx="12" cy="14" r="2"/><path d="M14 4v4H8V4"/></g></svg>

--- a/assets/icons/tabler/plus.svg
+++ b/assets/icons/tabler/plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m-7-7h14"/></svg>

--- a/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
+++ b/src/ClientBundle/Resources/views/Components/ClientCredit.html.twig
@@ -7,15 +7,22 @@
         {{ 'client.view.actions.add_credit'|trans }}
     </button>
 
+    {{ form_start(form, {
+        attr: {
+            'data-action': 'live#action:prevent',
+            'data-live-action-param': 'save'
+        }
+    }) }}
     <twig:Ui:Modal id="add-client-credit" title="{{ 'client.modal.add_credit'|trans }}">
-        {{ form(form) }}
+        {{ form_row(form) }}
 
         <twig:block name="footer">
             <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
-            <button type="button" class="btn btn-primary" data-action="live#action:prevent" data-live-action-param="save">
+            <button type="submit" class="btn btn-primary">
                 {{ ux_icon('tabler:device-floppy', {width: 16, height: 16}) }}
                 {{ 'Save'|trans }}
             </button>
         </twig:block>
     </twig:Ui:Modal>
+    {{ form_end(form) }}
 </div>

--- a/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
+++ b/src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Twig\Components;
+
+use Brick\Math\BigInteger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Twig\Components\ClientCredit;
+use SolidInvoice\CoreBundle\Test\LiveComponentTest;
+use Symfony\UX\LiveComponent\Test\TestLiveComponent;
+use Zenstruck\Foundry\Test\Factories;
+
+#[CoversClass(ClientCredit::class)]
+final class ClientCreditTest extends LiveComponentTest
+{
+    use Factories;
+
+    private function createCreditComponent(Client $client): TestLiveComponent
+    {
+        return $this->createLiveComponent(
+            name: ClientCredit::class,
+            data: ['client' => $client],
+            client: $this->client,
+        )->actingAs($this->getUser());
+    }
+
+    public function testSaveWithValidAmountAddsCredit(): void
+    {
+        $clientProxy = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ]);
+        $client = $clientProxy->_real();
+
+        self::assertEquals(BigInteger::zero(), $client->getCredit()->getValue());
+
+        $component = $this->createCreditComponent($client);
+
+        // Simulate submitting the form with amount = 10 (dollars)
+        // 'credit' is the form block prefix / LiveProp fieldName for formValues
+        $component->set('credit', ['amount' => '10']);
+        $component->call('save');
+
+        // Re-fetch via a fresh entity manager to avoid detached-entity issues
+        $em = self::getContainer()->get('doctrine')->getManager();
+        $refreshed = $em->find(Client::class, $client->getId());
+
+        // 10 dollars × 100 = 1000 cents
+        self::assertEquals(BigInteger::of(1000), $refreshed->getCredit()->getValue());
+    }
+
+    public function testSaveWithEmptyAmountDoesNotAddCredit(): void
+    {
+        $clientProxy = ClientFactory::createOne([
+            'currencyCode' => 'USD',
+            'company' => $this->company,
+        ]);
+        $client = $clientProxy->_real();
+
+        self::assertEquals(BigInteger::zero(), $client->getCredit()->getValue());
+
+        $component = $this->createCreditComponent($client);
+
+        // Call save with no form data — form should be invalid (amount is required)
+        $component->set('credit', []);
+        $component->call('save');
+
+        // Re-fetch via a fresh entity manager to avoid detached-entity issues
+        $em = self::getContainer()->get('doctrine')->getManager();
+        $refreshed = $em->find(Client::class, $client->getId());
+
+        // Credit must remain zero
+        self::assertEquals(BigInteger::zero(), $refreshed->getCredit()->getValue());
+    }
+}

--- a/src/ClientBundle/Twig/Components/ClientCredit.php
+++ b/src/ClientBundle/Twig/Components/ClientCredit.php
@@ -55,6 +55,10 @@ final class ClientCredit extends AbstractController
     {
         $this->submitForm();
 
+        if (! $this->getForm()->isValid()) {
+            return;
+        }
+
         $data = $this->getForm()->getData();
 
         $this->repository->addCredit($this->client, $data['amount'] ?? 0);

--- a/src/ClientBundle/Twig/Components/ClientCredit.php
+++ b/src/ClientBundle/Twig/Components/ClientCredit.php
@@ -25,6 +25,9 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
+/**
+ * @see \SolidInvoice\ClientBundle\Tests\Twig\Components\ClientCreditTest
+ */
 #[AsLiveComponent]
 final class ClientCredit extends AbstractController
 {


### PR DESCRIPTION
## Summary

Fixes #2506 — clicking "Save" in the Add Credit modal closed the modal but never actually updated the client's credit balance.

### Root cause

The template used `{{ form(form) }}` which renders a self-contained `<form>…</form>` inside the modal body. The Save button lived in the modal **footer**, which sits outside that `<form>` element, so clicking it dispatched a bare live action request with no field values. `submitForm()` received empty data, the `NotBlank` constraint was satisfied by the default empty string, and `addCredit()` was called with `0`.

### Fix

- **Template** (`ClientCredit.html.twig`): replace `{{ form(form) }}` with `form_start` / `form_end` wrapping the entire modal (the same pattern used by `AddressCollection.html.twig` and `ContactCollection.html.twig`). Render only the field with `form_row()`. Change the Save button to `type="submit"` so the browser includes the field value in the POST body.
- **Component** (`ClientCredit.php`): add the missing `isValid()` guard so an empty/invalid submission returns early without saving.
- **Icons**: add `tabler/plus.svg` and `tabler/device-floppy.svg` locally so the live component integration tests don't need to reach `api.iconify.design`.
- **Tests**: add `ClientCreditTest` with two cases — valid amount increases credit by the expected cent value, empty amount leaves credit unchanged.

## Test plan

- [ ] `bin/phpunit src/ClientBundle/Tests/Twig/Components/ClientCreditTest.php` — both tests pass
- [ ] `bin/ecs check` — no style errors
- [ ] PHPStan analysis — no errors
- [ ] Manual: open a client, click "Add Credit", enter an amount, click Save — credit balance updates correctly
- [ ] Manual: open a client, click "Add Credit", leave amount blank, click Save — modal stays open with validation error, credit unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvyATSiGRSFh1pr47xvNPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvyATSiGRSFh1pr47xvNPZ)_