### PR TITLE
Fix ValidationException when creating Quote via API without contacts (#2524)

### DIFF
--- a/src/ApiBundle/State/Processor/QuoteAutoUsersStateProcessor.php
+++ b/src/ApiBundle/State/Processor/QuoteAutoUsersStateProcessor.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\State\Processor;
+
+use ApiPlatform\Doctrine\Common\State\PersistProcessor;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+
+/**
+ * When no contacts are provided for a new Quote via the API, automatically
+ * assign all contacts from the Quote's client. This matches the behaviour of
+ * the UI (QuoteFormManager) and prevents the "users: You need to select at
+ * least 1 user to attach to the Quote" validation error for API clients that
+ * specify a client but omit the users field.
+ *
+ * @implements ProcessorInterface<object, object>
+ */
+#[AsDecorator(decorates: PersistProcessor::class)]
+final readonly class QuoteAutoUsersStateProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<object, object> $inner
+     */
+    public function __construct(
+        private ProcessorInterface $inner,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        if ($data instanceof Quote && $operation instanceof Post && $data->getUsers()->isEmpty() && $data->getClient() !== null) {
+            foreach ($data->getClient()->getContacts() as $contact) {
+                assert($contact instanceof Contact);
+                $data->addUser($contact);
+            }
+        }
+
+        return $this->inner->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/src/ApiBundle/State/Processor/QuoteAutoUsersStateProcessor.php
+++ b/src/ApiBundle/State/Processor/QuoteAutoUsersStateProcessor.php
@@ -17,6 +17,7 @@ use ApiPlatform\Doctrine\Common\State\PersistProcessor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
+use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Entity\Contact;
 use SolidInvoice\QuoteBundle\Entity\Quote;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
@@ -29,6 +30,7 @@ use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
  * specify a client but omit the users field.
  *
  * @implements ProcessorInterface<object, object>
+ * @see \SolidInvoice\ApiBundle\Tests\State\Processor\QuoteAutoUsersStateProcessorTest
  */
 #[AsDecorator(decorates: PersistProcessor::class)]
 final readonly class QuoteAutoUsersStateProcessor implements ProcessorInterface
@@ -43,7 +45,7 @@ final readonly class QuoteAutoUsersStateProcessor implements ProcessorInterface
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
-        if ($data instanceof Quote && $operation instanceof Post && $data->getUsers()->isEmpty() && $data->getClient() !== null) {
+        if ($data instanceof Quote && $operation instanceof Post && $data->getUsers()->isEmpty() && $data->getClient() instanceof Client) {
             foreach ($data->getClient()->getContacts() as $contact) {
                 assert($contact instanceof Contact);
                 $data->addUser($contact);

--- a/src/ApiBundle/Tests/State/Processor/QuoteAutoUsersStateProcessorTest.php
+++ b/src/ApiBundle/Tests/State/Processor/QuoteAutoUsersStateProcessorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\State\Processor;
+
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ApiBundle\State\Processor\QuoteAutoUsersStateProcessor;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Entity\Contact;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+
+final class QuoteAutoUsersStateProcessorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testAutoAssignsClientContactsWhenUsersEmpty(): void
+    {
+        $contact1 = new Contact();
+        $contact2 = new Contact();
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getContacts')
+            ->once()
+            ->andReturn(new ArrayCollection([$contact1, $contact2]));
+
+        $quote = new Quote();
+        $quote->setClient($client);
+
+        $inner = Mockery::mock(ProcessorInterface::class);
+        $inner->shouldReceive('process')
+            ->once()
+            ->with($quote, Mockery::type(Post::class), [], [])
+            ->andReturn($quote);
+
+        $processor = new QuoteAutoUsersStateProcessor($inner);
+        $processor->process($quote, new Post(), [], []);
+
+        self::assertCount(2, $quote->getUsers());
+        self::assertTrue($quote->getUsers()->contains($contact1));
+        self::assertTrue($quote->getUsers()->contains($contact2));
+    }
+
+    public function testDoesNotOverwriteExistingUsers(): void
+    {
+        $existingContact = new Contact();
+        $quote = new Quote();
+        $quote->addUser($existingContact);
+
+        $inner = Mockery::mock(ProcessorInterface::class);
+        $inner->shouldReceive('process')
+            ->once()
+            ->andReturn($quote);
+
+        $processor = new QuoteAutoUsersStateProcessor($inner);
+        $processor->process($quote, new Post(), [], []);
+
+        self::assertCount(1, $quote->getUsers());
+        self::assertTrue($quote->getUsers()->contains($existingContact));
+    }
+
+    public function testDoesNotAssignWhenClientIsNull(): void
+    {
+        $quote = new Quote();
+
+        $inner = Mockery::mock(ProcessorInterface::class);
+        $inner->shouldReceive('process')
+            ->once()
+            ->andReturn($quote);
+
+        $processor = new QuoteAutoUsersStateProcessor($inner);
+        $processor->process($quote, new Post(), [], []);
+
+        self::assertCount(0, $quote->getUsers());
+    }
+
+    public function testNonPostOperationIsPassedThrough(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getContacts')->never();
+
+        $quote = new Quote();
+        $quote->setClient($client);
+
+        $inner = Mockery::mock(ProcessorInterface::class);
+        $inner->shouldReceive('process')
+            ->once()
+            ->andReturn($quote);
+
+        $processor = new QuoteAutoUsersStateProcessor($inner);
+        $processor->process($quote, new Patch(), [], []);
+
+        self::assertCount(0, $quote->getUsers());
+    }
+
+    public function testNonQuoteDataIsPassedThrough(): void
+    {
+        $invoice = new Invoice();
+
+        $inner = Mockery::mock(ProcessorInterface::class);
+        $inner->shouldReceive('process')
+            ->once()
+            ->with($invoice, Mockery::type(Post::class), [], [])
+            ->andReturn($invoice);
+
+        $processor = new QuoteAutoUsersStateProcessor($inner);
+        $result = $processor->process($invoice, new Post(), [], []);
+
+        self::assertSame($invoice, $result);
+    }
+}


### PR DESCRIPTION
Closes #2524

## Root cause

The `Quote` entity carries an `Assert\Count(min: 1)` constraint on its `$users` collection (the contacts to whom the quote is addressed). When an API client POSTs to `/api/quotes` without including the `users` field, API Platform's validator throws a `ValidationException`:

```
users: You need to select at least 1 user to attach to the Quote
```

This is the correct guard in the UI (the form always requires contacts), but API clients often omit the field because the field is named `users` even though it holds `Contact` entities, making the requirement non-obvious. Many API clients naturally provide a `client` IRI and expect the system to resolve contacts.

Sentry **SOLIDINVOICE-8R** recorded **1,803 occurrences across 10 users** before this fix.

## Fix

Add `QuoteAutoUsersStateProcessor` — a decorator on API Platform's `PersistProcessor` that runs before the entity is persisted. When it detects a Quote `Post` operation with an empty `users` collection but a non-null `client`, it auto-assigns all contacts from that client to the quote. This mirrors the existing behaviour in `QuoteFormManager`, which does exactly the same thing in the web UI flow.

Existing API clients who explicitly supply `users` are entirely unaffected (the auto-assign is skipped when the collection is non-empty).

## Test approach

Added `QuoteAutoUsersStateProcessorTest` with five cases:

1. **`testAutoAssignsClientContactsWhenUsersEmpty`** — Quote with no users and a client: asserts all client contacts are added before the inner processor is called.
2. **`testDoesNotOverwriteExistingUsers`** — Quote already has a contact: asserts the existing collection is untouched.
3. **`testDoesNotAssignWhenClientIsNull`** — Quote has no client: asserts nothing is added (the Count constraint will still fail — a clientless quote is invalid).
4. **`testNonPostOperationIsPassedThrough`** — `Patch` operation: asserts `getContacts()` is never called and the quote is passed through unchanged.
5. **`testNonQuoteDataIsPassedThrough`** — Non-Quote entity: asserts the processor is a no-op and returns the input unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L4PM7u5a1LnUXBugV7S1z4)_