### PR TITLE
refactor: replace serialize/unserialize with JSON for DataGrid context hydration

### DIFF
--- a/src/DataGridBundle/Twig/Components/DataGrid.php
+++ b/src/DataGridBundle/Twig/Components/DataGrid.php
@@ -49,7 +49,6 @@ use Symfony\UX\TwigComponent\Attribute\PostMount;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
 use function explode;
-use function unserialize;
 
 /**
  * @template T of object
@@ -465,7 +464,13 @@ class DataGrid extends AbstractController
      */
     public function dehydrateContext(array $context): string
     {
-        return serialize($context);
+        array_walk_recursive($context, static function (mixed &$value): void {
+            if ($value instanceof Ulid) {
+                $value = (string) $value;
+            }
+        });
+
+        return json_encode($context, JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -473,6 +478,6 @@ class DataGrid extends AbstractController
      */
     public function hydrateContext(string $context): array
     {
-        return unserialize($context, ['allowed_classes' => [Ulid::class]]);
+        return json_decode($context, true, 512, JSON_THROW_ON_ERROR) ?? [];
     }
 }


### PR DESCRIPTION
## Summary

- Replace `serialize`/`unserialize` with `json_encode`/`json_decode` in `DataGrid::dehydrateContext()` / `hydrateContext()`
- Convert `Ulid` objects to their string representation before JSON encoding; Doctrine's `AbstractUidType::convertToDatabaseValue()` accepts strings and calls `Ulid::fromString()` internally, so grid query filtering (e.g. `client_id`, `invoice_id` context values) is unaffected
- Remove now-unused `use function unserialize` import

## Test plan

- [ ] Verify client invoice/quote/payment grids still filter correctly by client (uses `context="{{ {'client_id': client.id} }}"`)
- [ ] Verify payment grid still filters by invoice when opened from an invoice page
- [ ] Run DataGrid test suite: `bin/phpunit src/DataGridBundle/Tests/`