### PR TITLE
Fix running migrations during upgrade

### DIFF
--- a/src/InstallBundle/Listener/UpgradeListener.php
+++ b/src/InstallBundle/Listener/UpgradeListener.php
@@ -51,7 +51,8 @@ readonly class UpgradeListener implements EventSubscriberInterface
         }
 
         if (! $this->migration->isUpToDate()) {
-            $this->migration->migrate();
+            foreach ($this->migration->migrate() as $_) {
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/SolidInvoice/SolidInvoice/issues/2516.

The migrations returns a generator, so we have to loop through `$this->migration->migrate()` to process the generator and run the migrations