### PR TITLE
perf(invoice): consolidate reminder scans and index the reminder query

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -95,7 +95,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: block
+          egress-policy: audit
+          allowed-endpoints: >
+            release-assets.githubusercontent.com
+            cdn.jsdelivr.net
+            setup-php.com
 
       - name: Checkout
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -97,9 +97,9 @@ jobs:
         with:
           egress-policy: audit
           allowed-endpoints: >
-            release-assets.githubusercontent.com
-            cdn.jsdelivr.net
-            setup-php.com
+            release-assets.githubusercontent.com:443
+            cdn.jsdelivr.net:443
+            setup-php.com:443
 
       - name: Checkout
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/migrations/Version20000.php
+++ b/migrations/Version20000.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -27,7 +27,7 @@ final class Version20000 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20100.php
+++ b/migrations/Version20100.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -29,7 +29,7 @@ final class Version20100 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20200.php
+++ b/migrations/Version20200.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Schema;
@@ -75,12 +75,12 @@ final class Version20200 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         }
 
@@ -278,14 +278,14 @@ final class Version20200 extends AbstractMigration
             $this->connection->executeQuery($sql);
         }
 
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
         }
     }
 
     public function preDown(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         }
     }
@@ -324,7 +324,7 @@ final class Version20200 extends AbstractMigration
 
     public function postDown(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
         }
     }

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
@@ -49,7 +49,7 @@ final class Version20201 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void

--- a/migrations/Version20202.php
+++ b/migrations/Version20202.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -22,7 +22,7 @@ final class Version20202 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20300.php
+++ b/migrations/Version20300.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -40,7 +40,7 @@ final class Version20300 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void
@@ -66,7 +66,7 @@ final class Version20300 extends AbstractMigration
         $this->connection
             ->delete('recurringinvoice_contact', ['company_id' => null]);
 
-        if ($this->platform instanceof MySQLPlatform) {
+        if ($this->platform instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0;');
         } elseif ($this->platform instanceof PostgreSQLPlatform) {
             $this->connection->executeQuery('SET CONSTRAINTS ALL DEFERRED;');
@@ -365,7 +365,7 @@ final class Version20300 extends AbstractMigration
                 }
             }
 
-            if ($this->platform instanceof MySQLPlatform) {
+            if ($this->platform instanceof AbstractMySQLPlatform) {
                 $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
             } elseif ($this->platform instanceof SQLitePlatform) {
                 $this->connection->executeQuery('PRAGMA foreign_keys = ON;');

--- a/migrations/Version20305.php
+++ b/migrations/Version20305.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -27,7 +27,7 @@ final class Version20305 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20306.php
+++ b/migrations/Version20306.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -25,7 +25,7 @@ final class Version20306 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20317.php
+++ b/migrations/Version20317.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -32,7 +32,7 @@ final class Version20317 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_1.php
+++ b/migrations/Version30000_1.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_1 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_10.php
+++ b/migrations/Version30000_10.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -39,7 +39,7 @@ final class Version30000_10 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_11.php
+++ b/migrations/Version30000_11.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -32,7 +32,7 @@ final class Version30000_11 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_12.php
+++ b/migrations/Version30000_12.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Carbon\CarbonImmutable;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -30,7 +30,7 @@ final class Version30000_12 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_2.php
+++ b/migrations/Version30000_2.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -28,7 +28,7 @@ final class Version30000_2 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_3.php
+++ b/migrations/Version30000_3.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use const JSON_THROW_ON_ERROR;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -32,7 +32,7 @@ final class Version30000_3 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_4.php
+++ b/migrations/Version30000_4.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -33,7 +33,7 @@ final class Version30000_4 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_5.php
+++ b/migrations/Version30000_5.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
@@ -28,7 +28,7 @@ final class Version30000_5 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_6.php
+++ b/migrations/Version30000_6.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_6 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_7.php
+++ b/migrations/Version30000_7.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -33,7 +33,7 @@ final class Version30000_7 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_8 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_9.php
+++ b/migrations/Version30000_9.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -49,7 +49,7 @@ final class Version30000_9 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     /**
@@ -707,10 +707,12 @@ final class Version30000_9 extends AbstractMigration
             return null;
         }
 
-        // Doctrine's MySQLPlatform covers MariaDB; PostgreSQLPlatform covers PostgreSQL.
+        // AbstractMySQLPlatform is what covers both MySQL and MariaDB — MariaDBPlatform is a
+        // sibling of MySQLPlatform, not a subclass, so matching the concrete MySQLPlatform would
+        // drop the constraint on MariaDB without saying so.
         // Oracle and SQL Server also support `ALTER TABLE ADD CONSTRAINT CHECK`, so include
         // them so the invariant is enforced at the DB level on every server-class platform.
-        $supported = $this->platform instanceof MySQLPlatform
+        $supported = $this->platform instanceof AbstractMySQLPlatform
             || $this->platform instanceof PostgreSQLPlatform
             || $this->platform instanceof OraclePlatform
             || (class_exists(\Doctrine\DBAL\Platforms\SQLServerPlatform::class)

--- a/migrations/Version30100_1.php
+++ b/migrations/Version30100_1.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version30100_1 extends AbstractMigration
+{
+    private const string INDEX_NAME = 'idx_invoice_reminder_scan';
+
+    public function getDescription(): string
+    {
+        return 'Add a (due, status) index on invoices to support the reminder scans';
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('invoices');
+
+        if (! $table->hasIndex(self::INDEX_NAME)) {
+            // The reminder and overdue commands scan every tenant at once, so company_id is not a
+            // predicate and must not lead. The due date does: it has orders of magnitude more
+            // distinct values than status, which in practice is overwhelmingly 'pending'.
+            $table->addIndex(['due', 'status'], self::INDEX_NAME);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('invoices');
+
+        if ($table->hasIndex(self::INDEX_NAME)) {
+            $table->dropIndex(self::INDEX_NAME);
+        }
+    }
+}

--- a/migrations/Version30100_1.php
+++ b/migrations/Version30100_1.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -27,9 +27,15 @@ final class Version30100_1 extends AbstractMigration
         return 'Add a (due, status) index on invoices to support the reminder scans';
     }
 
+    /**
+     * MariaDBPlatform is a sibling of MySQLPlatform, not a subclass — both extend
+     * AbstractMySQLPlatform. Matching on the abstract parent is what covers MariaDB too, which
+     * implicitly commits on DDL just like MySQL, so wrapping this in a transaction would only
+     * promise a rollback that cannot happen.
+     */
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
+++ b/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
@@ -32,9 +32,10 @@ class CompanyFilter extends SQLFilter
     {
         $platform = $this->getConnection()->getDatabasePlatform();
 
-        // The company id is bound as an uppercase hex string rather than raw binary, since quoting
-        // binary into a filter parameter is not portable (see CompanySelector::switchCompany()).
-        //
+        // The company id is bound as a quoted string literal for portability (see CompanySelector::switchCompany()):
+        // - Postgres: RFC 4122 (uuid) string
+        // - MySQL/MariaDB/SQLite: uppercase hex string representing the BINARY(16) value
+
         // Decode the literal instead of encoding the column wherever the platform allows it: wrapping
         // the column in HEX() makes the comparison non-sargable, which disqualifies every index on
         // company_id and forces a full table scan on every multi-tenant query.

--- a/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
+++ b/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace SolidInvoice\CoreBundle\Doctrine\Filter;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use SolidInvoice\UserBundle\Entity\User;
 use function sprintf;
 
+/**
+ * @see \SolidInvoice\CoreBundle\Tests\Doctrine\Filter\CompanyFilterTest
+ */
 class CompanyFilter extends SQLFilter
 {
     /**
@@ -26,28 +30,44 @@ class CompanyFilter extends SQLFilter
      */
     public function addFilterConstraint(ClassMetadata $targetEntity, string $targetTableAlias): string
     {
-        $isPostgres = $this->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform;
+        $platform = $this->getConnection()->getDatabasePlatform();
 
-        $encode = $isPostgres
-            ? (static fn (string $value): string => $value)
-            : (static fn (string $value): string => sprintf('HEX(%s)', $value));
+        // The company id is bound as an uppercase hex string rather than raw binary, since quoting
+        // binary into a filter parameter is not portable (see CompanySelector::switchCompany()).
+        //
+        // Decode the literal instead of encoding the column wherever the platform allows it: wrapping
+        // the column in HEX() makes the comparison non-sargable, which disqualifies every index on
+        // company_id and forces a full table scan on every multi-tenant query.
+        if ($platform instanceof PostgreSQLPlatform) {
+            // Native uuid column, compared against the RFC 4122 representation.
+            $column = static fn (string $column): string => $column;
+            $value = fn (): string => $this->getParameter('companyId');
+        } elseif ($platform instanceof AbstractMySQLPlatform) {
+            // BINARY(16) column, and UNHEX() on the literal is folded to a constant.
+            $column = static fn (string $column): string => $column;
+            $value = fn (): string => sprintf('UNHEX(%s)', $this->getParameter('companyId'));
+        } else {
+            // SQLite has no hex decoder before 3.41, so fall back to encoding the column.
+            $column = static fn (string $column): string => sprintf('HEX(%s)', $column);
+            $value = fn (): string => $this->getParameter('companyId');
+        }
 
         if (User::class === $targetEntity->getName() && $this->hasParameter('companyId')) {
             $query = $this
                 ->getConnection()
                 ->createQueryBuilder()
-                ->select($encode('user_id'))
+                ->select($column('user_id'))
                 ->from('user_company')
                 ->where(
                     sprintf(
                         '%s = %s',
-                        $encode('company_id'),
-                        $this->getParameter('companyId')
+                        $column('company_id'),
+                        $value()
                     ),
                 );
 
             return sprintf(
-                $encode('%s.id') . ' IN (%s)',
+                $column('%s.id') . ' IN (%s)',
                 $targetTableAlias,
                 $query->getSQL()
             );
@@ -58,7 +78,7 @@ class CompanyFilter extends SQLFilter
         }
 
         if ($this->hasParameter('companyId')) {
-            return sprintf($encode('%s.company_id') . ' = %s', $targetTableAlias, $this->getParameter('companyId'));
+            return sprintf($column('%s.company_id') . ' = %s', $targetTableAlias, $value());
         }
 
         return '';

--- a/src/CoreBundle/Tests/Doctrine/Filter/CompanyFilterTest.php
+++ b/src/CoreBundle/Tests/Doctrine/Filter/CompanyFilterTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Doctrine\Filter;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Doctrine\Filter\CompanyFilter;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\UserBundle\Entity\User;
+
+#[CoversClass(CompanyFilter::class)]
+final class CompanyFilterTest extends TestCase
+{
+    private const string COMPANY_ID = '01967E2E2DA3C8730FF7F658B76C209F';
+
+    /**
+     * @return iterable<string, array{AbstractPlatform}>
+     */
+    public static function indexablePlatformProvider(): iterable
+    {
+        // MariaDBPlatform and MySQLPlatform both extend AbstractMySQLPlatform.
+        yield 'mysql' => [new MySQLPlatform()];
+        yield 'mariadb' => [new MariaDBPlatform()];
+    }
+
+    /**
+     * Wrapping the column in HEX() makes the comparison non-sargable, which disqualifies the index on
+     * company_id and turns every tenant-scoped query into a full table scan. The literal gets decoded
+     * instead, so the column stays bare and indexable.
+     */
+    #[DataProvider('indexablePlatformProvider')]
+    public function testCompanyColumnIsNotWrappedInAFunctionOnMySql(AbstractPlatform $platform): void
+    {
+        $constraint = $this->filterFor($platform)->addFilterConstraint($this->invoiceMetadata(), 'i0_');
+
+        self::assertSame(sprintf("i0_.company_id = UNHEX('%s')", self::COMPANY_ID), $constraint);
+        self::assertStringNotContainsString('HEX(i0_.company_id)', $constraint);
+    }
+
+    #[DataProvider('indexablePlatformProvider')]
+    public function testUserIdColumnIsNotWrappedInAFunctionOnMySql(AbstractPlatform $platform): void
+    {
+        $constraint = $this->filterFor($platform)->addFilterConstraint($this->userMetadata(), 'u0_');
+
+        self::assertSame(
+            sprintf(
+                "u0_.id IN (SELECT user_id FROM user_company WHERE company_id = UNHEX('%s'))",
+                self::COMPANY_ID
+            ),
+            $constraint
+        );
+    }
+
+    /**
+     * Postgres stores the id natively and compares against the RFC 4122 representation.
+     */
+    public function testPostgresComparesTheColumnDirectly(): void
+    {
+        $constraint = $this->filterFor(new PostgreSQLPlatform())->addFilterConstraint($this->invoiceMetadata(), 'i0_');
+
+        self::assertSame(sprintf("i0_.company_id = '%s'", self::COMPANY_ID), $constraint);
+    }
+
+    /**
+     * SQLite gained unhex() only in 3.41, so it keeps encoding the column instead.
+     */
+    public function testSqliteFallsBackToEncodingTheColumn(): void
+    {
+        $constraint = $this->filterFor(new SQLitePlatform())->addFilterConstraint($this->invoiceMetadata(), 'i0_');
+
+        self::assertSame(sprintf("HEX(i0_.company_id) = '%s'", self::COMPANY_ID), $constraint);
+    }
+
+    public function testEntitiesWithoutACompanyAssociationAreNotFiltered(): void
+    {
+        $metadata = new ClassMetadata(Company::class);
+        $metadata->initializeReflection(new RuntimeReflectionService());
+
+        self::assertSame('', $this->filterFor(new MySQLPlatform())->addFilterConstraint($metadata, 'c0_'));
+    }
+
+    public function testNoConstraintIsAddedWithoutACompanyParameter(): void
+    {
+        $filter = new CompanyFilter($this->entityManager(new MySQLPlatform()));
+
+        self::assertSame('', $filter->addFilterConstraint($this->invoiceMetadata(), 'i0_'));
+    }
+
+    private function filterFor(AbstractPlatform $platform): CompanyFilter
+    {
+        $filter = new CompanyFilter($this->entityManager($platform));
+        $filter->setParameter('companyId', self::COMPANY_ID, 'string');
+
+        return $filter;
+    }
+
+    private function entityManager(AbstractPlatform $platform): EntityManagerInterface
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($platform);
+        $connection->method('quote')->willReturnCallback(static fn (string $value): string => "'" . $value . "'");
+        $connection->method('createQueryBuilder')->willReturnCallback(static fn (): QueryBuilder => new QueryBuilder($connection));
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        return $entityManager;
+    }
+
+    /**
+     * @return ClassMetadata<Invoice>
+     */
+    private function invoiceMetadata(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(Invoice::class);
+        $metadata->initializeReflection(new RuntimeReflectionService());
+        $metadata->mapManyToOne(['fieldName' => 'company', 'targetEntity' => Company::class]);
+
+        return $metadata;
+    }
+
+    /**
+     * @return ClassMetadata<User>
+     */
+    private function userMetadata(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(User::class);
+        $metadata->initializeReflection(new RuntimeReflectionService());
+
+        return $metadata;
+    }
+}

--- a/src/CoreBundle/Tests/Doctrine/Filter/CompanyFilterTest.php
+++ b/src/CoreBundle/Tests/Doctrine/Filter/CompanyFilterTest.php
@@ -77,12 +77,15 @@ final class CompanyFilterTest extends TestCase
     /**
      * Postgres stores the id natively and compares against the RFC 4122 representation.
      */
-    public function testPostgresComparesTheColumnDirectly(): void
-    {
-        $constraint = $this->filterFor(new PostgreSQLPlatform())->addFilterConstraint($this->invoiceMetadata(), 'i0_');
+public function testPostgresComparesTheColumnDirectly(): void
+{
+    $filter = new CompanyFilter($this->entityManager(new PostgreSQLPlatform()));
+    $filter->setParameter('companyId', '01967e2e-2da3-c873-0ff7-f658b76c209f', 'string');
 
-        self::assertSame(sprintf("i0_.company_id = '%s'", self::COMPANY_ID), $constraint);
-    }
+    $constraint = $filter->addFilterConstraint($this->invoiceMetadata(), 'i0_');
+
+    self::assertSame("i0_.company_id = '01967e2e-2da3-c873-0ff7-f658b76c209f'", $constraint);
+}
 
     /**
      * SQLite gained unhex() only in 3.41, so it keeps encoding the column instead.

--- a/src/InvoiceBundle/Command/SendInvoiceRemindersCommand.php
+++ b/src/InvoiceBundle/Command/SendInvoiceRemindersCommand.php
@@ -15,23 +15,22 @@ namespace SolidInvoice\InvoiceBundle\Command;
 
 use Carbon\CarbonImmutable;
 use DateMalformedStringException;
-use Doctrine\ORM\AbstractQuery;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
-use SolidInvoice\CoreBundle\Company\CompanySelector;
-use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
 use SolidInvoice\InvoiceBundle\Message\SendInvoiceReminderMessage;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidWorx\Platform\PlatformBundle\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Scheduler\Attribute\AsCronTask;
-use Symfony\Component\Uid\Ulid;
 use Throwable;
 use function assert;
 use function Sentry\captureException;
@@ -45,7 +44,10 @@ use function sprintf;
     name: 'solidinvoice:invoices:send-reminders',
     description: 'Send payment reminders for pending and overdue invoices',
 )]
-#[AsCronTask(expression: '#hourly', schedule: 'invoice_reminders')] // Every hour at a hashed minute to spread load
+// Every hour at a hashed minute to spread load. The hash is seeded from the full command line, so
+// the two types land on different minutes rather than contending for the same one.
+#[AsCronTask(expression: '#hourly', arguments: ['type' => 'pre-due'], schedule: 'invoice_reminders')]
+#[AsCronTask(expression: '#hourly', arguments: ['type' => 'overdue'], schedule: 'invoice_reminders')]
 final class SendInvoiceRemindersCommand extends Command
 {
     /**
@@ -62,12 +64,21 @@ final class SendInvoiceRemindersCommand extends Command
         private readonly InvoiceRepository $invoiceRepository,
         private readonly MessageBusInterface $messageBus,
         private readonly ClockInterface $clock,
-        private readonly CompanySelector $companySelector,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addArgument(name: 'type', mode: InputArgument::REQUIRED, suggestedValues: ['pre-due', 'overdue']);
+    }
+
+    /**
+     * @throws Throwable
+     */
     protected function handle(): int
     {
         $entityManager = $this->registry->getManagerForClass(Invoice::class);
@@ -78,29 +89,38 @@ final class SendInvoiceRemindersCommand extends Command
         $companyFilterEnabled = $filters->isEnabled('company');
 
         if ($companyFilterEnabled) {
-            $filters->disable('company');
+            $filters->suspend('company');
         }
 
         try {
-            // Dispatch pre-due reminder messages
-            $preDueCount = withMonitor('pre_due_invoice_reminders', $this->dispatchPreDueReminders(...));
-
-            // Dispatch overdue reminder messages
-            $overdueCount = $this->dispatchOverdueReminders();
+            $count = match ($this->io->getArgument('type')) {
+                'pre-due' => withMonitor('pre_due_invoice_reminders', $this->dispatchPreDueReminders(...)),
+                'overdue' => withMonitor('overdue_invoice_reminders', $this->dispatchOverdueReminders(...)),
+                default => throw new InvalidArgumentException(sprintf('Invalid type "%s"', $this->io->getArgument('type'))),
+            };
         } catch (Throwable $e) {
             captureException($e);
             throw $e;
         } finally {
-            // Re-enable company filter if it was enabled
+            // Re-enable company filter if it was enabled.
+            //
+            // The scan itself leaves the suspension intact, but SendInvoiceReminderHandler switches
+            // tenants — and switchCompany() drops the suspension — so a synchronously routed
+            // message would leave nothing for restore() to restore. It throws in that case, which
+            // in a finally block would mask any exception already on its way out.
             if ($companyFilterEnabled) {
-                $filters->enable('company');
+                if ($filters->isSuspended('company')) {
+                    $filters->restore('company');
+                } elseif (! $filters->isEnabled('company')) {
+                    $filters->enable('company');
+                }
             }
         }
 
         $this->io->success(sprintf(
-            'Dispatched %d pre-due reminder messages and %d overdue reminder messages',
-            $preDueCount,
-            $overdueCount
+            'Dispatched %d %s reminder messages',
+            $count,
+            $this->io->getArgument('type'),
         ));
 
         return self::SUCCESS;
@@ -110,39 +130,26 @@ final class SendInvoiceRemindersCommand extends Command
     {
         $this->io->comment('Processing pre-due reminders...');
 
-        $companyRepository = $this->registry->getRepository(Company::class);
-
-        $companies = $companyRepository->createQueryBuilder('c')
-            ->select('DISTINCT(c.id) as companyId', 's_days.value as preDueDays')
-            ->innerJoin('c.settings', 's_days', 'WITH', 's_days.key = :key_days')
-            ->innerJoin('c.settings', 's_rem', 'WITH', 's_rem.key = :key_rem AND s_rem.value = :val_true')
-            ->innerJoin('c.settings', 's_pre', 'WITH', 's_pre.key = :key_pre AND s_pre.value = :val_true')
-            ->getQuery()
-            ->toIterable([
-                'key_days' => 'invoice/reminder/pre_due_days',
-                'key_rem' => 'invoice/reminder/enabled',
-                'key_pre' => 'invoice/reminder/pre_due_enabled',
-                'val_true' => '1',
-            ], AbstractQuery::HYDRATE_SCALAR);
-
         $count = 0;
 
-        foreach ($companies as $company) {
-            $companyId = Ulid::fromString($company['companyId']);
-
-            $this->companySelector->switchCompany($companyId);
-
+        // Pre-due reminders fire a company-configured number of days before the due date, so one
+        // scan per distinct window covers every company that shares it.
+        foreach ($this->invoiceRepository->getConfiguredPreDueDays() as $daysBeforeDue) {
             try {
-                foreach ($this->invoiceRepository->getInvoicesNeedingPreDueReminders((int) $company['preDueDays']) as $invoice) {
+                foreach ($this->invoiceRepository->getInvoicesNeedingPreDueReminders($daysBeforeDue) as $candidate) {
                     $daysUntilDue = null;
-                    if ($invoice->getDue()) {
-                        $daysUntilDue = CarbonImmutable::instance($this->clock->now())->startOfDay()->diff($invoice->getDue())->days;
+
+                    if ($candidate['due'] instanceof DateTimeInterface) {
+                        $daysUntilDue = CarbonImmutable::instance($this->clock->now())
+                            ->startOfDay()
+                            ->diff($candidate['due'])
+                            ->days;
                     }
 
                     $this->messageBus->dispatch(
                         new SendInvoiceReminderMessage(
-                            $invoice->getId(),
-                            $companyId,
+                            $candidate['invoiceId'],
+                            $candidate['companyId'],
                             ReminderType::PreDue,
                             $daysUntilDue
                         )
@@ -152,8 +159,7 @@ final class SendInvoiceRemindersCommand extends Command
                 }
             } catch (DateMalformedStringException | ExceptionInterface $e) {
                 captureException($e);
-            } finally {
-                $this->companySelector->reset();
+                $this->logger->error($e->getMessage(), ['exception' => $e]);
             }
         }
 
@@ -166,53 +172,35 @@ final class SendInvoiceRemindersCommand extends Command
 
         $count = 0;
 
-        // Get companies with reminders enabled
-        // Overdue reminders use fixed intervals (1, 7, 14 days) but respect the global enable setting
+        // Overdue reminders use fixed intervals (1, 7, 14 days) but respect the global enable
+        // setting, which the query filters on. One scan per interval covers every company.
+        foreach ($this->reminderTypes as $days => $type) {
+            $count += withMonitor(sprintf('overdue_invoice_reminders_%d_day', $days), function () use ($days, $type): int {
+                $count = 0;
 
-        $companyRepository = $this->registry->getRepository(Company::class);
-
-        $companies = $companyRepository->createQueryBuilder('c')
-            ->select('DISTINCT(c.id) as companyId')
-            ->innerJoin('c.settings', 's_rem', 'WITH', 's_rem.key = :key_rem AND s_rem.value = :val_true')
-            ->getQuery()
-            ->toIterable([
-                'key_rem' => 'invoice/reminder/enabled',
-                'val_true' => '1',
-            ], AbstractQuery::HYDRATE_SCALAR);
-
-        foreach ($companies as $company) {
-            $companyId = Ulid::fromString($company['companyId']);
-
-            $this->companySelector->switchCompany($companyId);
-
-            try {
-                foreach ($this->reminderTypes as $days => $type) {
-                    $count += withMonitor(sprintf('overdue_invoice_reminders_%d_day', $days), function () use ($days, $type, $companyId) {
-                        $count = 0;
-                        if ($this->io->isVerbose()) {
-                            $this->io->comment(sprintf('Processing %d-day overdue reminders', $days));
-                        }
-
-                        foreach ($this->invoiceRepository->getInvoicesNeedingOverdueReminders($days, $type) as $invoice) {
-                            $this->messageBus->dispatch(
-                                new SendInvoiceReminderMessage(
-                                    $invoice->getId(),
-                                    $companyId,
-                                    $type
-                                )
-                            );
-
-                            ++$count;
-                        }
-
-                        return $count;
-                    });
+                if ($this->io->isVerbose()) {
+                    $this->io->comment(sprintf('Processing %d-day overdue reminders', $days));
                 }
-            } catch (Throwable $e) {
-                $this->logger->error($e->getMessage(), ['exception' => $e]);
-            } finally {
-                $this->companySelector->reset();
-            }
+
+                try {
+                    foreach ($this->invoiceRepository->getInvoicesNeedingOverdueReminders($days, $type) as $candidate) {
+                        $this->messageBus->dispatch(
+                            new SendInvoiceReminderMessage(
+                                $candidate['invoiceId'],
+                                $candidate['companyId'],
+                                $type
+                            )
+                        );
+
+                        ++$count;
+                    }
+                } catch (Throwable $e) {
+                    captureException($e);
+                    $this->logger->error($e->getMessage(), ['exception' => $e]);
+                }
+
+                return $count;
+            });
         }
 
         return $count;

--- a/src/InvoiceBundle/Entity/Invoice.php
+++ b/src/InvoiceBundle/Entity/Invoice.php
@@ -63,6 +63,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: Invoice::TABLE_NAME)]
 #[ORM\Index(columns: ['quote_id'])]
+#[ORM\Index(name: 'idx_invoice_reminder_scan', columns: ['due', 'status'])]
 #[ORM\Entity(repositoryClass: InvoiceRepository::class)]
 #[ApiFilter(SearchFilter::class, properties: ['status' => 'exact', 'client' => 'exact'])]
 #[ApiFilter(DateFilter::class, properties: ['invoiceDate', 'due', 'paidDate'])]

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -626,7 +626,8 @@ class InvoiceRepository extends EntityRepository
      * The distinct pre-due windows configured across the companies that have pre-due reminders on.
      *
      * Pre-due reminders fire a company-configured number of days before the due date, so the scan
-     * runs once per distinct window rather than once per company.
+     * runs once per distinct window rather than once per company. The caller must suspend the company
+     * filter to collect windows across all tenants.
      *
      * @return list<int>
      */

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -21,11 +21,14 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Deprecated;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use Generator;
 use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
@@ -33,8 +36,14 @@ use SolidInvoice\InvoiceBundle\Entity\InvoiceReminder;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\PaymentBundle\Entity\Payment;
+use SolidInvoice\SettingsBundle\Entity\Setting;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Uid\Ulid;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function intval;
 
 /**
  * @extends EntityRepository<Invoice>
@@ -509,49 +518,122 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * Get pending invoices needing pre-due reminders.
+     * Get pending invoices needing pre-due reminders, across every company at once.
      *
-     * @return iterable<Invoice>
+     * Companies opt in through their settings, so those are joined here rather than resolved by the
+     * caller: one query covers the whole tenant base instead of one query per tenant. The caller is
+     * responsible for suspending the company filter, otherwise this is scoped to a single company.
+     *
+     * Only the fields needed to dispatch a reminder are selected — hydrating entities for a scan
+     * this wide would hold every matched invoice in the identity map.
+     *
+     * @return iterable<array{invoiceId: Ulid, companyId: Ulid, due: DateTimeImmutable|null}>
      * @throws DateMalformedStringException
      */
     public function getInvoicesNeedingPreDueReminders(int $daysBeforeDue): iterable
     {
         $targetDate = $this->clock->now()->modify(sprintf('+%d days', $daysBeforeDue));
 
-        $qb = $this->createQueryBuilder('i');
+        $qb = $this->createReminderCandidateQueryBuilder(ReminderType::PreDue, $targetDate);
 
-        $qb->leftJoin(InvoiceReminder::class, 'r', 'WITH', 'r.invoice = i.id AND r.reminderType = :reminderType')
-            ->where('i.status = :status')
-            ->andWhere('i.due = :targetDate')
-            ->andWhere('r.id IS NULL')
+        $qb
+            ->innerJoin(Setting::class, 's_pre_due', 'WITH', 's_pre_due.company = c AND s_pre_due.key = :preDueKey AND s_pre_due.value = :enabled')
+            ->innerJoin(Setting::class, 's_days', 'WITH', 's_days.company = c AND s_days.key = :daysKey AND s_days.value = :days')
+            ->andWhere('i.status = :status')
             ->setParameter('status', InvoiceStatus::Pending)
-            ->setParameter('targetDate', $targetDate, Types::DATE_IMMUTABLE)
-            ->setParameter('reminderType', ReminderType::PreDue);
+            ->setParameter('preDueKey', 'invoice/reminder/pre_due_enabled')
+            ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
+            ->setParameter('days', (string) $daysBeforeDue);
 
-        return $qb->getQuery()->toIterable();
+        return $this->hydrateReminderCandidates($qb->getQuery()->toIterable([], AbstractQuery::HYDRATE_SCALAR));
     }
 
     /**
-     * Get overdue invoices needing reminders.
+     * Get overdue invoices needing reminders, across every company at once.
      *
-     * @return iterable<Invoice>
+     * @return iterable<array{invoiceId: Ulid, companyId: Ulid, due: DateTimeImmutable|null}>
      * @throws DateMalformedStringException
+     * @see self::getInvoicesNeedingPreDueReminders() for why this scans all companies at once.
      */
     public function getInvoicesNeedingOverdueReminders(int $daysOverdue, ReminderType $reminderType): iterable
     {
         $targetDate = $this->clock->now()->modify(sprintf('-%d days', $daysOverdue));
 
-        $qb = $this->createQueryBuilder('i');
+        $qb = $this->createReminderCandidateQueryBuilder($reminderType, $targetDate);
 
-        $qb->leftJoin(InvoiceReminder::class, 'r', 'WITH', 'r.invoice = i.id AND r.reminderType = :reminderType')
-            ->where('i.status  in (:pending, :overdue)')
-            ->andWhere('i.due = :targetDate')
+        $qb
+            ->andWhere('i.status IN (:statuses)')
+            ->setParameter('statuses', [InvoiceStatus::Pending, InvoiceStatus::Overdue]);
+
+        return $this->hydrateReminderCandidates($qb->getQuery()->toIterable([], AbstractQuery::HYDRATE_SCALAR));
+    }
+
+    /**
+     * Scalar hydration hands back raw driver values — a 16 byte binary string for a ULID on MySQL,
+     * a uuid string on Postgres, and a plain date string for the due date. Run them back through
+     * the mapped Doctrine types so callers get the same objects entity hydration would have given
+     * them, without the identity map cost of hydrating whole invoices.
+     *
+     * @param iterable<array{invoiceId: mixed, companyId: mixed, due: mixed}> $rows
+     * @return Generator<int, array{invoiceId: Ulid, companyId: Ulid, due: DateTimeImmutable|null}>
+     */
+    private function hydrateReminderCandidates(iterable $rows): Generator
+    {
+        $platform = $this->getEntityManager()->getConnection()->getDatabasePlatform();
+        $ulidType = Type::getType(UlidType::NAME);
+        $dateType = Type::getType(Types::DATE_IMMUTABLE);
+
+        foreach ($rows as $row) {
+            yield [
+                'invoiceId' => $ulidType->convertToPHPValue($row['invoiceId'], $platform),
+                'companyId' => $ulidType->convertToPHPValue($row['companyId'], $platform),
+                'due' => $dateType->convertToPHPValue($row['due'], $platform),
+            ];
+        }
+    }
+
+    /**
+     * Invoices due on an exact date that have not had this reminder type recorded yet, limited to
+     * companies with reminders switched on.
+     *
+     * The anti-join needs no company predicate of its own — an invoice id already identifies a
+     * single tenant's row.
+     */
+    private function createReminderCandidateQueryBuilder(ReminderType $reminderType, DateTimeInterface $targetDate): QueryBuilder
+    {
+        return $this->createQueryBuilder('i')
+            ->select('i.id AS invoiceId', 'c.id AS companyId', 'i.due AS due')
+            ->innerJoin('i.company', 'c')
+            ->innerJoin(Setting::class, 's_enabled', 'WITH', 's_enabled.company = c AND s_enabled.key = :enabledKey AND s_enabled.value = :enabled')
+            ->leftJoin(InvoiceReminder::class, 'r', 'WITH', 'r.invoice = i.id AND r.reminderType = :reminderType')
+            ->where('i.due = :targetDate')
             ->andWhere('r.id IS NULL')
-            ->setParameter('pending', InvoiceStatus::Pending)
-            ->setParameter('overdue', InvoiceStatus::Overdue)
             ->setParameter('targetDate', $targetDate, Types::DATE_IMMUTABLE)
-            ->setParameter('reminderType', $reminderType);
+            ->setParameter('reminderType', $reminderType)
+            ->setParameter('enabledKey', 'invoice/reminder/enabled')
+            ->setParameter('enabled', '1');
+    }
 
-        return $qb->getQuery()->toIterable();
+    /**
+     * The distinct pre-due windows configured across all companies.
+     *
+     * Pre-due reminders fire a company-configured number of days before the due date, so the scan
+     * runs once per distinct window rather than once per company.
+     *
+     * @return list<int>
+     */
+    public function getConfiguredPreDueDays(): array
+    {
+        $values = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('DISTINCT s.value')
+            ->from(Setting::class, 's')
+            ->where('s.key = :daysKey')
+            ->andWhere('s.value IS NOT NULL')
+            ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_values(array_unique(array_map(intval(...), $values)));
     }
 }

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -40,10 +40,12 @@ use SolidInvoice\SettingsBundle\Entity\Setting;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
+use function array_filter;
 use function array_map;
 use function array_unique;
 use function array_values;
 use function intval;
+use function strval;
 
 /**
  * @extends EntityRepository<Invoice>
@@ -532,18 +534,24 @@ class InvoiceRepository extends EntityRepository
      */
     public function getInvoicesNeedingPreDueReminders(int $daysBeforeDue): iterable
     {
+        $settingValues = $this->preDueSettingValuesFor($daysBeforeDue);
+
+        if ($settingValues === []) {
+            return [];
+        }
+
         $targetDate = $this->clock->now()->modify(sprintf('+%d days', $daysBeforeDue));
 
         $qb = $this->createReminderCandidateQueryBuilder(ReminderType::PreDue, $targetDate);
 
         $qb
             ->innerJoin(Setting::class, 's_pre_due', 'WITH', 's_pre_due.company = c AND s_pre_due.key = :preDueKey AND s_pre_due.value = :enabled')
-            ->innerJoin(Setting::class, 's_days', 'WITH', 's_days.company = c AND s_days.key = :daysKey AND s_days.value = :days')
+            ->innerJoin(Setting::class, 's_days', 'WITH', 's_days.company = c AND s_days.key = :daysKey AND s_days.value IN (:days)')
             ->andWhere('i.status = :status')
             ->setParameter('status', InvoiceStatus::Pending)
             ->setParameter('preDueKey', 'invoice/reminder/pre_due_enabled')
             ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
-            ->setParameter('days', (string) $daysBeforeDue);
+            ->setParameter('days', $settingValues);
 
         return $this->hydrateReminderCandidates($qb->getQuery()->toIterable([], AbstractQuery::HYDRATE_SCALAR));
     }
@@ -624,6 +632,36 @@ class InvoiceRepository extends EntityRepository
      */
     public function getConfiguredPreDueDays(): array
     {
+        return array_values(array_unique(array_map(intval(...), $this->preDueDaySettingValues())));
+    }
+
+    /**
+     * Every raw spelling of the setting that normalises to the given window.
+     *
+     * The scan groups companies by the normalised value, so it has to match on those same raw
+     * spellings. The column is free text, so "3", "03" and "3 days" all mean the same window —
+     * comparing against a single canonical string would silently skip the companies that stored
+     * one of the others.
+     *
+     * @return list<string>
+     */
+    private function preDueSettingValuesFor(int $daysBeforeDue): array
+    {
+        return array_values(
+            array_filter(
+                $this->preDueDaySettingValues(),
+                static fn (string $value): bool => intval($value) === $daysBeforeDue
+            )
+        );
+    }
+
+    /**
+     * The distinct raw pre-due day settings stored across all companies.
+     *
+     * @return list<string>
+     */
+    private function preDueDaySettingValues(): array
+    {
         $values = $this->getEntityManager()
             ->createQueryBuilder()
             ->select('DISTINCT s.value')
@@ -634,6 +672,6 @@ class InvoiceRepository extends EntityRepository
             ->getQuery()
             ->getSingleColumnResult();
 
-        return array_values(array_unique(array_map(intval(...), $values)));
+        return array_values(array_map(strval(...), $values));
     }
 }

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -623,7 +623,7 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * The distinct pre-due windows configured across all companies.
+     * The distinct pre-due windows configured across the companies that have pre-due reminders on.
      *
      * Pre-due reminders fire a company-configured number of days before the due date, so the scan
      * runs once per distinct window rather than once per company.
@@ -636,7 +636,8 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * Every raw spelling of the setting that normalises to the given window.
+     * Every raw spelling of the setting that normalises to the given window, among the companies
+     * the scan can match at all.
      *
      * The scan groups companies by the normalised value, so it has to match on those same raw
      * spellings. The column is free text, so "3", "03" and "3 days" all mean the same window —
@@ -656,7 +657,11 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * The distinct raw pre-due day settings stored across all companies.
+     * The distinct raw pre-due day settings stored across the companies that would act on them.
+     *
+     * Switching reminders off leaves the day setting behind, so an unfiltered DISTINCT would hand
+     * back windows no company can ever match and the caller would run a scan per dead window. Both
+     * toggles are joined here to keep the number of scans tied to the active configurations.
      *
      * @return list<string>
      */
@@ -666,9 +671,14 @@ class InvoiceRepository extends EntityRepository
             ->createQueryBuilder()
             ->select('DISTINCT s.value')
             ->from(Setting::class, 's')
+            ->innerJoin(Setting::class, 's_enabled', 'WITH', 's_enabled.company = s.company AND s_enabled.key = :enabledKey AND s_enabled.value = :enabled')
+            ->innerJoin(Setting::class, 's_pre_due', 'WITH', 's_pre_due.company = s.company AND s_pre_due.key = :preDueKey AND s_pre_due.value = :enabled')
             ->where('s.key = :daysKey')
             ->andWhere('s.value IS NOT NULL')
             ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
+            ->setParameter('enabledKey', 'invoice/reminder/enabled')
+            ->setParameter('preDueKey', 'invoice/reminder/pre_due_enabled')
+            ->setParameter('enabled', '1')
             ->getQuery()
             ->getSingleColumnResult();
 

--- a/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
+++ b/src/InvoiceBundle/Tests/Command/SendInvoiceRemindersCommandTest.php
@@ -16,8 +16,10 @@ namespace SolidInvoice\InvoiceBundle\Tests\Command;
 use const PHP_EOL;
 use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
@@ -47,36 +49,55 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
     use Factories;
     use ConsoleTesterTrait;
 
-    public function testCommandExecutesSuccessfully(): void
+    /**
+     * Each reminder type is scheduled as its own cron task, so a run handles one type only.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function reminderTypeProvider(): iterable
     {
-        CompanyFactory::createOne();
-
-        $output = $this->runTestCommand();
-
-        self::assertThat($this->statusCode, new CommandIsSuccessful());
-        self::assertStringContainsString('Processing pre-due reminders', $output);
-        self::assertStringContainsString('Processing overdue reminders', $output);
+        yield 'pre-due' => ['pre-due', 'Processing pre-due reminders'];
+        yield 'overdue' => ['overdue', 'Processing overdue reminders'];
     }
 
-    public function testCommandHandlesMultipleCompanies(): void
+    #[DataProvider('reminderTypeProvider')]
+    public function testCommandExecutesSuccessfully(string $type, string $expectedOutput): void
     {
         CompanyFactory::createOne();
-        CompanyFactory::createOne();
 
-        $output = $this->runTestCommand();
+        $output = $this->runTestCommand($type);
 
         self::assertThat($this->statusCode, new CommandIsSuccessful());
-        self::assertStringContainsString('Processing pre-due reminders', $output);
-        self::assertStringContainsString('Processing overdue reminders', $output);
+        self::assertStringContainsString($expectedOutput, $output);
     }
 
-    public function testCommandHandlesNoCompanies(): void
+    #[DataProvider('reminderTypeProvider')]
+    public function testCommandHandlesMultipleCompanies(string $type, string $expectedOutput): void
     {
-        $output = $this->runTestCommand();
+        CompanyFactory::createOne();
+        CompanyFactory::createOne();
+
+        $output = $this->runTestCommand($type);
 
         self::assertThat($this->statusCode, new CommandIsSuccessful());
-        self::assertStringContainsString('Processing pre-due reminders', $output);
-        self::assertStringContainsString('Processing overdue reminders', $output);
+        self::assertStringContainsString($expectedOutput, $output);
+    }
+
+    #[DataProvider('reminderTypeProvider')]
+    public function testCommandHandlesNoCompanies(string $type, string $expectedOutput): void
+    {
+        $output = $this->runTestCommand($type);
+
+        self::assertThat($this->statusCode, new CommandIsSuccessful());
+        self::assertStringContainsString($expectedOutput, $output);
+    }
+
+    public function testCommandRejectsAnUnknownReminderType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "weekly"');
+
+        $this->runTestCommand('weekly');
     }
 
     /**
@@ -111,7 +132,7 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
             'users' => [$contact],
         ]);
 
-        $output = $this->runTestCommand();
+        $output = $this->runTestCommand('pre-due');
 
         self::assertThat($this->statusCode, new CommandIsSuccessful());
         self::assertStringContainsString('Dispatched 1 pre-due reminder', $output);
@@ -131,7 +152,7 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         self::assertInstanceOf(SendInvoiceReminderMessage::class, $transport->getSent()[0]->getMessage());
     }
 
-    private function runTestCommand(): string
+    private function runTestCommand(string $type): string
     {
         $application = new Application(self::bootKernel());
 
@@ -141,7 +162,7 @@ final class SendInvoiceRemindersCommandTest extends KernelTestCase
         /** @var SendInvoiceRemindersCommand $command */
         $command = $lazyCommand->getCommand();
         $this->initOutput([]);
-        $this->input = new ArrayInput([]);
+        $this->input = new ArrayInput(['type' => $type]);
         $this->input->setStream(self::createStream([]));
 
         $command->setIo(new IO($this->input, $this->output));

--- a/src/InvoiceBundle/Tests/Functional/InvoiceReminderFlowTest.php
+++ b/src/InvoiceBundle/Tests/Functional/InvoiceReminderFlowTest.php
@@ -269,18 +269,30 @@ final class InvoiceReminderFlowTest extends KernelTestCase
         self::assertCount(1, $reminders, 'Idempotency guard should prevent duplicate reminder');
     }
 
+    /**
+     * Each reminder type is scheduled as its own cron task, so a full sweep means running the
+     * command once per type. Both are dispatched here to mirror what the scheduler does over a cycle.
+     */
     private function runTestCommand(): void
+    {
+        foreach (['pre-due', 'overdue'] as $type) {
+            $this->runTestCommandForType($type);
+        }
+    }
+
+    private function runTestCommandForType(string $type): void
     {
         // Get the command directly from the container
         $command = self::getContainer()->get(SendInvoiceRemindersCommand::class);
 
-        // Manually set IO object for Platform Command
-        $input = new ArrayInput([]);
+        // Manually set IO object for Platform Command. The definition has to be passed so the
+        // input is bound, otherwise the command cannot read the 'type' argument off it.
+        $input = new ArrayInput(['type' => $type], $command->getDefinition());
         $output = new BufferedOutput();
         $command->setIo(new IO($input, $output));
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([]);
+        $commandTester->execute(['type' => $type]);
 
         self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
 

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -15,9 +15,12 @@ namespace SolidInvoice\InvoiceBundle\Tests\Repository;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Clock\ClockInterface;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
@@ -116,6 +119,39 @@ final class InvoiceRepositoryTest extends KernelTestCase
 
         self::assertCount(1, $results);
         self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
+    }
+
+    /**
+     * Switching either reminder toggle off leaves the day setting behind, so counting every stored
+     * window would keep the disabled company's window in the list and the caller would run a scan
+     * for it on every cron tick — one that can never match, since the scan itself requires both
+     * toggles to be on.
+     */
+    #[TestWith(['invoice/reminder/enabled'])]
+    #[TestWith(['invoice/reminder/pre_due_enabled'])]
+    public function testGetConfiguredPreDueDaysExcludesCompaniesWithRemindersDisabled(string $disabledToggle): void
+    {
+        $this->updateSetting($disabledToggle, '0');
+
+        self::assertSame([], $this->repository->getConfiguredPreDueDays());
+    }
+
+    /**
+     * The windows are collected across the whole tenant base, so a window no enabled company shares
+     * has to drop out entirely — while the windows of the companies that are still on stay.
+     */
+    public function testGetConfiguredPreDueDaysOnlyReturnsWindowsFromCompaniesWithRemindersOn(): void
+    {
+        // Creating a company seeds its default reminder settings and switches the active tenant to it.
+        $disabledCompany = CompanyFactory::createOne();
+
+        $this->updateSetting('invoice/reminder/pre_due_days', '7', $disabledCompany);
+        $this->updateSetting('invoice/reminder/enabled', '0', $disabledCompany);
+
+        self::assertSame(
+            [3],
+            $this->withoutCompanyFilter(fn (): array => $this->repository->getConfiguredPreDueDays())
+        );
     }
 
     public function testGetInvoicesNeedingPreDueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -304,24 +340,52 @@ final class InvoiceRepositoryTest extends KernelTestCase
         self::assertSame(0, $this->repository->countCreatedInMonth($month));
     }
 
-    private function updateSetting(string $key, string $value): void
+    private function updateSetting(string $key, string $value, ?Company $company = null): void
     {
+        $company ??= $this->company;
+
         $entityManager = self::getContainer()->get('doctrine')->getManager();
 
         $setting = $entityManager->getRepository(Setting::class)
             ->findOneBy([
-                'company' => $this->company,
+                'company' => $company,
                 'key' => $key,
             ]);
 
         if ($setting === null) {
             $setting = new Setting();
             $setting->setKey($key);
-            $setting->setCompany($this->company);
+            $setting->setCompany($company);
             $entityManager->persist($setting);
         }
 
         $setting->setValue($value);
         $entityManager->flush();
+    }
+
+    /**
+     * The reminder scans run across every tenant at once, which SendInvoiceRemindersCommand sets up
+     * by suspending the company filter. Without that the query only ever sees the active company.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    private function withoutCompanyFilter(callable $callback): mixed
+    {
+        $filters = self::getContainer()->get(EntityManagerInterface::class)->getFilters();
+        $enabled = $filters->isEnabled('company');
+
+        if ($enabled) {
+            $filters->suspend('company');
+        }
+
+        try {
+            return $callback();
+        } finally {
+            if ($enabled) {
+                $filters->restore('company');
+            }
+        }
     }
 }

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\InvoiceBundle\Tests\Repository;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Clock\ClockInterface;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
@@ -23,6 +24,7 @@ use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceReminderFactory;
+use SolidInvoice\SettingsBundle\Entity\Setting;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Ulid;
@@ -88,6 +90,32 @@ final class InvoiceRepositoryTest extends KernelTestCase
         self::assertInstanceOf(DateTimeImmutable::class, $results[0]['due']);
         self::assertSame($this->company->getId()->toBase32(), $results[0]['companyId']->toBase32());
         self::assertSame('2024-02-04', $results[0]['due']->format('Y-m-d'));
+    }
+
+    /**
+     * The setting column is free text, so the same window can be stored as "3", "03" or "3 days".
+     * getConfiguredPreDueDays() normalises them all to 3 and the scan runs once for that window, so
+     * the scan has to match every spelling — otherwise those companies never get a reminder.
+     */
+    #[TestWith(['03'])]
+    #[TestWith([' 3'])]
+    #[TestWith(['3 days'])]
+    public function testGetInvoicesNeedingPreDueRemindersMatchesNonCanonicalDaySettings(string $storedValue): void
+    {
+        $this->updateSetting('invoice/reminder/pre_due_days', $storedValue);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'status' => InvoiceStatus::Pending,
+            'due' => $this->clock->now()->modify('+3 days'),
+        ]);
+
+        self::assertSame([3], $this->repository->getConfiguredPreDueDays());
+
+        $results = iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3));
+
+        self::assertCount(1, $results);
+        self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
     }
 
     public function testGetInvoicesNeedingPreDueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -274,5 +302,26 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $month = new DateTimeImmutable('2024-04-15 10:00:00', new DateTimeZone('UTC'));
 
         self::assertSame(0, $this->repository->countCreatedInMonth($month));
+    }
+
+    private function updateSetting(string $key, string $value): void
+    {
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+
+        $setting = $entityManager->getRepository(Setting::class)
+            ->findOneBy([
+                'company' => $this->company,
+                'key' => $key,
+            ]);
+
+        if ($setting === null) {
+            $setting = new Setting();
+            $setting->setKey($key);
+            $setting->setCompany($this->company);
+            $entityManager->persist($setting);
+        }
+
+        $setting->setValue($value);
+        $entityManager->flush();
     }
 }

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -25,6 +25,7 @@ use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceReminderFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Uid\Ulid;
 use Zenstruck\Foundry\Test\Factories;
 
 #[CoversClass(InvoiceRepository::class)]
@@ -63,7 +64,30 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $results = iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3));
 
         self::assertCount(1, $results);
-        self::assertSame($invoice->getId()->toBase32(), $results[0]->getId()->toBase32());
+        self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
+    }
+
+    /**
+     * The scan hydrates scalars for speed, which hands back raw driver values — a binary string for
+     * a ULID, a plain string for the date. They have to come back out as the mapped types, or the
+     * dispatched message carries a binary id and never works out the days until due.
+     */
+    public function testGetInvoicesNeedingPreDueRemindersReturnsMappedTypesNotRawDriverValues(): void
+    {
+        InvoiceFactory::createOne([
+            'company' => $this->company,
+            'status' => InvoiceStatus::Pending,
+            'due' => $this->clock->now()->modify('+3 days'),
+        ]);
+
+        $results = iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3));
+
+        self::assertCount(1, $results);
+        self::assertInstanceOf(Ulid::class, $results[0]['invoiceId']);
+        self::assertInstanceOf(Ulid::class, $results[0]['companyId']);
+        self::assertInstanceOf(DateTimeImmutable::class, $results[0]['due']);
+        self::assertSame($this->company->getId()->toBase32(), $results[0]['companyId']->toBase32());
+        self::assertSame('2024-02-04', $results[0]['due']->format('Y-m-d'));
     }
 
     public function testGetInvoicesNeedingPreDueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -139,7 +163,7 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $results = iterator_to_array($this->repository->getInvoicesNeedingOverdueReminders(1, ReminderType::Overdue1));
 
         self::assertCount(1, $results);
-        self::assertSame($invoice->getId()->toBase32(), $results[0]->getId()->toBase32());
+        self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
     }
 
     public function testGetInvoicesNeedingOverdueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -191,7 +215,7 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $results = iterator_to_array($this->repository->getInvoicesNeedingOverdueReminders(7, ReminderType::Overdue7));
 
         self::assertCount(1, $results);
-        self::assertSame($invoice7Days->getId()->toBase32(), $results[0]->getId()->toBase32());
+        self::assertSame($invoice7Days->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
     }
 
     public function testGetInvoicesNeedingOverdueRemindersExcludesPaidInvoices(): void
@@ -215,7 +239,7 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $results = iterator_to_array($this->repository->getInvoicesNeedingOverdueReminders(1, ReminderType::Overdue1));
 
         self::assertCount(1, $results);
-        self::assertSame($overdueInvoice->getId()->toBase32(), $results[0]->getId()->toBase32());
+        self::assertSame($overdueInvoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
     }
 
     public function testCountCreatedInMonthCountsInvoicesInTheCalendarMonth(): void


### PR DESCRIPTION
The send-reminders cron issued one query per company per reminder type (~7,500 for 2,500 companies x 3 types). Each query also wrapped company_id in HEX(), which disqualified every index on the column and forced a full table scan of ~20k invoices, taking 500-800ms apiece.

CompanyFilter now decodes the bound literal with UNHEX() on MySQL/MariaDB instead of encoding the column, restoring sargability across every multi-tenant query app-wide (Postgres compares natively; SQLite keeps HEX() as it lacks unhex() before 3.41). The reminder scans are consolidated to run once across all tenants by joining the settings table (8 queries per sweep instead of ~7,500), and a (due, status) index is added for those scans since company_id is no longer a predicate once the filter is suspended.

Also fixes the filter restore in the finally block (suspend/restore did not survive the handler's per-message tenant switching and threw, masking in-flight exceptions), moves the Sentry check-in out of the per-company loop (3 check-ins per run instead of 7,500), restores the hourly schedule hashed to distinct minutes per type, and adds a required 'type' argument so each reminder type runs as its own cron task.