### PR TITLE
feat(saas): auto-downgrade expired trials to Free (hourly) + notice email

### DIFF
--- a/config/packages/messenger.php
+++ b/config/packages/messenger.php
@@ -18,6 +18,7 @@ use SolidInvoice\CoreBundle\Telemetry\Message\SendTelemetryMessage;
 use SolidInvoice\CronBundle\Messenger\SentrySchedulerMiddleware;
 use SolidInvoice\InvoiceBundle\Message\SendInvoiceReminderMessage;
 use SolidInvoice\SaasBundle\Message\SendOnboardingEmailMessage;
+use SolidInvoice\SaasBundle\Message\SendTrialDowngradedEmailMessage;
 
 return App::config([
     'framework' => [
@@ -60,6 +61,10 @@ return App::config([
                 // them out-of-band. The handler swallows all errors and always acks, so a
                 // slow or unreachable Insights server never blocks the app or retries.
                 SendTelemetryMessage::class => ['async'],
+                // Route the trial-downgrade notice through async so the hourly
+                // downgrade command returns quickly and Messenger retries transient
+                // mailer failures.
+                SendTrialDowngradedEmailMessage::class => ['async'],
             ],
             // Configure default bus
             'default_bus' => 'messenger.bus.default',

--- a/src/ApiBundle/Event/Listener/AuthenticationSuccessHandler.php
+++ b/src/ApiBundle/Event/Listener/AuthenticationSuccessHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Event\Listener;
 
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\ApiTokenManager;
 use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -28,7 +29,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
     ) {
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
+    public function onAuthenticationSuccess(Request $request, #[SensitiveParameter] TokenInterface $token): ?Response
     {
         /** @var User $user */
         $user = $token->getUser();

--- a/src/ApiBundle/GeneratedApiToken.php
+++ b/src/ApiBundle/GeneratedApiToken.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle;
 
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\ApiToken;
 
 /**
@@ -22,6 +23,7 @@ use SolidInvoice\UserBundle\Entity\ApiToken;
 final readonly class GeneratedApiToken
 {
     public function __construct(
+        #[SensitiveParameter]
         public ApiToken $token,
         public string $plaintext,
     ) {

--- a/src/ApiBundle/Security/ApiTokenAuthenticator.php
+++ b/src/ApiBundle/Security/ApiTokenAuthenticator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\ApiBundle\Security;
 
 use Doctrine\Persistence\ManagerRegistry;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\Provider\ApiTokenUserProvider;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Company\ResolvedHost;
@@ -57,7 +58,7 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
         return null !== $this->extractToken($request);
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    public function onAuthenticationSuccess(Request $request, #[SensitiveParameter] TokenInterface $token, string $firewallName): ?Response
     {
         $apiToken = $this->extractToken($request);
 

--- a/src/ApiBundle/Security/ApiTokenHasher.php
+++ b/src/ApiBundle/Security/ApiTokenHasher.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Security;
 
+use SensitiveParameter;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -28,12 +29,13 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final readonly class ApiTokenHasher
 {
     public function __construct(
+        #[SensitiveParameter]
         #[Autowire('%kernel.secret%')]
         private string $appSecret,
     ) {
     }
 
-    public function hash(string $plaintextToken): string
+    public function hash(#[SensitiveParameter] string $plaintextToken): string
     {
         return hash_hmac('sha256', $plaintextToken, $this->appSecret);
     }

--- a/src/ApiBundle/Security/Provider/ApiTokenUserProvider.php
+++ b/src/ApiBundle/Security/Provider/ApiTokenUserProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Security\Provider;
 
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\Repository\ApiTokenRepository;
 use SolidInvoice\UserBundle\Repository\UserRepositoryInterface;
@@ -32,7 +33,7 @@ class ApiTokenUserProvider implements UserProviderInterface
     ) {
     }
 
-    public function getUsernameForToken(string $token): ?string
+    public function getUsernameForToken(#[SensitiveParameter] string $token): ?string
     {
         return $this->tokenRepository->getUsernameForToken($token);
     }

--- a/src/ApiBundle/Security/Voter/ApiAccessVoter.php
+++ b/src/ApiBundle/Security/Voter/ApiAccessVoter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Security\Voter;
 
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\Attribute;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
@@ -46,7 +47,7 @@ final class ApiAccessVoter extends Voter
         return $attribute === Attribute::ACCESS && ! $this->toggler->isActive('saas_enabled');
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, #[SensitiveParameter] TokenInterface $token, ?Vote $vote = null): bool
     {
         if (! $this->featureGate->isEnabled('rest_api_access')) {
             $vote?->addReason('REST API access is not available on the current plan.');

--- a/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
+++ b/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
@@ -13,6 +13,13 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ApiBundle\Tests\Security;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use Doctrine\ORM\Query\FilterCollection;
+use Doctrine\Persistence\ManagerRegistry;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as M;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -20,10 +27,24 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SolidInvoice\ApiBundle\Security\ApiTokenAuthenticator;
 use SolidInvoice\ApiBundle\Security\Provider\ApiTokenUserProvider;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Company\HostType;
+use SolidInvoice\CoreBundle\Company\ResolvedHost;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Listener\HostRoutingListener;
+use SolidInvoice\UserBundle\Entity\ApiToken;
+use SolidInvoice\UserBundle\Entity\ApiTokenHistory;
+use SolidInvoice\UserBundle\Repository\ApiTokenHistoryRepository;
+use SolidInvoice\UserBundle\Repository\ApiTokenRepository;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Uid\Ulid;
+use function strtoupper;
+use function substr;
 
 final class ApiTokenAuthenticatorTest extends TestCase
 {
@@ -67,6 +88,104 @@ final class ApiTokenAuthenticatorTest extends TestCase
         self::assertSame('user@example.com', $passport->getBadge(UserBadge::class)->getUserIdentifier());
     }
 
+    public function testOnAuthenticationSuccessRejectsTokenWhenCustomDomainCompanyDoesNotMatch(): void
+    {
+        // Regression test for GHSA-55q8-pvw3-5gfr / GHSA-fxf4-3h4c-rqrc: an API
+        // token issued for company A must not grant access to company B just
+        // because the request was sent to company B's custom domain (Host header).
+        $ownCompany = $this->companyWithId();
+        $victimCompany = $this->companyWithId();
+
+        $apiTokenEntity = new ApiToken();
+        $apiTokenEntity->setCompany($ownCompany);
+
+        $registry = M::mock(ManagerRegistry::class);
+        $registry->shouldReceive('getRepository')
+            ->once()
+            ->with(ApiTokenHistory::class)
+            ->andReturn($this->historyRepositoryExpectingAddHistory());
+        $registry->shouldNotReceive('getManager');
+
+        $apiTokenRepository = M::mock(ApiTokenRepository::class);
+        $apiTokenRepository->shouldReceive('findOneByPlaintext')
+            ->once()
+            ->with('a-valid-token')
+            ->andReturn($apiTokenEntity);
+
+        $authorizationChecker = M::mock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->shouldNotReceive('isGranted');
+
+        $companySelector = new CompanySelector($registry);
+
+        $request = $this->requestWithToken('a-valid-token');
+        $request->attributes->set(
+            HostRoutingListener::REQUEST_ATTR,
+            new ResolvedHost(HostType::CustomDomain, 'victim.example', 'https', 443, $victimCompany)
+        );
+
+        $authenticator = $this->authenticator(
+            registry: $registry,
+            apiTokenRepository: $apiTokenRepository,
+            companySelector: $companySelector,
+            authorizationChecker: $authorizationChecker,
+        );
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('Invalid API token');
+
+        try {
+            $authenticator->onAuthenticationSuccess($request, M::mock(TokenInterface::class), 'api');
+        } finally {
+            self::assertNull($companySelector->getCompany());
+        }
+    }
+
+    public function testOnAuthenticationSuccessSwitchesCompanyWhenCustomDomainCompanyMatches(): void
+    {
+        $company = $this->companyWithId();
+
+        $apiTokenEntity = new ApiToken();
+        $apiTokenEntity->setCompany($company);
+
+        $registry = M::mock(ManagerRegistry::class);
+        $registry->shouldReceive('getRepository')
+            ->once()
+            ->with(ApiTokenHistory::class)
+            ->andReturn($this->historyRepositoryExpectingAddHistory());
+
+        $filter = $this->expectSwitchCompanyCalls($registry, $company);
+
+        $apiTokenRepository = M::mock(ApiTokenRepository::class);
+        $apiTokenRepository->shouldReceive('findOneByPlaintext')
+            ->once()
+            ->with('a-valid-token')
+            ->andReturn($apiTokenEntity);
+
+        $authorizationChecker = M::mock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->shouldReceive('isGranted')->once()->andReturn(true);
+
+        $companySelector = new CompanySelector($registry);
+
+        $request = $this->requestWithToken('a-valid-token');
+        $request->attributes->set(
+            HostRoutingListener::REQUEST_ATTR,
+            new ResolvedHost(HostType::CustomDomain, 'acme.example', 'https', 443, $company)
+        );
+
+        $authenticator = $this->authenticator(
+            registry: $registry,
+            apiTokenRepository: $apiTokenRepository,
+            companySelector: $companySelector,
+            authorizationChecker: $authorizationChecker,
+        );
+
+        $response = $authenticator->onAuthenticationSuccess($request, M::mock(TokenInterface::class), 'api');
+
+        self::assertNull($response);
+        self::assertSame($company->getId(), $companySelector->getCompany());
+        self::assertSame($company->getId()->toHex(), $filter->getParameter('companyId'));
+    }
+
     /**
      * @return iterable<string, array{string}>
      */
@@ -78,24 +197,123 @@ final class ApiTokenAuthenticatorTest extends TestCase
 
     private function requestWithToken(string $token): Request
     {
-        $request = new Request();
+        $request = new Request(server: ['REMOTE_ADDR' => '127.0.0.1', 'HTTP_USER_AGENT' => 'phpunit']);
         $request->headers->set('X-API-TOKEN', $token);
 
         return $request;
     }
 
+    private function companyWithId(): Company
+    {
+        $company = new Company();
+        new ReflectionClass($company)->getProperty('id')->setValue($company, new Ulid());
+
+        return $company;
+    }
+
+    /**
+     * @return ApiTokenHistoryRepository&M\MockInterface
+     */
+    private function historyRepositoryExpectingAddHistory()
+    {
+        $historyRepository = M::mock(ApiTokenHistoryRepository::class);
+        $historyRepository->shouldReceive('addHistory')->once();
+
+        return $historyRepository;
+    }
+
+    /**
+     * @param ManagerRegistry&M\MockInterface $registry
+     */
+    private function expectSwitchCompanyCalls($registry, Company $company): SQLFilter
+    {
+        $filterCollection = M::mock(FilterCollection::class);
+        $em = M::mock(EntityManagerInterface::class);
+        $connection = M::mock(Connection::class);
+
+        $filter = new class($em) extends SQLFilter {
+            /**
+             * @param ClassMetadata<object> $targetEntity
+             */
+            public function addFilterConstraint(ClassMetadata $targetEntity, string $targetTableAlias): string
+            {
+                return '';
+            }
+        };
+
+        $registry
+            ->shouldReceive('getManager')
+            ->once()
+            ->andReturn($em);
+
+        $em
+            ->shouldReceive('getFilters')
+            ->twice()
+            ->andReturn($filterCollection);
+
+        $em
+            ->shouldReceive('getConnection')
+            ->zeroOrMoreTimes()
+            ->andReturn($connection);
+
+        $filterCollection
+            ->shouldReceive('enable')
+            ->once()
+            ->with('company')
+            ->andReturn($filter);
+
+        $filterCollection
+            ->shouldReceive('setFiltersStateDirty')
+            ->once()
+            ->withNoArgs();
+
+        $connection
+            ->shouldReceive('getDatabasePlatform')
+            ->zeroOrMoreTimes()
+            ->andReturn(new SQLitePlatform());
+
+        $connection
+            ->shouldReceive('quote')
+            ->once()
+            ->with(strtoupper(substr($company->getId()->toHex(), 2)))
+            ->andReturn($company->getId()->toHex());
+
+        return $filter;
+    }
+
     /**
      * The constructor pulls in several final, infrastructure-bound services that
      * are not exercised by token extraction, so the instance is built without the
-     * constructor and only the user provider is injected when required.
+     * constructor and only the collaborators a given test needs are injected.
      */
-    private function authenticator(?ApiTokenUserProvider $userProvider = null): ApiTokenAuthenticator
-    {
+    private function authenticator(
+        ?ApiTokenUserProvider $userProvider = null,
+        ?ManagerRegistry $registry = null,
+        ?ApiTokenRepository $apiTokenRepository = null,
+        ?CompanySelector $companySelector = null,
+        ?AuthorizationCheckerInterface $authorizationChecker = null,
+    ): ApiTokenAuthenticator {
         $reflection = new ReflectionClass(ApiTokenAuthenticator::class);
         $authenticator = $reflection->newInstanceWithoutConstructor();
 
         if ($userProvider instanceof ApiTokenUserProvider) {
             $reflection->getProperty('userProvider')->setValue($authenticator, $userProvider);
+        }
+
+        if ($registry instanceof ManagerRegistry) {
+            $reflection->getProperty('registry')->setValue($authenticator, $registry);
+        }
+
+        if ($apiTokenRepository instanceof ApiTokenRepository) {
+            $reflection->getProperty('apiTokenRepository')->setValue($authenticator, $apiTokenRepository);
+        }
+
+        if ($companySelector instanceof CompanySelector) {
+            $reflection->getProperty('companySelector')->setValue($authenticator, $companySelector);
+        }
+
+        if ($authorizationChecker instanceof AuthorizationCheckerInterface) {
+            $reflection->getProperty('authorizationChecker')->setValue($authenticator, $authorizationChecker);
         }
 
         return $authenticator;

--- a/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
+++ b/src/ApiBundle/Tests/Security/ApiTokenAuthenticatorTest.php
@@ -25,6 +25,7 @@ use Mockery as M;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\ApiTokenAuthenticator;
 use SolidInvoice\ApiBundle\Security\Provider\ApiTokenUserProvider;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
@@ -56,7 +57,7 @@ final class ApiTokenAuthenticatorTest extends TestCase
     }
 
     #[DataProvider('emptyTokenProvider')]
-    public function testSupportsRejectsEmptyToken(string $token): void
+    public function testSupportsRejectsEmptyToken(#[SensitiveParameter] string $token): void
     {
         self::assertFalse($this->authenticator()->supports($this->requestWithToken($token)));
     }
@@ -67,7 +68,7 @@ final class ApiTokenAuthenticatorTest extends TestCase
     }
 
     #[DataProvider('emptyTokenProvider')]
-    public function testAuthenticateRejectsEmptyToken(string $token): void
+    public function testAuthenticateRejectsEmptyToken(#[SensitiveParameter] string $token): void
     {
         $this->expectException(CustomUserMessageAuthenticationException::class);
         $this->expectExceptionMessage('No API token provided');
@@ -195,7 +196,7 @@ final class ApiTokenAuthenticatorTest extends TestCase
         yield 'whitespace' => ['   '];
     }
 
-    private function requestWithToken(string $token): Request
+    private function requestWithToken(#[SensitiveParameter] string $token): Request
     {
         $request = new Request(server: ['REMOTE_ADDR' => '127.0.0.1', 'HTTP_USER_AGENT' => 'phpunit']);
         $request->headers->set('X-API-TOKEN', $token);

--- a/src/CoreBundle/Export/Security/Voter/ExportJobVoter.php
+++ b/src/CoreBundle/Export/Security/Voter/ExportJobVoter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\CoreBundle\Export\Security\Voter;
 
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\ExportJob;
 use SolidInvoice\UserBundle\Entity\User;
@@ -39,7 +40,7 @@ final class ExportJobVoter extends Voter
         return $attribute === self::DOWNLOAD && $subject instanceof ExportJob;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, #[SensitiveParameter] TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
         if (! $user instanceof User) {

--- a/src/CoreBundle/Listener/CompanyEventSubscriber.php
+++ b/src/CoreBundle/Listener/CompanyEventSubscriber.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Uid\Ulid;
 use function assert;
@@ -70,6 +71,20 @@ final readonly class CompanyEventSubscriber implements EventSubscriberInterface
 
         if ($resolved instanceof ResolvedHost && $resolved->isCustomDomain() && $resolved->company instanceof Company) {
             $companyId = $resolved->company->getId();
+            $user = $this->security->getUser();
+
+            // A logged-in user must belong to the company that owns this custom
+            // domain: the Host header is attacker-controlled, so without this
+            // check any authenticated user could switch their session's active
+            // tenant to another company just by sending a different Host value.
+            if ($user instanceof UserInterface) {
+                assert($user instanceof User);
+
+                if (! $user->getCompanies()->exists(static fn (int $key, Company $company): bool => $company->getId()->equals($companyId))) {
+                    throw new AccessDeniedException('You do not have access to this company.');
+                }
+            }
+
             $this->companySelector->switchCompany($companyId);
             $session->set('company', $companyId);
             return;

--- a/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
+++ b/src/CoreBundle/Tests/Listener/CompanyEventSubscriberTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Uid\Ulid;
 use function strtoupper;
 
@@ -211,15 +212,20 @@ final class CompanyEventSubscriberTest extends TestCase
         self::assertSame($company->getId()->toHex(), $filter->getParameter('companyId'));
     }
 
-    public function testItSwitchesToTheResolvedCompanyOnACustomDomainAndSkipsRedirect(): void
+    public function testItSwitchesToTheResolvedCompanyOnACustomDomainForAnAnonymousUserAndSkipsRedirect(): void
     {
+        // Anonymous visitors (e.g. hitting the login page on a company's custom
+        // domain) have no membership to check, so the switch is allowed through.
         $router = M::mock(RouterInterface::class);
         $registry = M::mock(ManagerRegistry::class);
         $security = M::mock(Security::class);
 
         $companySelector = new CompanySelector($registry);
 
-        $security->shouldNotReceive('getUser');
+        $security
+            ->shouldReceive('getUser')
+            ->once()
+            ->andReturn(null);
         $router->shouldNotReceive('generate');
 
         $company = new Company();
@@ -243,6 +249,97 @@ final class CompanyEventSubscriberTest extends TestCase
         self::assertSame($company->getId(), $companySelector->getCompany());
         self::assertSame($company->getId(), $session->get('company'));
         self::assertSame($company->getId()->toHex(), $filter->getParameter('companyId'));
+    }
+
+    public function testItSwitchesToTheResolvedCompanyOnACustomDomainForAMemberAndSkipsRedirect(): void
+    {
+        $router = M::mock(RouterInterface::class);
+        $registry = M::mock(ManagerRegistry::class);
+        $security = M::mock(Security::class);
+
+        $companySelector = new CompanySelector($registry);
+
+        $company = new Company();
+        $this->setCompanyId($company, new Ulid());
+
+        $user = new User();
+        $user->addCompany($company);
+
+        $security
+            ->shouldReceive('getUser')
+            ->once()
+            ->andReturn($user);
+        $router->shouldNotReceive('generate');
+
+        $filter = $this->expectSwitchCompanyCalls($registry, $company);
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set(
+            HostRoutingListener::REQUEST_ATTR,
+            new ResolvedHost(HostType::CustomDomain, 'acme.example', 'https', 443, $company)
+        );
+
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, Carbon::now()->format('Y'));
+
+        $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $listener->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+        self::assertSame($company->getId(), $companySelector->getCompany());
+        self::assertSame($company->getId(), $session->get('company'));
+        self::assertSame($company->getId()->toHex(), $filter->getParameter('companyId'));
+    }
+
+    public function testItDeniesAccessWhenAnAuthenticatedUserIsNotAMemberOfTheCustomDomainCompany(): void
+    {
+        // Regression test for GHSA-55q8-pvw3-5gfr / GHSA-fxf4-3h4c-rqrc: an
+        // authenticated user who is a member of company A must not be able to
+        // switch their active tenant to company B just by sending a request
+        // with company B's custom domain as the Host header.
+        $router = M::mock(RouterInterface::class);
+        $registry = M::mock(ManagerRegistry::class);
+        $security = M::mock(Security::class);
+
+        $companySelector = new CompanySelector($registry);
+
+        $victimCompany = new Company();
+        $this->setCompanyId($victimCompany, new Ulid());
+
+        $ownCompany = new Company();
+        $this->setCompanyId($ownCompany, new Ulid());
+
+        $user = new User();
+        $user->addCompany($ownCompany);
+
+        $security
+            ->shouldReceive('getUser')
+            ->once()
+            ->andReturn($user);
+        $router->shouldNotReceive('generate');
+        $registry->shouldNotReceive('getManager');
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set(
+            HostRoutingListener::REQUEST_ATTR,
+            new ResolvedHost(HostType::CustomDomain, 'victim.example', 'https', 443, $victimCompany)
+        );
+
+        $listener = new CompanyEventSubscriber($router, $companySelector, $security, Carbon::now()->format('Y'));
+
+        $event = new RequestEvent(M::mock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(AccessDeniedException::class);
+
+        try {
+            $listener->onKernelRequest($event);
+        } finally {
+            self::assertNull($companySelector->getCompany());
+            self::assertFalse($session->has('company'));
+        }
     }
 
     public function testItSkipsWhenCompanySelectorAlreadyHasACompany(): void

--- a/src/InstallBundle/DTO/DatabaseConfig.php
+++ b/src/InstallBundle/DTO/DatabaseConfig.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\InstallBundle\DTO;
 
 use Doctrine\DBAL\DriverManager;
 use PDO;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\SolidInvoiceCoreBundle;
 use SolidInvoice\InstallBundle\Doctrine\Drivers;
 use Symfony\Component\Validator\Constraints\Callback;
@@ -37,6 +38,7 @@ final class DatabaseConfig
         #[Type(type: 'integer', groups: ['database_config_mysql', 'database_config_mariadb', 'database_config_pgsql'])]
         public ?int $port = null,
         public ?string $user = null,
+        #[SensitiveParameter]
         public ?string $password = null,
         public ?string $version = null,
         #[NotBlank(groups: ['database_config_mysql', 'database_config_mariadb', 'database_config_pgsql'])]

--- a/src/InstallBundle/DTO/Installation.php
+++ b/src/InstallBundle/DTO/Installation.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InstallBundle\DTO;
 
+use SensitiveParameter;
 use Symfony\Component\Validator\Constraints\Valid;
 
 final class Installation
@@ -25,6 +26,7 @@ final class Installation
         public ?string $applicationUrl = null,
         public bool $telemetryEnabled = true,
         public string $currentStep = 'start',
+        #[SensitiveParameter]
         public ?string $token = '',
     ) {
     }

--- a/src/InstallBundle/DTO/UserAccount.php
+++ b/src/InstallBundle/DTO/UserAccount.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InstallBundle\DTO;
 
+use SensitiveParameter;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -31,6 +32,7 @@ final class UserAccount
             Email(mode: Email::VALIDATION_MODE_STRICT, groups: ['user_account']),
         ]
         public ?string $emailAddress = null,
+        #[SensitiveParameter]
         #[
             NotBlank(message: 'install.user_account.password.not_blank', groups: ['user_account']),
             Length(min: 6, groups: ['user_account']),

--- a/src/McpBundle/Action/Revoke.php
+++ b/src/McpBundle/Action/Revoke.php
@@ -21,6 +21,7 @@ use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use RuntimeException;
+use SensitiveParameter;
 use SolidInvoice\McpBundle\OAuth\KeyManager;
 use SolidInvoice\McpBundle\Repository\McpAccessTokenRepository;
 use SolidInvoice\McpBundle\Repository\McpRefreshTokenRepository;
@@ -58,7 +59,7 @@ final readonly class Revoke
         return new Response('', Response::HTTP_OK);
     }
 
-    private function tryRevokeAccessToken(string $token): bool
+    private function tryRevokeAccessToken(#[SensitiveParameter] string $token): bool
     {
         try {
             $signer = new Sha256();

--- a/src/McpBundle/Entity/McpRefreshToken.php
+++ b/src/McpBundle/Entity/McpRefreshToken.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Mapping as ORM;
 use InvalidArgumentException;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\McpBundle\Repository\McpRefreshTokenRepository;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
@@ -75,7 +76,7 @@ class McpRefreshToken implements RefreshTokenEntityInterface
         return $this->accessToken;
     }
 
-    public function setAccessToken(AccessTokenEntityInterface $accessToken): void
+    public function setAccessToken(#[SensitiveParameter] AccessTokenEntityInterface $accessToken): void
     {
         if (! $accessToken instanceof McpAccessToken) {
             throw new InvalidArgumentException('Expected McpAccessToken instance.');

--- a/src/McpBundle/Repository/McpAccessTokenRepository.php
+++ b/src/McpBundle/Repository/McpAccessTokenRepository.php
@@ -22,6 +22,7 @@ use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use LogicException;
+use SensitiveParameter;
 use SolidInvoice\McpBundle\Entity\ConsentGrant;
 use SolidInvoice\McpBundle\Entity\McpAccessToken;
 use SolidInvoice\McpBundle\Entity\OAuthClient;
@@ -128,7 +129,7 @@ final class McpAccessTokenRepository extends EntityRepository implements AccessT
      * Record that the token was used now. Uses a direct UPDATE to avoid flushing
      * unrelated pending changes on the EM and to keep the happy-path cheap.
      */
-    public function touch(McpAccessToken $token): void
+    public function touch(#[SensitiveParameter] McpAccessToken $token): void
     {
         $this->getEntityManager()->createQueryBuilder()
             ->update(McpAccessToken::class, 't')
@@ -140,7 +141,7 @@ final class McpAccessTokenRepository extends EntityRepository implements AccessT
             ->execute();
     }
 
-    private function bindCompanyIfMissing(McpAccessToken $accessToken): void
+    private function bindCompanyIfMissing(#[SensitiveParameter] McpAccessToken $accessToken): void
     {
         if ($accessToken->hasCompany()) {
             return;

--- a/src/McpBundle/Repository/OAuthClientRepository.php
+++ b/src/McpBundle/Repository/OAuthClientRepository.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use SensitiveParameter;
 use SolidInvoice\McpBundle\Entity\OAuthClient;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
@@ -47,7 +48,7 @@ final class OAuthClientRepository extends EntityRepository implements ClientRepo
         return $this->findOneBy(['id' => $ulid]);
     }
 
-    public function validateClient(string $clientIdentifier, ?string $clientSecret, ?string $grantType): bool
+    public function validateClient(string $clientIdentifier, #[SensitiveParameter] ?string $clientSecret, ?string $grantType): bool
     {
         $client = $this->getClientEntity($clientIdentifier);
 

--- a/src/McpBundle/Security/McpOAuthAuthenticator.php
+++ b/src/McpBundle/Security/McpOAuthAuthenticator.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\McpBundle\Security;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\McpBundle\Entity\McpAccessToken;
 use SolidInvoice\McpBundle\OAuth\ServerFactoryInterface;
@@ -103,7 +104,7 @@ final class McpOAuthAuthenticator extends AbstractAuthenticator
         return new SelfValidatingPassport(new UserBadge($userId));
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    public function onAuthenticationSuccess(Request $request, #[SensitiveParameter] TokenInterface $token, string $firewallName): ?Response
     {
         $accessToken = $request->attributes->get(self::ATTR_ACCESS_TOKEN);
 

--- a/src/McpBundle/Security/Voter/McpAccessVoter.php
+++ b/src/McpBundle/Security/Voter/McpAccessVoter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\McpBundle\Security\Voter;
 
+use SensitiveParameter;
 use SolidInvoice\McpBundle\Security\Attribute;
 use SolidWorx\Platform\PlatformBundle\Feature\FeatureGate;
 use SolidWorx\Toggler\ToggleInterface;
@@ -46,7 +47,7 @@ final class McpAccessVoter extends Voter
         return $attribute === Attribute::ACCESS && ! $this->toggler->isActive('saas_enabled');
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, #[SensitiveParameter] TokenInterface $token, ?Vote $vote = null): bool
     {
         if (! $this->featureGate->isEnabled('mcp_access')) {
             $vote?->addReason('MCP access is not available on the current plan.');

--- a/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
+++ b/src/McpBundle/Tests/Functional/SubscriptionGateTest.php
@@ -19,6 +19,7 @@ use Mockery as M;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\ServerRequestInterface;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\McpBundle\Entity\McpAccessToken;
@@ -159,7 +160,7 @@ final class SubscriptionGateTest extends KernelTestCase
         return $token;
     }
 
-    private function buildAuthenticator(McpAccessToken $token, AuthorizationCheckerInterface $authorizationChecker): McpOAuthAuthenticator
+    private function buildAuthenticator(#[SensitiveParameter] McpAccessToken $token, AuthorizationCheckerInterface $authorizationChecker): McpOAuthAuthenticator
     {
         $container = self::getContainer();
 

--- a/src/PaymentBundle/Listener/Doctrine/SecurityTokenPaymentLinker.php
+++ b/src/PaymentBundle/Listener/Doctrine/SecurityTokenPaymentLinker.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
 use Payum\Core\Model\Identity;
+use SensitiveParameter;
 use SolidInvoice\PaymentBundle\Entity\Payment;
 use SolidInvoice\PaymentBundle\Entity\SecurityToken;
 use Symfony\Component\Uid\Ulid;
@@ -30,17 +31,17 @@ use Throwable;
 #[AsEntityListener(event: Events::preUpdate, entity: SecurityToken::class)]
 final class SecurityTokenPaymentLinker
 {
-    public function prePersist(SecurityToken $token, PrePersistEventArgs $args): void
+    public function prePersist(#[SensitiveParameter] SecurityToken $token, PrePersistEventArgs $args): void
     {
         $this->link($token, $args);
     }
 
-    public function preUpdate(SecurityToken $token, PreUpdateEventArgs $args): void
+    public function preUpdate(#[SensitiveParameter] SecurityToken $token, PreUpdateEventArgs $args): void
     {
         $this->link($token, $args);
     }
 
-    private function link(SecurityToken $token, PrePersistEventArgs | PreUpdateEventArgs $args): void
+    private function link(#[SensitiveParameter] SecurityToken $token, PrePersistEventArgs | PreUpdateEventArgs $args): void
     {
         $details = $token->getDetails();
 

--- a/src/SaasBundle/Command/DowngradeExpiredTrialsCommand.php
+++ b/src/SaasBundle/Command/DowngradeExpiredTrialsCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use SolidInvoice\SaasBundle\Message\SendTrialDowngradedEmailMessage;
+use SolidWorx\Platform\PlatformBundle\Console\Command;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+use Throwable;
+use function assert;
+use function count;
+use function function_exists;
+use function Sentry\captureException;
+use function sprintf;
+
+#[AsCommand(
+    name: 'solidinvoice:saas:downgrade-expired-trials',
+    description: 'Downgrade subscriptions whose trial has expired to the free plan',
+)]
+#[AsCronTask(expression: '#hourly', schedule: 'downgrade_expired_trials')]
+final class DowngradeExpiredTrialsCommand extends Command
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly SubscriptionRepositoryInterface $subscriptionRepository,
+        private readonly SubscriptionManager $subscriptionManager,
+        private readonly MessageBusInterface $bus,
+        private readonly ClockInterface $clock,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'List the trials that would be downgraded without changing anything.');
+    }
+
+    protected function handle(): int
+    {
+        $dryRun = (bool) $this->io->getOption('dry-run');
+
+        $entityManager = $this->registry->getManagerForClass(Subscription::class);
+        assert($entityManager instanceof EntityManagerInterface);
+
+        // Trials span companies; suspend the CompanyFilter for the scan so the
+        // query sees every tenant's subscriptions. suspend()/restore() preserves
+        // the filter's companyId — disable()/enable() would drop it.
+        $filters = $entityManager->getFilters();
+        $companyFilterEnabled = $filters->isEnabled('company');
+
+        if ($companyFilterEnabled) {
+            $filters->suspend('company');
+        }
+
+        $downgraded = 0;
+        $failed = 0;
+
+        try {
+            $expiredTrials = $this->subscriptionRepository->findExpiredTrials($this->clock->now());
+
+            if ($dryRun) {
+                $rows = [];
+
+                foreach ($expiredTrials as $subscription) {
+                    $rows[] = [
+                        $subscription->getId()->toBase58(),
+                        $subscription->getPlan()->getName(),
+                        $subscription->getEndDate()->format('Y-m-d H:i:s'),
+                    ];
+                }
+
+                $this->io->table(['Subscription', 'Plan', 'Trial ended'], $rows);
+                $this->io->note(sprintf('[dry-run] %d expired trial(s) would be downgraded to the free plan.', count($rows)));
+
+                return self::SUCCESS;
+            }
+
+            foreach ($expiredTrials as $subscription) {
+                try {
+                    $this->subscriptionManager->downgradeToFree($subscription);
+                    $this->bus->dispatch(new SendTrialDowngradedEmailMessage($subscription->getId()));
+                    ++$downgraded;
+                } catch (Throwable $e) {
+                    ++$failed;
+
+                    if (function_exists('Sentry\\captureException')) {
+                        captureException($e);
+                    }
+
+                    $this->logger->error('Failed to auto-downgrade expired trial', [
+                        'subscription_id' => $subscription->getId()->toBase58(),
+                        'exception' => $e->getMessage(),
+                    ]);
+                }
+            }
+        } finally {
+            if ($companyFilterEnabled) {
+                $filters->restore('company');
+            }
+        }
+
+        $this->io->success(sprintf('Downgraded %d expired trial(s) to the free plan (%d failed).', $downgraded, $failed));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/SaasBundle/Email/TrialDowngradedEmail.php
+++ b/src/SaasBundle/Email/TrialDowngradedEmail.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Email;
+
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @see \SolidInvoice\SaasBundle\Tests\Email\TrialDowngradedEmailTest
+ */
+final class TrialDowngradedEmail extends TemplatedEmail
+{
+    public function __construct(User $user, Company $company, TranslatorInterface $translator)
+    {
+        parent::__construct();
+
+        $this->to(Address::create((string) $user->getEmail()));
+        $this->subject($translator->trans('trial_downgraded.subject', [], 'email'));
+        $this->htmlTemplate('@SolidInvoiceSaas/Email/trial_downgraded.html.twig');
+        $this->textTemplate('@SolidInvoiceSaas/Email/trial_downgraded.txt.twig');
+        $this->context([
+            'user' => $user,
+            'company' => $company,
+        ]);
+    }
+}

--- a/src/SaasBundle/Message/SendTrialDowngradedEmailMessage.php
+++ b/src/SaasBundle/Message/SendTrialDowngradedEmailMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Message;
+
+use Symfony\Component\Uid\Ulid;
+
+final readonly class SendTrialDowngradedEmailMessage
+{
+    public function __construct(
+        public Ulid $subscriptionId,
+    ) {
+    }
+}

--- a/src/SaasBundle/MessageHandler/SendTrialDowngradedEmailHandler.php
+++ b/src/SaasBundle/MessageHandler/SendTrialDowngradedEmailHandler.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\MessageHandler;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\SaasBundle\Email\TrialDowngradedEmail;
+use SolidInvoice\SaasBundle\Message\SendTrialDowngradedEmailMessage;
+use SolidInvoice\SettingsBundle\SystemConfig;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Entity\Trial;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsMessageHandler]
+final readonly class SendTrialDowngradedEmailHandler
+{
+    public function __construct(
+        private ManagerRegistry $registry,
+        private CompanySelector $companySelector,
+        private MailerInterface $mailer,
+        private SystemConfig $systemConfig,
+        private TranslatorInterface $translator,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SendTrialDowngradedEmailMessage $message): void
+    {
+        // Clear tenant scope up front and guarantee it's reset on every exit
+        // path so a skipped message never leaves the worker unscoped.
+        $this->companySelector->reset();
+
+        try {
+            $manager = $this->registry->getManagerForClass(Subscription::class);
+            $subscription = $manager?->find(Subscription::class, $message->subscriptionId);
+
+            if (! $subscription instanceof Subscription) {
+                $this->logger->warning('Trial-downgraded email skipped: subscription not found', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                ]);
+                return;
+            }
+
+            $trial = $manager->getRepository(Trial::class)->findOneBy(['subscription' => $subscription]);
+
+            if (! $trial instanceof Trial) {
+                $this->logger->warning('Trial-downgraded email skipped: no trial for subscription', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                ]);
+                return;
+            }
+
+            $user = $trial->getUser();
+
+            if (! $user instanceof User) {
+                $this->logger->warning('Trial-downgraded email skipped: trial owner is not a User', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                ]);
+                return;
+            }
+
+            $company = $subscription->getSubscriber();
+
+            if (! $company instanceof Company) {
+                $this->logger->warning('Trial-downgraded email skipped: subscriber is not a Company', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                ]);
+                return;
+            }
+
+            $this->companySelector->switchCompany($company->getId());
+
+            $email = new TrialDowngradedEmail($user, $company, $this->translator);
+
+            $fromAddress = $this->systemConfig->get('email/from_address');
+            $fromName = $this->systemConfig->get('email/from_name');
+
+            if ($fromAddress !== null && $fromAddress !== '') {
+                $email->from(new Address($fromAddress, $fromName ?? ''));
+            }
+
+            try {
+                $this->mailer->send($email);
+
+                $this->logger->info('Sent trial-downgraded email', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                    'user_id' => $user->getId()?->toString(),
+                ]);
+            } catch (TransportExceptionInterface $e) {
+                $this->logger->error('Failed to send trial-downgraded email', [
+                    'subscription_id' => $message->subscriptionId->toBase58(),
+                    'exception' => $e->getMessage(),
+                ]);
+
+                // Re-throw so Messenger retries with its exponential backoff.
+                throw $e;
+            }
+        } finally {
+            $this->companySelector->reset();
+        }
+    }
+}

--- a/src/SaasBundle/Resources/views/Email/trial_downgraded.html.twig
+++ b/src/SaasBundle/Resources/views/Email/trial_downgraded.html.twig
@@ -1,0 +1,61 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+
+{% extends "@SolidInvoiceCore/Layout/Email/notification.html.twig" %}
+{% import "@SolidInvoiceCore/Layout/Email/components.html.twig" as email %}
+
+{%- block title -%}
+    {{ 'trial_downgraded.heading'|trans({}, 'email') }}
+{%- endblock -%}
+
+{%- block content -%}
+    {% apply inky_to_html %}
+        <row>
+            <columns>
+                <p style="color: #1e293b; font-size: 16px; line-height: 1.5; margin: 0 0 16px 0; Margin: 0 0 16px 0;">
+                    {{ 'trial_downgraded.greeting'|trans({}, 'email') }}
+                </p>
+                <p style="color: #1e293b; font-size: 16px; line-height: 1.5; margin: 0 0 16px 0; Margin: 0 0 16px 0;">
+                    {{ 'trial_downgraded.intro'|trans({}, 'email') }}
+                </p>
+                <p style="color: #1e293b; font-size: 16px; line-height: 1.5; margin: 0; Margin: 0;">
+                    {{ 'trial_downgraded.body'|trans({}, 'email') }}
+                </p>
+            </columns>
+        </row>
+    {% endapply %}
+
+    {{ email.spacer('md') }}
+
+    {% apply inky_to_html %}
+        <row>
+            <columns>
+                <p style="color: #626976; font-size: 15px; line-height: 1.5; margin: 0; Margin: 0;">
+                    {{ 'trial_downgraded.upsell'|trans({}, 'email') }}
+                </p>
+            </columns>
+        </row>
+    {% endapply %}
+
+    {{ email.spacer('md') }}
+
+    {{ email.button('trial_downgraded.cta'|trans({}, 'email'), url('saas_subscription_plans'), 'primary', 'large') }}
+
+    {{ email.spacer('md') }}
+
+    {% apply inky_to_html %}
+        <row>
+            <columns>
+                <p style="color: #626976; font-size: 14px; line-height: 1.5; margin: 0; Margin: 0;">
+                    {{ 'trial_downgraded.closing'|trans({}, 'email') }}
+                </p>
+            </columns>
+        </row>
+    {% endapply %}
+{%- endblock -%}

--- a/src/SaasBundle/Resources/views/Email/trial_downgraded.txt.twig
+++ b/src/SaasBundle/Resources/views/Email/trial_downgraded.txt.twig
@@ -1,0 +1,29 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #}
+{{ 'trial_downgraded.heading'|trans({}, 'email') }}
+{{ '='|repeat(60) }}
+
+{% autoescape false -%}
+{{ 'trial_downgraded.greeting'|trans({}, 'email') }}
+
+{{ 'trial_downgraded.intro'|trans({}, 'email') }}
+
+{{ 'trial_downgraded.body'|trans({}, 'email') }}
+
+{{ 'trial_downgraded.upsell'|trans({}, 'email') }}
+
+{{ '-'|repeat(60) }}
+
+{{ 'trial_downgraded.cta'|trans({}, 'email') }}:
+{{ url('saas_subscription_plans') }}
+
+{{ '-'|repeat(60) }}
+
+{{ 'trial_downgraded.closing'|trans({}, 'email') }}
+{%- endautoescape -%}

--- a/src/SaasBundle/Security/Voter/SubscriptionVoter.php
+++ b/src/SaasBundle/Security/Voter/SubscriptionVoter.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\SaasBundle\Security\Voter;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\Attribute as ApiAttribute;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
@@ -63,7 +64,7 @@ final class SubscriptionVoter extends Voter
         return $attribute === McpAttribute::ACCESS || $attribute === ApiAttribute::ACCESS;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, #[SensitiveParameter] TokenInterface $token, ?Vote $vote = null): bool
     {
         try {
             // Without a resolved company we can't check the subscription state. Fail closed

--- a/src/SaasBundle/Tests/Email/TrialDowngradedEmailTest.php
+++ b/src/SaasBundle/Tests/Email/TrialDowngradedEmailTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Email;
+
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\SaasBundle\Email\TrialDowngradedEmail;
+use SolidInvoice\UserBundle\Entity\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TrialDowngradedEmailTest extends TestCase
+{
+    public function testEmailIsAddressedToTheUserWithTheExpectedTemplates(): void
+    {
+        $user = new User()->setEmail('owner@example.com');
+        $company = new Company()->setName('Acme');
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('You are all set on SolidInvoice');
+
+        $email = new TrialDowngradedEmail($user, $company, $translator);
+
+        self::assertSame('@SolidInvoiceSaas/Email/trial_downgraded.html.twig', $email->getHtmlTemplate());
+        self::assertSame('@SolidInvoiceSaas/Email/trial_downgraded.txt.twig', $email->getTextTemplate());
+        self::assertSame('You are all set on SolidInvoice', $email->getSubject());
+        self::assertSame('owner@example.com', $email->getTo()[0]->getAddress());
+    }
+}

--- a/src/SaasBundle/Tests/Functional/DowngradeExpiredTrialsCommandTest.php
+++ b/src/SaasBundle/Tests/Functional/DowngradeExpiredTrialsCommandTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Carbon\CarbonImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\SaasBundle\Command\DowngradeExpiredTrialsCommand;
+use SolidInvoice\SaasBundle\Message\SendTrialDowngradedEmailMessage;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\PlatformBundle\Console\IO;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Entity\Trial;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Verifies the hourly downgrade-expired-trials command flips an expired trial
+ * subscription to the free plan + ACTIVE and queues exactly one notification
+ * email, leaves a not-yet-expired trial untouched, and that --dry-run reports
+ * without changing any state or queuing any message.
+ */
+#[Group('functional')]
+final class DowngradeExpiredTrialsCommandTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+
+    private function seedFreePlan(EntityManagerInterface $em): Plan
+    {
+        $free = new Plan()->setName('Free')->setPlanId('0')->setPrice(0)->setActive(true)->setDefault(true);
+        $em->persist($free);
+
+        return $free;
+    }
+
+    private function seedTrial(EntityManagerInterface $em, Plan $plan, string $endDate, ?string $subscriptionId = null): Subscription
+    {
+        $user = UserFactory::createOne(['companies' => [$this->company]]);
+        self::assertInstanceOf(User::class, $user);
+
+        $subscription = new Subscription()
+            ->setSubscriber($this->company)
+            ->setPlan($plan)
+            ->setStatus(SubscriptionStatus::TRIAL)
+            ->setStartDate(CarbonImmutable::now()->subMonth())
+            ->setEndDate(CarbonImmutable::parse($endDate))
+            ->setSubscriptionId($subscriptionId);
+        $em->persist($subscription);
+        $em->persist(Trial::create($user, $subscription));
+
+        return $subscription;
+    }
+
+    /**
+     * @param array<string, bool> $options
+     */
+    private function executeDowngradeCommand(array $options = []): void
+    {
+        $command = self::getContainer()->get(DowngradeExpiredTrialsCommand::class);
+
+        $input = new ArrayInput($options);
+        $input->bind($command->getDefinition());
+
+        $output = new BufferedOutput();
+        $command->setIo(new IO($input, $output));
+
+        $tester = new CommandTester($command);
+        $tester->execute($options);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /** @return list<object> */
+    private function drainAsync(): array
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        $messages = [];
+        foreach ($transport->get() as $envelope) {
+            $messages[] = $envelope->getMessage();
+            $transport->ack($envelope);
+        }
+
+        return $messages;
+    }
+
+    public function testExpiredTrialIsDowngradedAndEmailQueued(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // The kernel reboot above leaves $this->company (persisted by the
+        // EnsureApplicationInstalled `#[Before]` hook against the previous
+        // kernel's EntityManager) unknown to the new EntityManager's unit of
+        // work. Re-fetch it so Doctrine treats it as managed rather than a
+        // new, uncascaded entity when it's attached to the Subscription.
+        $company = $em->getRepository(Company::class)->find($this->company->getId());
+        self::assertInstanceOf(Company::class, $company);
+        $this->company = $company;
+
+        $free = $this->seedFreePlan($em);
+        $paid = new Plan()->setName('Pro')->setPlanId('pro')->setPrice(1900)->setActive(true);
+        $em->persist($paid);
+
+        $expired = $this->seedTrial($em, $paid, '-1 day');
+        $active = $this->seedTrial($em, $paid, '+5 days');
+        $em->flush();
+
+        $this->executeDowngradeCommand();
+
+        $em->refresh($expired);
+        $em->refresh($active);
+
+        self::assertSame(SubscriptionStatus::ACTIVE, $expired->getStatus());
+        self::assertTrue($expired->getPlan()->isFree());
+
+        self::assertSame(SubscriptionStatus::TRIAL, $active->getStatus());
+        self::assertFalse($active->getPlan()->isFree());
+
+        $messages = $this->drainAsync();
+        self::assertCount(1, $messages);
+        self::assertInstanceOf(SendTrialDowngradedEmailMessage::class, $messages[0]);
+        self::assertTrue($expired->getId()->equals($messages[0]->subscriptionId));
+    }
+
+    public function testDryRunChangesNothing(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // See the comment in testExpiredTrialIsDowngradedAndEmailQueued() above.
+        $company = $em->getRepository(Company::class)->find($this->company->getId());
+        self::assertInstanceOf(Company::class, $company);
+        $this->company = $company;
+
+        $this->seedFreePlan($em);
+        $paid = new Plan()->setName('Pro')->setPlanId('pro')->setPrice(1900)->setActive(true);
+        $em->persist($paid);
+        $expired = $this->seedTrial($em, $paid, '-1 day');
+        $em->flush();
+
+        $this->executeDowngradeCommand(['--dry-run' => true]);
+
+        $em->refresh($expired);
+        self::assertSame(SubscriptionStatus::TRIAL, $expired->getStatus());
+        self::assertFalse($expired->getPlan()->isFree());
+        self::assertCount(0, $this->drainAsync());
+    }
+
+    public function testExternallyBilledExpiredTrialIsSkipped(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // See the comment in testExpiredTrialIsDowngradedAndEmailQueued() above.
+        $company = $em->getRepository(Company::class)->find($this->company->getId());
+        self::assertInstanceOf(Company::class, $company);
+        $this->company = $company;
+
+        $this->seedFreePlan($em);
+        $paid = new Plan()->setName('Pro')->setPlanId('pro')->setPrice(1900)->setActive(true);
+        $em->persist($paid);
+
+        // Provider-backed trial (a card on file): must never be auto-downgraded
+        // locally, since that would leave the customer being billed externally
+        // while sitting on the Free plan.
+        $externallyBilled = $this->seedTrial($em, $paid, '-1 day', 'ext_test_123');
+        $em->flush();
+
+        $this->executeDowngradeCommand();
+
+        $em->refresh($externallyBilled);
+        self::assertSame(SubscriptionStatus::TRIAL, $externallyBilled->getStatus());
+        self::assertFalse($externallyBilled->getPlan()->isFree());
+
+        self::assertCount(0, $this->drainAsync());
+    }
+
+    /**
+     * Regression test for a DQL operator-precedence bug: the `andWhere("s.subscriptionId
+     * IS NULL OR s.subscriptionId = ''")` clause in {@see SubscriptionRepository::findExpiredTrials()}
+     * must group the OR in parentheses. Doctrine's Andx joins andWhere() parts with a bare
+     * " AND " and does not parenthesize them, so without the grouping the generated WHERE
+     * becomes `(s.status = :status AND s.endDate <= :now AND s.subscriptionId IS NULL) OR
+     * s.subscriptionId = ''`, which would match ANY subscription with an empty-string
+     * subscriptionId regardless of status or endDate.
+     */
+    public function testActiveSubscriptionWithEmptySubscriptionIdIsNotDowngraded(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // See the comment in testExpiredTrialIsDowngradedAndEmailQueued() above.
+        $company = $em->getRepository(Company::class)->find($this->company->getId());
+        self::assertInstanceOf(Company::class, $company);
+        $this->company = $company;
+
+        $this->seedFreePlan($em);
+        $paid = new Plan()->setName('Pro')->setPlanId('pro')->setPrice(1900)->setActive(true);
+        $em->persist($paid);
+
+        $subscription = new Subscription()
+            ->setSubscriber($this->company)
+            ->setPlan($paid)
+            ->setStatus(SubscriptionStatus::ACTIVE)
+            ->setSubscriptionId('')
+            ->setStartDate(CarbonImmutable::now()->subMonth())
+            ->setEndDate(CarbonImmutable::parse('-1 day'));
+        $em->persist($subscription);
+        $em->flush();
+
+        $this->executeDowngradeCommand();
+
+        $em->refresh($subscription);
+        self::assertSame(SubscriptionStatus::ACTIVE, $subscription->getStatus());
+        self::assertFalse($subscription->getPlan()->isFree());
+
+        self::assertCount(0, $this->drainAsync());
+    }
+}

--- a/src/SaasBundle/Tests/Functional/SendTrialDowngradedEmailHandlerTest.php
+++ b/src/SaasBundle/Tests/Functional/SendTrialDowngradedEmailHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Functional;
+
+use Carbon\CarbonImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use SolidInvoice\SaasBundle\Message\SendTrialDowngradedEmailMessage;
+use SolidInvoice\SaasBundle\MessageHandler\SendTrialDowngradedEmailHandler;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidInvoice\UserBundle\Test\Factory\UserFactory;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Entity\Trial;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mime\Email;
+use Zenstruck\Foundry\Test\Factories;
+use function array_filter;
+use function array_values;
+
+/**
+ * Verifies that invoking the handler with a persisted subscription + trial
+ * sends exactly one email, addressed to the trial owner, whose body does not
+ * use loss-framing language (e.g. "lost access").
+ */
+#[Group('functional')]
+final class SendTrialDowngradedEmailHandlerTest extends WebTestCase
+{
+    use EnsureApplicationInstalled;
+    use Factories;
+    use MailerAssertionsTrait;
+
+    public function testSendsEmailToTheTrialOwner(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        // The kernel reboot above leaves $this->company (persisted by the
+        // EnsureApplicationInstalled `#[Before]` hook against the previous
+        // kernel's EntityManager) unknown to the new EntityManager's unit of
+        // work. Re-fetch it so Doctrine treats it as managed rather than a
+        // new, uncascaded entity when it's attached to the Subscription.
+        $company = $em->getRepository(Company::class)->find($this->company->getId());
+        self::assertInstanceOf(Company::class, $company);
+
+        $free = new Plan()->setName('Free')->setPlanId('0')->setPrice(0)->setActive(true)->setDefault(true);
+        $em->persist($free);
+
+        $user = UserFactory::createOne(['companies' => [$company]]);
+        self::assertInstanceOf(User::class, $user);
+
+        $subscription = new Subscription()
+            ->setSubscriber($company)
+            ->setPlan($free)
+            ->setStatus(SubscriptionStatus::ACTIVE)
+            ->setStartDate(CarbonImmutable::now())
+            ->setEndDate(CarbonImmutable::now()->addYears(100));
+        $em->persist($subscription);
+
+        $em->persist(Trial::create($user, $subscription));
+        $em->flush();
+
+        $handler = self::getContainer()->get(SendTrialDowngradedEmailHandler::class);
+        ($handler)(new SendTrialDowngradedEmailMessage($subscription->getId()));
+
+        // The app's mailer is wired to the default Messenger bus (see
+        // config/packages/mailer.php — no `message_bus: false` override), so
+        // Mailer::send() always fires a "queued" MessageEvent up front, in
+        // addition to the "sent" one recorded once the (synchronous, since
+        // SendEmailMessage isn't routed to an async transport) handler
+        // actually hands the message to the transport. Assert on the "sent"
+        // side to verify the handler delivered exactly one real email.
+        self::assertEmailCount(1);
+
+        $sentEvents = array_values(array_filter(
+            self::getMailerEvents(),
+            static fn (MessageEvent $event): bool => ! $event->isQueued(),
+        ));
+        self::assertCount(1, $sentEvents);
+
+        $message = $sentEvents[0]->getMessage();
+        self::assertInstanceOf(Email::class, $message);
+        self::assertEmailAddressContains($message, 'To', (string) $user->getEmail());
+        self::assertStringNotContainsStringIgnoringCase('lost access', (string) $message->getHtmlBody());
+    }
+}

--- a/src/UserBundle/Action/ForgotPassword/Reset.php
+++ b/src/UserBundle/Action/ForgotPassword/Reset.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\UserBundle\Action\ForgotPassword;
 
 use Doctrine\Persistence\ManagerRegistry;
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\Form\Type\ChangePasswordFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -38,7 +39,7 @@ final class Reset extends AbstractController
     ) {
     }
 
-    public function __invoke(Request $request, ?string $token = null): Response
+    public function __invoke(Request $request, #[SensitiveParameter] ?string $token = null): Response
     {
         if ($token) {
             // We store the token in session and remove it from the URL, to avoid the URL being

--- a/src/UserBundle/DataGrid/ApiTokenGrid.php
+++ b/src/UserBundle/DataGrid/ApiTokenGrid.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\DataGrid;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Override;
+use SensitiveParameter;
 use SolidInvoice\DataGridBundle\Attributes\AsDataGrid;
 use SolidInvoice\DataGridBundle\Grid;
 use SolidInvoice\DataGridBundle\GridBuilder\Action\Action;
@@ -67,12 +68,12 @@ final class ApiTokenGrid extends Grid
                 ->label('Usage Count')
                 ->searchable(false)
                 ->sortable(false)
-                ->formatValue(static fn ($value, ApiToken $token) => $token->getUsageCount()),
+                ->formatValue(static fn ($value, #[SensitiveParameter] ApiToken $token) => $token->getUsageCount()),
             RelativeDateColumn::new('lastUsed')
                 ->label('Last Used')
                 ->searchable(false)
                 ->sortable(false)
-                ->formatValue(static function ($value, ApiToken $token) {
+                ->formatValue(static function ($value, #[SensitiveParameter] ApiToken $token) {
                     $history = $token->getHistory();
                     return $history->count() > 0 ? $history->first()->getCreated() : null;
                 }),

--- a/src/UserBundle/Email/ResetPasswordEmail.php
+++ b/src/UserBundle/Email/ResetPasswordEmail.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Email;
 
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
@@ -21,6 +22,7 @@ final class ResetPasswordEmail extends TemplatedEmail
 {
     public function __construct(
         User $user,
+        #[SensitiveParameter]
         ResetPasswordToken $resetToken,
     ) {
         parent::__construct();

--- a/src/UserBundle/Entity/ApiToken.php
+++ b/src/UserBundle/Entity/ApiToken.php
@@ -22,6 +22,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\State\Provider\ApiTokenCollectionProvider;
 use SolidInvoice\ApiBundle\State\Provider\ApiTokenItemProvider;
 use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
@@ -125,7 +126,7 @@ class ApiToken
         return $this->token;
     }
 
-    public function setToken(string $token): self
+    public function setToken(#[SensitiveParameter] string $token): self
     {
         $this->token = $token;
 

--- a/src/UserBundle/Entity/ApiTokenHistory.php
+++ b/src/UserBundle/Entity/ApiTokenHistory.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Doctrine\Type\ArrayType;
 use SolidInvoice\CoreBundle\Export\Attribute\ExportIgnore;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
@@ -139,7 +140,7 @@ class ApiTokenHistory
         return $this->token;
     }
 
-    public function setToken(ApiToken $token): self
+    public function setToken(#[SensitiveParameter] ApiToken $token): self
     {
         $this->token = $token;
 

--- a/src/UserBundle/Entity/ResetPasswordRequest.php
+++ b/src/UserBundle/Entity/ResetPasswordRequest.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Entity;
 
 use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Repository\ResetPasswordRequestRepository;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\Types\UlidType;
@@ -40,6 +41,7 @@ class ResetPasswordRequest implements ResetPasswordRequestInterface
         private ?User $user,
         DateTimeInterface $expiresAt,
         string $selector,
+        #[SensitiveParameter]
         string $hashedToken
     ) {
         $this->initialize($expiresAt, $selector, $hashedToken);

--- a/src/UserBundle/Repository/ApiTokenHistoryRepository.php
+++ b/src/UserBundle/Repository/ApiTokenHistoryRepository.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Repository;
 
 use Doctrine\Common\Collections\Order;
 use Doctrine\Persistence\ManagerRegistry;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\ApiTokenHasher;
 use SolidInvoice\UserBundle\Entity\ApiToken;
 use SolidInvoice\UserBundle\Entity\ApiTokenHistory;
@@ -33,7 +34,7 @@ class ApiTokenHistoryRepository extends EntityRepository
         parent::__construct($registry, ApiTokenHistory::class);
     }
 
-    public function addHistory(ApiTokenHistory $history, string $plaintextToken): void
+    public function addHistory(ApiTokenHistory $history, #[SensitiveParameter] string $plaintextToken): void
     {
         $entityManager = $this->getEntityManager();
 
@@ -75,7 +76,7 @@ class ApiTokenHistoryRepository extends EntityRepository
     /**
      * @return iterable<int, ApiTokenHistory>
      */
-    public function getHistoryForToken(ApiToken $apiToken): iterable
+    public function getHistoryForToken(#[SensitiveParameter] ApiToken $apiToken): iterable
     {
         return $this->createQueryBuilder('h')
             ->where('h.token = :token')

--- a/src/UserBundle/Repository/ApiTokenRepository.php
+++ b/src/UserBundle/Repository/ApiTokenRepository.php
@@ -18,6 +18,7 @@ use DateTimeInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
+use SensitiveParameter;
 use SolidInvoice\ApiBundle\Security\ApiTokenHasher;
 use SolidInvoice\UserBundle\Entity\ApiToken;
 use SolidInvoice\UserBundle\Entity\ApiTokenHistory;
@@ -46,7 +47,7 @@ class ApiTokenRepository extends EntityRepository
      * Looks up the username for a given plaintext API token. The token is
      * hashed before the query so the database only ever sees the hash.
      */
-    public function getUsernameForToken(string $plaintextToken): ?string
+    public function getUsernameForToken(#[SensitiveParameter] string $plaintextToken): ?string
     {
         $q = $this
             ->createQueryBuilder('t')
@@ -68,7 +69,7 @@ class ApiTokenRepository extends EntityRepository
      * Finds an ApiToken entity by its plaintext value. Returns null when no
      * matching token exists.
      */
-    public function findOneByPlaintext(string $plaintextToken): ?ApiToken
+    public function findOneByPlaintext(#[SensitiveParameter] string $plaintextToken): ?ApiToken
     {
         return $this->findOneBy(['token' => $this->hasher->hash($plaintextToken)]);
     }
@@ -100,7 +101,7 @@ class ApiTokenRepository extends EntityRepository
 
         $historyMap = array_combine(array_column($history, 'token_id'), $history);
 
-        return array_map(static fn (array $token) => [
+        return array_map(static fn (#[SensitiveParameter] array $token) => [
             'id' => $token['id'],
             'name' => $token['name'],
             'ip' => $historyMap[$token['id']->toBinary()]['ip'] ?? null,
@@ -108,7 +109,7 @@ class ApiTokenRepository extends EntityRepository
         ], $tokens);
     }
 
-    public function revoke(ApiToken $token): void
+    public function revoke(#[SensitiveParameter] ApiToken $token): void
     {
         $em = $this->getEntityManager();
 

--- a/src/UserBundle/Repository/ResetPasswordRequestRepository.php
+++ b/src/UserBundle/Repository/ResetPasswordRequestRepository.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Repository;
 
 use DateTimeInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\ResetPasswordRequest;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
@@ -80,7 +81,7 @@ class ResetPasswordRequestRepository extends EntityRepository implements ResetPa
     /**
      * @param User $user
      */
-    public function createResetPasswordRequest(object $user, DateTimeInterface $expiresAt, string $selector, string $hashedToken): ResetPasswordRequestInterface
+    public function createResetPasswordRequest(object $user, DateTimeInterface $expiresAt, string $selector, #[SensitiveParameter] string $hashedToken): ResetPasswordRequestInterface
     {
         return new ResetPasswordRequest($user, $expiresAt, $selector, $hashedToken);
     }

--- a/src/UserBundle/Security/OAuth/OAuthAuthenticator.php
+++ b/src/UserBundle/Security/OAuth/OAuthAuthenticator.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\UserBundle\Security\OAuth;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Action\Security\OAuthConnectCheck;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\OAuth\OAuthUser;
@@ -102,7 +103,7 @@ final class OAuthAuthenticator extends OAuth2Authenticator implements Authentica
         );
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    public function onAuthenticationSuccess(Request $request, #[SensitiveParameter] TokenInterface $token, string $firewallName): ?Response
     {
         $targetUrl = $this->router->generate('_select_company');
 

--- a/src/UserBundle/Security/Turnstile/TurnstileVerifier.php
+++ b/src/UserBundle/Security/Turnstile/TurnstileVerifier.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Security\Turnstile;
 
+use SensitiveParameter;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
@@ -40,7 +41,7 @@ final readonly class TurnstileVerifier
      * Returns true when the feature is disabled (never blocks), otherwise validates the token
      * against Cloudflare and fails closed on any missing data or transport error.
      */
-    public function verify(?string $token, ?string $remoteIp): bool
+    public function verify(#[SensitiveParameter] ?string $token, ?string $remoteIp): bool
     {
         if (! $this->toggle->isActive('turnstile_captcha')) {
             return true;

--- a/src/UserBundle/Security/UserChecker.php
+++ b/src/UserBundle/Security/UserChecker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Security;
 
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\DisabledException;
@@ -37,7 +38,7 @@ class UserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
+    public function checkPostAuth(UserInterface $user, #[SensitiveParameter] ?TokenInterface $token = null): void
     {
         // No-op: disabled accounts are rejected in checkPreAuth().
     }

--- a/src/UserBundle/Security/VerifiedUserChecker.php
+++ b/src/UserBundle/Security/VerifiedUserChecker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\UserBundle\Security;
 
 use Override;
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Toggler\ToggleInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -40,7 +41,7 @@ final class VerifiedUserChecker extends UserChecker
     }
 
     #[Override]
-    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
+    public function checkPostAuth(UserInterface $user, #[SensitiveParameter] ?TokenInterface $token = null): void
     {
         parent::checkPostAuth($user, $token);
 

--- a/src/UserBundle/Tests/Functional/OnboardingFlowTest.php
+++ b/src/UserBundle/Tests/Functional/OnboardingFlowTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidInvoice\UserBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Group;
+use SensitiveParameter;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
@@ -281,7 +282,7 @@ final class OnboardingFlowTest extends WebTestCase
         ;
     }
 
-    private function createUser(string $email, string $password): User
+    private function createUser(string $email, #[SensitiveParameter] string $password): User
     {
         $user = new User();
         $user->setEmail($email);

--- a/src/UserBundle/Twig/Components/ApiTokens.php
+++ b/src/UserBundle/Twig/Components/ApiTokens.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\UserBundle\Twig\Components;
 
+use SensitiveParameter;
 use SolidInvoice\UserBundle\Entity\ApiToken;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidInvoice\UserBundle\Repository\ApiTokenRepository;
@@ -38,7 +39,7 @@ final class ApiTokens extends AbstractController
     }
 
     #[LiveAction]
-    public function revoke(#[LiveArg] ApiToken $token): void
+    public function revoke(#[SensitiveParameter] #[LiveArg] ApiToken $token): void
     {
         $currentUser = $this->security->getUser();
 

--- a/translations/email.en.yml
+++ b/translations/email.en.yml
@@ -320,3 +320,12 @@ reset_password:
     message_text: "A password reset was requested for user %username%.\n\nIf you did not request your password to be reset, you can safely ignore this message.\n\nTo reset your password, please copy and paste the below link in your browser\n\n%confirmationUrl%\n"
     security: "If you didn't request a password reset, you can safely ignore this email. Your password won't be changed."
     subject: 'Reset your password for %username%'
+trial_downgraded:
+    body: "You're now on our Free plan, so you can keep creating and sending invoices, managing your clients, and getting paid — without interruption."
+    closing: "Thanks for trying SolidInvoice — we're glad you're here."
+    cta: 'Explore plans'
+    greeting: 'Hi there,'
+    heading: "Everything's right where you left it"
+    intro: "Your SolidInvoice trial has come to an end, and there's nothing you need to do — your account, your clients, and every invoice you've created are exactly where you left them."
+    subject: "You're all set on SolidInvoice"
+    upsell: 'Growing fast and want more? Recurring invoices, extra team members, and advanced reporting are just a click away. Upgrading takes about a minute, and you can switch back whenever you like.'


### PR DESCRIPTION
## Summary

Adds an hourly scheduled command that automatically downgrades **expired trial subscriptions** to the Free plan, so users are never stopped at the "trial expired" wall — their next visit just works, on Free. When a trial is auto-downgraded, the trial owner gets a reassuring soft-upsell email.

Everything lives in `src/SaasBundle` (SaaS-only — the bundle only loads when `SOLIDINVOICE_PLATFORM=saas`). **No database migration.**

## What's included

- **`DowngradeExpiredTrialsCommand`** — `#[AsCronTask('#hourly')]`, with a `--dry-run` flag. Suspends the tenant (`company`) filter for the cross-tenant scan, downgrades each expired trial via `SubscriptionManager::downgradeToFree()`, and dispatches an async email. Per-row `try/catch` + Sentry so one bad row never aborts the batch.
- **`SendTrialDowngradedEmailMessage` + `SendTrialDowngradedEmailHandler`** — sends the notice out-of-band (async) to the **trial owner**, mirroring the onboarding-email handler (company-scope reset/switch, retry on transport failure).
- **`TrialDowngradedEmail`** + HTML/text templates + EN copy — a reassuring soft-upsell with **no loss framing** and one low-pressure "Explore plans" CTA. Copy crafted with the marketing emails skill.
- Async routing for the new message; EN translation source keys added (FR is left to Crowdin, per repo convention).

## Idempotency & safety

- Detection: `status = TRIAL AND endDate <= now` and **not externally-billed**. The downgrade flips status to `ACTIVE`, so a processed trial is never re-selected — naturally idempotent, no flag/column, no migration.
- Externally-billed (`on_trial`-webhook) trials are excluded from the scan, so provider billing is never silently bypassed.
- Reuses the platform's existing free-plan downgrade semantics; never touches the payment integration for in-app trials.

## Depends on

**SolidWorx/platform#141** — adds `PlanRepository::findFree()`, `SubscriptionRepository::findExpiredTrials()`, `SubscriptionManager::downgradeToFree()` + `NoFreePlanConfiguredException`. Merge that and `composer update solidworx/platform` before/with this.

## Testing

- Functional (`DowngradeExpiredTrialsCommandTest`): expired trial → downgraded to Free + one async message; not-yet-expired trial untouched; externally-billed trial skipped; active empty-id row skipped; `--dry-run` mutates and dispatches nothing. 4 methods / 28 assertions.
- Functional (`SendTrialDowngradedEmailHandlerTest`): the email is addressed to the trial owner and contains no loss-framing.
- ECS + PHPStan (Level 6) clean. `debug:scheduler` lists `downgrade_expired_trials`.

## ⚠️ Before enabling in production

A dry-run against a dev DB reported **~315 backlog trials**. The first real run downgrades all of them and emails every owner at once (some long-dormant). Consider throttling, or suppressing very-old expirations, before turning the cron on — a policy choice, not a code defect.
