### PR TITLE
Scope API token history grid to the current user

### DIFF
--- a/src/UserBundle/DataGrid/ApiTokenHistoryGrid.php
+++ b/src/UserBundle/DataGrid/ApiTokenHistoryGrid.php
@@ -25,7 +25,9 @@ use SolidInvoice\DataGridBundle\GridBuilder\Filter\DateRangeFilter;
 use SolidInvoice\DataGridBundle\GridBuilder\Query;
 use SolidInvoice\DataGridBundle\Source\ORMSource;
 use SolidInvoice\UserBundle\Entity\ApiTokenHistory;
+use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Translation\TranslatableMessage;
 
 /**
@@ -34,6 +36,11 @@ use Symfony\Component\Translation\TranslatableMessage;
 #[AsDataGrid(name: 'api_token_history_grid', title: 'Request History')]
 final class ApiTokenHistoryGrid extends Grid
 {
+    public function __construct(
+        private readonly Security $security
+    ) {
+    }
+
     public function entityFQCN(): string
     {
         return ApiTokenHistory::class;
@@ -94,14 +101,26 @@ final class ApiTokenHistoryGrid extends Grid
     #[Override]
     public function query(EntityManagerInterface $entityManager, Query $query): Query
     {
+        $user = $this->security->getUser();
+
+        assert($user instanceof User);
+
+        $queryBuilder = $query->getQueryBuilder();
+
+        // Only ever expose history for tokens that belong to the current user
+        $queryBuilder
+            ->join(ORMSource::ALIAS . '.token', 'apiToken')
+            ->andWhere('apiToken.user = :user')
+            ->setParameter('user', $user->getId(), UlidType::NAME);
+
         // Filter by token ID if provided in context
         if (isset($this->context['token_id'])) {
-            $query->getQueryBuilder()
+            $queryBuilder
                 ->andWhere('IDENTITY(' . ORMSource::ALIAS . '.token) = :token')
                 ->setParameter('token', $this->context['token_id'], UlidType::NAME);
         }
 
-        $query->getQueryBuilder()
+        $queryBuilder
             ->orderBy(ORMSource::ALIAS . '.created', 'DESC')
             ->setMaxResults(100);
 

--- a/src/UserBundle/Tests/DataGrid/ApiTokenHistoryGridTest.php
+++ b/src/UserBundle/Tests/DataGrid/ApiTokenHistoryGridTest.php
@@ -20,21 +20,23 @@ use SolidInvoice\DataGridBundle\GridBuilder\Query;
 use SolidInvoice\DataGridBundle\Source\ORMSource;
 use SolidInvoice\UserBundle\DataGrid\ApiTokenHistoryGrid;
 use SolidInvoice\UserBundle\Entity\ApiTokenHistory;
+use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Uid\Ulid;
 
 final class ApiTokenHistoryGridTest extends TestCase
 {
     public function testEntityFQCNReturnsApiTokenHistoryClass(): void
     {
-        $grid = new ApiTokenHistoryGrid();
+        $grid = new ApiTokenHistoryGrid($this->createStub(Security::class));
 
         self::assertSame(ApiTokenHistory::class, $grid->entityFQCN());
     }
 
-    public function testQueryAddsTokenFilterWhenTokenIdProvided(): void
+    public function testQueryAlwaysScopesToCurrentUser(): void
     {
-        $tokenId = Ulid::generate();
+        $userId = new Ulid();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $entityManager = $this->createStub(EntityManagerInterface::class);
@@ -42,14 +44,20 @@ final class ApiTokenHistoryGridTest extends TestCase
 
         $queryBuilder
             ->expects(self::once())
+            ->method('join')
+            ->with(ORMSource::ALIAS . '.token', 'apiToken')
+            ->willReturnSelf();
+
+        $queryBuilder
+            ->expects(self::once())
             ->method('andWhere')
-            ->with('IDENTITY(' . ORMSource::ALIAS . '.token) = :token')
+            ->with('apiToken.user = :user')
             ->willReturnSelf();
 
         $queryBuilder
             ->expects(self::once())
             ->method('setParameter')
-            ->with('token', $tokenId, UlidType::NAME)
+            ->with('user', $userId, UlidType::NAME)
             ->willReturnSelf();
 
         $queryBuilder
@@ -64,7 +72,72 @@ final class ApiTokenHistoryGridTest extends TestCase
             ->with(100)
             ->willReturnSelf();
 
-        $grid = new ApiTokenHistoryGrid();
+        $grid = new ApiTokenHistoryGrid($this->mockSecurity($userId));
+
+        $result = $grid->query($entityManager, $query);
+
+        self::assertSame($query, $result);
+    }
+
+    public function testQueryAddsTokenFilterWhenTokenIdProvided(): void
+    {
+        $userId = new Ulid();
+        $tokenId = new Ulid();
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $query = new Query($queryBuilder, ORMSource::ALIAS);
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('join')
+            ->with(ORMSource::ALIAS . '.token', 'apiToken')
+            ->willReturnSelf();
+
+        $queryBuilder
+            ->expects(self::exactly(2))
+            ->method('andWhere')
+            ->willReturnCallback(static function (string $where) use ($queryBuilder): QueryBuilder {
+                static $calls = [];
+                $calls[] = $where;
+
+                self::assertContains($where, [
+                    'apiToken.user = :user',
+                    'IDENTITY(' . ORMSource::ALIAS . '.token) = :token',
+                ]);
+
+                return $queryBuilder;
+            });
+
+        $queryBuilder
+            ->expects(self::exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(static function (string $name, $value, $type) use ($queryBuilder, $userId, $tokenId): QueryBuilder {
+                if ('user' === $name) {
+                    self::assertSame($userId, $value);
+                    self::assertSame(UlidType::NAME, $type);
+                } else {
+                    self::assertSame('token', $name);
+                    self::assertSame($tokenId, $value);
+                    self::assertSame(UlidType::NAME, $type);
+                }
+
+                return $queryBuilder;
+            });
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('orderBy')
+            ->with(ORMSource::ALIAS . '.created', 'DESC')
+            ->willReturnSelf();
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('setMaxResults')
+            ->with(100)
+            ->willReturnSelf();
+
+        $grid = new ApiTokenHistoryGrid($this->mockSecurity($userId));
         $grid->initialize(['token_id' => $tokenId]);
 
         $result = $grid->query($entityManager, $query);
@@ -72,36 +145,14 @@ final class ApiTokenHistoryGridTest extends TestCase
         self::assertSame($query, $result);
     }
 
-    public function testQueryDoesNotAddTokenFilterWhenTokenIdNotProvided(): void
+    private function mockSecurity(Ulid $userId): Security
     {
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $entityManager = $this->createStub(EntityManagerInterface::class);
-        $query = new Query($queryBuilder, ORMSource::ALIAS);
+        $user = $this->createStub(User::class);
+        $user->method('getId')->willReturn($userId);
 
-        $queryBuilder
-            ->expects(self::never())
-            ->method('andWhere');
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($user);
 
-        $queryBuilder
-            ->expects(self::never())
-            ->method('setParameter');
-
-        $queryBuilder
-            ->expects(self::once())
-            ->method('orderBy')
-            ->with(ORMSource::ALIAS . '.created', 'DESC')
-            ->willReturnSelf();
-
-        $queryBuilder
-            ->expects(self::once())
-            ->method('setMaxResults')
-            ->with(100)
-            ->willReturnSelf();
-
-        $grid = new ApiTokenHistoryGrid();
-
-        $result = $grid->query($entityManager, $query);
-
-        self::assertSame($query, $result);
+        return $security;
     }
 }


### PR DESCRIPTION
## What

Refines the `ApiTokenHistoryGrid` data grid so the request-history query is always constrained to API tokens that belong to the currently authenticated user.

- Inject `Security` into `ApiTokenHistoryGrid` (matching the existing pattern in `ApiTokenGrid`).
- `query()` now joins `ApiTokenHistory.token` and filters on `apiToken.user = :currentUser` on every request, before applying the optional `token_id` context filter.

## Why

The grid previously filtered history rows only by the `token_id` passed through the grid context, relying solely on the company-level Doctrine filter for scoping. Since a company can have multiple users, that left the grid returning history for any token in the company rather than just the caller's own tokens. Adding the explicit per-user constraint keeps the grid's behaviour consistent with `ApiTokenGrid`, which already scopes its results to the current user.

## Tests

- Updated `ApiTokenHistoryGridTest` for the new constructor dependency.
- Added `testQueryAlwaysScopesToCurrentUser` to assert the user constraint is applied on every query, and updated the token-filter test to assert both the user and token constraints are present.

Verified locally: `bin/phpunit` (grid + modal tests pass), `bin/phpstan analyse` (clean), `bin/ecs check` (clean).