### PR TITLE
Fix uninitialized $recurringOptions crashing recurring invoice grid (#2582)

### DIFF
--- a/src/InvoiceBundle/Entity/RecurringInvoice.php
+++ b/src/InvoiceBundle/Entity/RecurringInvoice.php
@@ -329,6 +329,10 @@ class RecurringInvoice extends BaseInvoice
 
     public function getRecurringOptions(): RecurringOptions
     {
+        if (! isset($this->recurringOptions)) {
+            $this->setRecurringOptions(new RecurringOptions());
+        }
+
         return $this->recurringOptions;
     }
 

--- a/src/InvoiceBundle/Tests/Entity/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Entity/RecurringInvoiceTest.php
@@ -16,8 +16,10 @@ namespace SolidInvoice\InvoiceBundle\Tests\Entity;
 use Carbon\CarbonImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
+use SolidInvoice\InvoiceBundle\Entity\RecurringOptions;
 
 #[CoversClass(RecurringInvoice::class)]
 final class RecurringInvoiceTest extends TestCase
@@ -72,5 +74,35 @@ final class RecurringInvoiceTest extends TestCase
 
         self::assertTrue($recurringInvoice->hasInvoiceForDay(CarbonImmutable::parse('2024-01-16 23:59:59')));
         self::assertFalse($recurringInvoice->hasInvoiceForDay(CarbonImmutable::parse('2024-01-18 00:00:00')));
+    }
+
+    public function testGetRecurringOptionsInitializesWhenBypassingConstructor(): void
+    {
+        // Simulate Doctrine's entity hydration which bypasses the constructor
+        $recurringInvoice = (new ReflectionClass(RecurringInvoice::class))->newInstanceWithoutConstructor();
+
+        $options = $recurringInvoice->getRecurringOptions();
+
+        self::assertInstanceOf(RecurringOptions::class, $options);
+        self::assertSame($recurringInvoice, $options->getRecurringInvoice());
+    }
+
+    public function testGetRecurringOptionsReturnsSameInstanceOnSubsequentCalls(): void
+    {
+        $recurringInvoice = (new ReflectionClass(RecurringInvoice::class))->newInstanceWithoutConstructor();
+
+        $first = $recurringInvoice->getRecurringOptions();
+        $second = $recurringInvoice->getRecurringOptions();
+
+        self::assertSame($first, $second);
+    }
+
+    public function testGetRecurringOptionsReturnsSetInstance(): void
+    {
+        $recurringInvoice = new RecurringInvoice();
+        $options = new RecurringOptions();
+        $recurringInvoice->setRecurringOptions($options);
+
+        self::assertSame($options, $recurringInvoice->getRecurringOptions());
     }
 }


### PR DESCRIPTION
Closes #2582

## Root cause

`RecurringInvoice::$recurringOptions` is a non-nullable typed property backed by a `OneToOne` (inverse/`mappedBy`) relationship. Doctrine bypasses `__construct()` when hydrating entities from the database; for inverse-side `OneToOne` associations it does not install a lazy proxy — it leaves the typed property completely uninitialized. Any call to `getRecurringOptions()` therefore throws:

```
Error: Typed property SolidInvoice\InvoiceBundle\Entity\RecurringInvoice::$recurringOptions
       must not be accessed before initialization
```

This is exactly what Sentry reported: the crash happens as soon as the recurring invoice data grid renders a row, because `BaseRecurringInvoiceGrid::columns()` calls `getRecurringOptions()` inside a `formatValue` closure.

## Fix

Added an `isset()` guard in `getRecurringOptions()` that lazy-initialises the property when it is uninitialized — using the same pattern already used by `getInvoiceTaxes()` in the same class:

```php
public function getRecurringOptions(): RecurringOptions
{
    if (! isset($this->recurringOptions)) {
        $this->setRecurringOptions(new RecurringOptions());
    }

    return $this->recurringOptions;
}
```

`setRecurringOptions()` also calls `$recurringOptions->setRecurringInvoice($this)`, so the back-reference is correctly wired up on the freshly created instance.

## Test approach

Three new unit tests added to `RecurringInvoiceTest`:

1. `testGetRecurringOptionsInitializesWhenBypassingConstructor` — creates the entity via `ReflectionClass::newInstanceWithoutConstructor()` (reproducing Doctrine's hydration path) and asserts that `getRecurringOptions()` returns a valid `RecurringOptions` instance with the back-reference set correctly. This test fails before the fix and passes after.
2. `testGetRecurringOptionsReturnsSameInstanceOnSubsequentCalls` — asserts idempotency: calling the getter twice on an uninitialized entity returns the same object.
3. `testGetRecurringOptionsReturnsSetInstance` — asserts the normal path (entity created with constructor + explicit `setRecurringOptions()`) still returns the set instance unchanged.

All 7 tests in `RecurringInvoiceTest` pass after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7qQekt9JY5G22TYBfMrzx)_