### PR TITLE
feat(saas): card-required trial mode + close free tier via Plan.active

### DIFF
--- a/assets/scss/components/_subscription-pages.scss
+++ b/assets/scss/components/_subscription-pages.scss
@@ -459,6 +459,66 @@
 }
 
 // ============================================================================
+// WELCOME / ACTIVATION PAGE (card-required onboarding)
+// ============================================================================
+// One plan, one call to action. The page reassures rather than sells: the
+// plan is a calm summary, not a pick-me card, and the three guarantees below it
+// exist to melt the hesitation of entering a card before the trial starts.
+
+.subscription-welcome-page {
+
+    .subscription-container {
+        max-width: 720px;
+    }
+}
+
+.welcome-plan {
+    border: 1px solid var(--swp-border);
+    border-radius: var(--swp-radius-lg);
+    box-shadow: var(--swp-shadow-xs);
+
+    .card-body {
+        padding: var(--swp-space-6);
+    }
+
+    // The plan's own feature list is reused from the picker; here it sits inside
+    // a summary card, so drop the picker's bottom margin.
+
+    .plan-card-features {
+        margin-bottom: 0;
+    }
+}
+
+.welcome-plan-pricing {
+    white-space: nowrap;
+}
+
+.welcome-plan-price {
+    font-size: var(--swp-text-2xl);
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+// Three quiet reassurances; the Bootstrap grid stacks them on mobile.
+
+.welcome-reassure-item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--swp-space-2-5);
+    height: 100%;
+    padding: var(--swp-space-4);
+    background: var(--swp-gray-50);
+    border: 1px solid var(--swp-border);
+    border-radius: var(--swp-radius-lg);
+
+    svg {
+        flex-shrink: 0;
+        margin-top: var(--swp-space-0-5);
+        color: var(--swp-success);
+    }
+}
+
+// ============================================================================
 // RESPONSIVE DESIGN
 // ============================================================================
 

--- a/config/packages/saas/services.php
+++ b/config/packages/saas/services.php
@@ -24,9 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_SAAS_TRIAL_BANNER_DAYS)', '7');
     $parameters->set('env(SOLIDINVOICE_SAAS_TRIAL_COUPON_DAYS)', '2');
 
-    // '1' requires payment details up front: the trial is started by Lemon
-    // Squeezy once the user completes checkout, instead of locally at signup.
-    // Defined here rather than under config/packages/saas/ because
-    // config/packages/toggler.php is loaded on every platform.
+    // '1' requires payment details up front: the trial is started
+    // once the user completes checkout, instead of locally at signup.
     $parameters->set('env(SOLIDINVOICE_SAAS_PAID_TRIAL)', '0');
 };

--- a/config/packages/saas/services.php
+++ b/config/packages/saas/services.php
@@ -23,4 +23,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT)', '30');
     $parameters->set('env(SOLIDINVOICE_SAAS_TRIAL_BANNER_DAYS)', '7');
     $parameters->set('env(SOLIDINVOICE_SAAS_TRIAL_COUPON_DAYS)', '2');
+
+    // '1' requires payment details up front: the trial is started by Lemon
+    // Squeezy once the user completes checkout, instead of locally at signup.
+    // Defined here rather than under config/packages/saas/ because
+    // config/packages/toggler.php is loaded on every platform.
+    $parameters->set('env(SOLIDINVOICE_SAAS_PAID_TRIAL)', '0');
 };

--- a/config/packages/saas/toggler.php
+++ b/config/packages/saas/toggler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return App::config([
+    'toggler' => [
+        'config' => [
+            'features' => [
+                'saas_paid_trial' => '@=env("SOLIDINVOICE_SAAS_PAID_TRIAL") == "1"',
+            ],
+        ],
+    ],
+]);

--- a/config/packages/toggler.php
+++ b/config/packages/toggler.php
@@ -21,6 +21,7 @@ return App::config([
                 'google_oauth_login' => '@=env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID") !== null && env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET") !== null',
                 'turnstile_captcha' => '@=env("SOLIDINVOICE_TURNSTILE_SITE_KEY") !== null && env("SOLIDINVOICE_TURNSTILE_SECRET_KEY") !== null',
                 'saas_enabled' => '@=env("SOLIDINVOICE_PLATFORM") === \'saas\'',
+                'saas_paid_trial' => '@=env("SOLIDINVOICE_SAAS_PAID_TRIAL") == "1"',
                 'meilisearch_search' => '@=env("SOLIDINVOICE_MEILISEARCH_URL") !== "" && env("SOLIDINVOICE_MEILISEARCH_API_KEY") !== ""',
             ],
         ],

--- a/config/packages/toggler.php
+++ b/config/packages/toggler.php
@@ -21,7 +21,6 @@ return App::config([
                 'google_oauth_login' => '@=env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_ID") !== null && env("SOLIDINVOICE_OAUTH_CLIENT_GOOGLE_CLIENT_SECRET") !== null',
                 'turnstile_captcha' => '@=env("SOLIDINVOICE_TURNSTILE_SITE_KEY") !== null && env("SOLIDINVOICE_TURNSTILE_SECRET_KEY") !== null',
                 'saas_enabled' => '@=env("SOLIDINVOICE_PLATFORM") === \'saas\'',
-                'saas_paid_trial' => '@=env("SOLIDINVOICE_SAAS_PAID_TRIAL") == "1"',
                 'meilisearch_search' => '@=env("SOLIDINVOICE_MEILISEARCH_URL") !== "" && env("SOLIDINVOICE_MEILISEARCH_API_KEY") !== ""',
             ],
         ],

--- a/config/services.php
+++ b/config/services.php
@@ -57,6 +57,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_MESSENGER_DSN)', 'doctrine://default?queue_name=async');
     $parameters->set('env(SOLIDINVOICE_PLATFORM)', null);
 
+    // '1' requires payment details up front: the trial is started by Lemon
+    // Squeezy once the user completes checkout, instead of locally at signup.
+    // Defined here rather than under config/packages/saas/ because
+    // config/packages/toggler.php is loaded on every platform.
+    $parameters->set('env(SOLIDINVOICE_SAAS_PAID_TRIAL)', '0');
+
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_URL)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_API_KEY)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_PREFIX)', 'solidinvoice_%env(SOLIDINVOICE_ENV)%_');

--- a/config/services.php
+++ b/config/services.php
@@ -50,6 +50,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_TRANSLATION_DSN)', '');
     $parameters->set('env(SOLIDINVOICE_MESSENGER_DSN)', 'doctrine://default?queue_name=async');
     $parameters->set('env(SOLIDINVOICE_PLATFORM)', null);
+
+    // '1' requires payment details up front: the trial is started by Lemon
+    // Squeezy once the user completes checkout, instead of locally at signup.
+    // Defined here rather than under config/packages/saas/ because
+    // config/packages/toggler.php is loaded on every platform.
+    $parameters->set('env(SOLIDINVOICE_SAAS_PAID_TRIAL)', '0');
+
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_URL)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_API_KEY)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_PREFIX)', 'solidinvoice_%env(SOLIDINVOICE_ENV)%_');

--- a/config/services.php
+++ b/config/services.php
@@ -50,13 +50,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set('env(SOLIDINVOICE_TRANSLATION_DSN)', '');
     $parameters->set('env(SOLIDINVOICE_MESSENGER_DSN)', 'doctrine://default?queue_name=async');
     $parameters->set('env(SOLIDINVOICE_PLATFORM)', null);
-
-    // '1' requires payment details up front: the trial is started by Lemon
-    // Squeezy once the user completes checkout, instead of locally at signup.
-    // Defined here rather than under config/packages/saas/ because
-    // config/packages/toggler.php is loaded on every platform.
-    $parameters->set('env(SOLIDINVOICE_SAAS_PAID_TRIAL)', '0');
-
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_URL)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_API_KEY)', '');
     $parameters->set('env(SOLIDINVOICE_MEILISEARCH_PREFIX)', 'solidinvoice_%env(SOLIDINVOICE_ENV)%_');

--- a/src/CoreBundle/Resources/views/Company/create.html.twig
+++ b/src/CoreBundle/Resources/views/Company/create.html.twig
@@ -87,20 +87,27 @@
 
                                 {# Pricing Information #}
                                 {% toggle 'saas_enabled' %}
+                                    {% set paidTrial = toggle('saas_paid_trial') %}
                                     {% if not userHasTrial and planHasTrial %}
                                         <div class="alert alert-info d-flex align-items-start" role="alert">
                                             <div class="me-3">
-                                                {{ ux_icon('tabler:gift', {width: 24, height: 24}) }}
+                                                {{ ux_icon(paidTrial ? 'tabler:credit-card' : 'tabler:gift', {width: 24, height: 24}) }}
                                             </div>
                                             <div class="flex-fill">
-                                                <div class="alert-title fw-semibold">{{ 'company.create.trial_title'|trans }}</div>
+                                                <div class="alert-title fw-semibold">
+                                                    {{ (paidTrial ? 'company.create.trial_title_paid' : 'company.create.trial_title')|trans }}
+                                                </div>
                                                 <div class="text-secondary mb-2">
                                                     {% set trial_label -%}
                                                         {% if trialDuration.y > 0 %}{{ '{1} %count% year|]1,Inf[ %count% years'|trans({'%count%': trialDuration.y}, count=trialDuration.y) }} {% endif %}
                                                         {% if trialDuration.m > 0 %}{{ '{1} %count% month|]1,Inf[ %count% months'|trans({'%count%': trialDuration.m}, count=trialDuration.m) }} {% endif %}
                                                         {% if trialDuration.d > 0 %}{{ '{1} %count% day|]1,Inf[ %count% days'|trans({'%count%': trialDuration.d}, count=trialDuration.d) }}{% endif %}
                                                     {%- endset %}
-                                                    {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%, completely free. No credit card required.{% endtrans %}
+                                                    {% if paidTrial %}
+                                                        {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%. We'll ask for your payment details to begin — cancel any time before the trial ends and you won't be charged.{% endtrans %}
+                                                    {% else %}
+                                                        {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%, completely free. No credit card required.{% endtrans %}
+                                                    {% endif %}
                                                 </div>
                                                 {% if planPrice %}
                                                     <div class="d-flex align-items-center gap-2 mt-2">

--- a/src/CoreBundle/Resources/views/Company/create.html.twig
+++ b/src/CoreBundle/Resources/views/Company/create.html.twig
@@ -64,20 +64,27 @@
 
                                 {# Pricing Information #}
                                 {% toggle 'saas_enabled' %}
+                                    {% set paidTrial = toggle('saas_paid_trial') %}
                                     {% if not userHasTrial and planHasTrial %}
                                         <div class="alert alert-info d-flex align-items-start" role="alert">
                                             <div class="me-3">
-                                                {{ ux_icon('tabler:gift', {width: 24, height: 24}) }}
+                                                {{ ux_icon(paidTrial ? 'tabler:credit-card' : 'tabler:gift', {width: 24, height: 24}) }}
                                             </div>
                                             <div class="flex-fill">
-                                                <div class="alert-title fw-semibold">{{ 'company.create.trial_title'|trans }}</div>
+                                                <div class="alert-title fw-semibold">
+                                                    {{ (paidTrial ? 'company.create.trial_title_paid' : 'company.create.trial_title')|trans }}
+                                                </div>
                                                 <div class="text-secondary mb-2">
                                                     {% set trial_label -%}
                                                         {% if trialDuration.y > 0 %}{{ '{1} %count% year|]1,Inf[ %count% years'|trans({'%count%': trialDuration.y}, count=trialDuration.y) }} {% endif %}
                                                         {% if trialDuration.m > 0 %}{{ '{1} %count% month|]1,Inf[ %count% months'|trans({'%count%': trialDuration.m}, count=trialDuration.m) }} {% endif %}
                                                         {% if trialDuration.d > 0 %}{{ '{1} %count% day|]1,Inf[ %count% days'|trans({'%count%': trialDuration.d}, count=trialDuration.d) }}{% endif %}
                                                     {%- endset %}
-                                                    {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%, completely free. No credit card required.{% endtrans %}
+                                                    {% if paidTrial %}
+                                                        {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%. We'll ask for your payment details to begin — cancel any time before the trial ends and you won't be charged.{% endtrans %}
+                                                    {% else %}
+                                                        {% trans with {'%duration%': trial_label|trim} %}Get full access for %duration%, completely free. No credit card required.{% endtrans %}
+                                                    {% endif %}
                                                 </div>
                                                 {% if planPrice %}
                                                     <div class="d-flex align-items-center gap-2 mt-2">

--- a/src/CoreBundle/Telemetry/TelemetryEvent.php
+++ b/src/CoreBundle/Telemetry/TelemetryEvent.php
@@ -34,6 +34,7 @@ enum TelemetryEvent: string
     // SaaS (hosted) upgrade-funnel events. Emitted only by SaasBundle, which is
     // registered only when SOLIDINVOICE_PLATFORM=saas, so these never fire on
     // self-hosted installations. See docs/superpowers/specs/2026-06-22-saas-conversion-telemetry-design.md
+    case SaasWelcomePageViewed = 'saas_welcome_page_viewed';
     case SaasPricingPageViewed = 'saas_pricing_page_viewed';
     case SaasPlanSelected = 'saas_plan_selected';
     case SaasCheckoutStarted = 'saas_checkout_started';

--- a/src/SaasBundle/Action/SelectPlanAction.php
+++ b/src/SaasBundle/Action/SelectPlanAction.php
@@ -17,6 +17,7 @@ use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Telemetry\Telemetry;
 use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
@@ -36,6 +37,7 @@ final class SelectPlanAction extends AbstractController
         private readonly CompanyRepository $companyRepository,
         private readonly CompanySelector $companySelector,
         private readonly Telemetry $telemetry,
+        private readonly BillingMode $billingMode,
     ) {
     }
 
@@ -45,6 +47,13 @@ final class SelectPlanAction extends AbstractController
 
         if ($subscription instanceof Subscription && $subscription->getStatus() === SubscriptionStatus::ACTIVE) {
             return $this->redirectToRoute('billing_index');
+        }
+
+        // Card-required onboarding has no plan choice — the default plan is
+        // activated from the dedicated welcome page. Keep the picker out of that
+        // flow entirely, even if a stale link points here.
+        if ($this->billingMode->requiresCardForTrial()) {
+            return $this->redirectToRoute('saas_subscription_welcome');
         }
 
         $plans = $this->planRepository->findAllOrdered();

--- a/src/SaasBundle/Action/WelcomeAction.php
+++ b/src/SaasBundle/Action/WelcomeAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Action;
+
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * The onboarding activation page shown once a card is required up front.
+ *
+ * Unlike the plan picker, this page never offers a choice: the company already
+ * has a PENDING subscription on the default plan (set at company creation), and
+ * this page simply invites the user to start their trial on it. It is the first
+ * screen after company setup and — because RequestListener keeps redirecting a
+ * PENDING subscription here — the screen a user returns to on every later login
+ * until they activate.
+ *
+ * @see \SolidInvoice\SaasBundle\Tests\Action\WelcomeActionTest
+ */
+final class WelcomeAction extends AbstractController
+{
+    public function __construct(
+        private readonly SubscriptionProviderInterface $subscriptionProvider,
+        private readonly CompanyRepository $companyRepository,
+        private readonly CompanySelectorInterface $companySelector,
+        private readonly BillingMode $billingMode,
+        private readonly Telemetry $telemetry,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        // Free-trial mode keeps the existing plan-picker onboarding; the welcome
+        // page belongs solely to the card-required flow.
+        if (! $this->billingMode->requiresCardForTrial()) {
+            return $this->redirectToRoute('saas_subscription_plans');
+        }
+
+        $subscription = $this->getSubscription();
+
+        if (! $subscription instanceof Subscription) {
+            $this->addFlash('error', 'saas.flash.no_subscription_short');
+
+            return $this->redirectToRoute('_dashboard');
+        }
+
+        // Only a PENDING subscription is still mid-activation. Anything else has
+        // already moved past onboarding (the trial is running, or the plan is
+        // active/paused/cancelled), so hand off to the subscription overview.
+        if ($subscription->getStatus() !== SubscriptionStatus::PENDING) {
+            return $this->redirectToRoute('billing_index');
+        }
+
+        $this->telemetry->event(TelemetryEvent::SaasWelcomePageViewed);
+
+        return $this->render('@SolidInvoiceSaas/subscription/welcome.html.twig', [
+            'subscription' => $subscription,
+            'plan' => $subscription->getPlan(),
+        ]);
+    }
+
+    private function getSubscription(): ?Subscription
+    {
+        $companyId = $this->companySelector->getCompany();
+
+        if (! $companyId instanceof Ulid) {
+            return null;
+        }
+
+        $company = $this->companyRepository->find($companyId);
+
+        if (! $company instanceof Company) {
+            return null;
+        }
+
+        return $this->subscriptionProvider->getSubscriptionFor($company);
+    }
+}

--- a/src/SaasBundle/Checklist/ActivateSubscriptionItem.php
+++ b/src/SaasBundle/Checklist/ActivateSubscriptionItem.php
@@ -13,21 +13,26 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Checklist;
 
-use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\DashboardBundle\Checklist\ChecklistItemInterface;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Component\Uid\Ulid;
 
+/**
+ * @see \SolidInvoice\SaasBundle\Tests\Checklist\ActivateSubscriptionItemTest
+ */
 final readonly class ActivateSubscriptionItem implements ChecklistItemInterface
 {
     public function __construct(
         private SubscriptionProviderInterface $subscriptionProvider,
-        private CompanySelector $companySelector,
+        private CompanySelectorInterface $companySelector,
         private CompanyRepository $companyRepository,
+        private BillingMode $billingMode,
     ) {
     }
 
@@ -58,7 +63,10 @@ final readonly class ActivateSubscriptionItem implements ChecklistItemInterface
 
     public function active(): bool
     {
-        return true;
+        // In paid-trial mode a company cannot reach the dashboard without an
+        // active subscription in the first place, so prompting them to activate
+        // one is redundant.
+        return ! $this->billingMode->requiresCardForTrial();
     }
 
     public function isComplete(): bool

--- a/src/SaasBundle/Controller/SubscribeController.php
+++ b/src/SaasBundle/Controller/SubscribeController.php
@@ -21,6 +21,7 @@ use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Telemetry\Telemetry;
 use SolidInvoice\CoreBundle\Telemetry\TelemetryEvent;
 use SolidInvoice\SaasBundle\Action\ChoosePlanAction;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
@@ -50,6 +51,7 @@ class SubscribeController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly Telemetry $telemetry,
         private readonly ClockInterface $clock,
+        private readonly BillingMode $billingMode,
     ) {
     }
 
@@ -64,18 +66,9 @@ class SubscribeController extends AbstractController
             return $this->redirectToRoute('_dashboard');
         }
 
-        // Grant Lemon Squeezy's built-in trial (skip_trial: false) only for a
-        // user who is still actively trialling and has not yet added a card.
-        // This is what makes the "extend your trial" offer real. Every other
-        // path (expired trial, cancelled, free-plan upgrade, plan change) is
-        // charged immediately and must not receive a second free trial.
-        $grantsTrialExtension = $subscription->getStatus() === SubscriptionStatus::TRIAL
-            && ! $subscription->isExternallyBilled()
-            && $subscription->getEndDate() > $this->clock->now();
-
         $options = Options::new()
             ->withEmail($user->getEmail())
-            ->withSkipTrial(! $grantsTrialExtension);
+            ->withSkipTrial(! $this->grantsProviderTrial($subscription));
 
         // The chosen plan id (LS variant) is passed in via query parameter
         // from ChoosePlanAction / ConfirmPlanChangeAction. We swap it onto the
@@ -123,6 +116,37 @@ class SubscribeController extends AbstractController
         $this->telemetry->event(TelemetryEvent::SaasCheckoutStarted, ['plan' => $planName]);
 
         return $this->redirect($checkoutUrl);
+    }
+
+    /**
+     * Whether this checkout should let Lemon Squeezy apply the variant's
+     * built-in trial (`skip_trial: false`).
+     *
+     * The two billing modes disagree on what the first checkout means:
+     *
+     *  - Paid trial: checkout is how a trial *starts*. The subscription is
+     *    still PENDING and has never been billed, so it must receive the
+     *    trial. A variant configured with no trial days simply charges
+     *    immediately, which is the intended "no trial" behaviour.
+     *  - Free trial: the trial already ran locally, and checkout is how the
+     *    user extends it by adding a card. Only an actively-trialling,
+     *    never-billed subscription qualifies.
+     *
+     * Either way, a subscription that is already externally billed is
+     * changing plans and must never receive a second trial.
+     */
+    private function grantsProviderTrial(Subscription $subscription): bool
+    {
+        if ($subscription->isExternallyBilled()) {
+            return false;
+        }
+
+        if ($this->billingMode->requiresCardForTrial()) {
+            return true;
+        }
+
+        return $subscription->getStatus() === SubscriptionStatus::TRIAL
+            && $subscription->getEndDate() > $this->clock->now();
     }
 
     private function getSubscription(): ?Subscription

--- a/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
+++ b/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
@@ -17,6 +17,7 @@ use DateInterval;
 use Doctrine\ORM\EntityManagerInterface;
 use SolidInvoice\CoreBundle\Event\CompanyCreatedEvent;
 use SolidInvoice\SaasBundle\Plan\DefaultPlanProvider;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
@@ -44,6 +45,7 @@ final class CompanyEventSubscriber
         private readonly TrialManagerInterface $trialManager,
         private readonly EntityManagerInterface $entityManager,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly BillingMode $billingMode,
     ) {
     }
 
@@ -65,6 +67,14 @@ final class CompanyEventSubscriber
             $user = $this->security->getUser();
             assert($user instanceof User);
 
+            if ($this->billingMode->requiresCardForTrial()) {
+                $this->recordTrialEntry($user);
+                $event->setResponse($this->createPlanSelectionRedirect());
+                $this->subscription = null;
+
+                return;
+            }
+
             $plan = $this->subscription->getPlan();
 
             if (! $this->trialManager->userHasTrial($user) && $plan->getTrialDuration() instanceof DateInterval) {
@@ -85,6 +95,30 @@ final class CompanyEventSubscriber
             }
 
             $this->subscription = null;
+        }
+    }
+
+    /**
+     * In paid-trial mode the trial is started by the payment provider once the
+     * user completes checkout, so nothing is started locally — the subscription
+     * stays PENDING and RequestListener blocks the app until the webhook lands.
+     *
+     * The Trial row is still recorded here. It is the ledger the onboarding
+     * email scheduler joins against, so skipping it would silently stop the
+     * whole onboarding sequence, not just the trial-specific emails. In this
+     * mode it records "entered the trial funnel" rather than "trial started".
+     */
+    private function recordTrialEntry(User $user): void
+    {
+        if ($this->trialManager->userHasTrial($user)) {
+            return;
+        }
+
+        try {
+            $this->trialManager->createTrial($user, $this->subscription);
+        } catch (TrialAlreadyExistsException) {
+            // Race condition: another request already recorded a trial for this
+            // user. Harmless — the user is headed to plan selection regardless.
         }
     }
 

--- a/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
+++ b/src/SaasBundle/EventSubscriber/CompanyEventSubscriber.php
@@ -69,7 +69,7 @@ final class CompanyEventSubscriber
 
             if ($this->billingMode->requiresCardForTrial()) {
                 $this->recordTrialEntry($user);
-                $event->setResponse($this->createPlanSelectionRedirect());
+                $event->setResponse($this->createWelcomeRedirect());
                 $this->subscription = null;
 
                 return;
@@ -125,5 +125,10 @@ final class CompanyEventSubscriber
     private function createPlanSelectionRedirect(): RedirectResponse
     {
         return new RedirectResponse($this->urlGenerator->generate('saas_subscription_plans'));
+    }
+
+    private function createWelcomeRedirect(): RedirectResponse
+    {
+        return new RedirectResponse($this->urlGenerator->generate('saas_subscription_welcome'));
     }
 }

--- a/src/SaasBundle/EventSubscriber/RequestListener.php
+++ b/src/SaasBundle/EventSubscriber/RequestListener.php
@@ -17,6 +17,7 @@ use Psr\Clock\ClockInterface;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidInvoice\SaasBundle\Service\TrialBanner;
 use SolidInvoice\SaasBundle\Service\TrialBannerResolver;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
@@ -24,7 +25,6 @@ use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -43,6 +43,11 @@ use function in_array;
 final readonly class RequestListener implements EventSubscriberInterface
 {
     private const array SKIPPED_ROUTES = [
+        // Always leave a way out of a blocking page. This matters most in
+        // paid-trial mode, where every new signup sits at PENDING until they
+        // complete checkout — without this they could not even sign out.
+        '_logout',
+
         '_switch_company',
         '_view_quote_external',
         '_view_invoice_external',
@@ -76,10 +81,7 @@ final readonly class RequestListener implements EventSubscriberInterface
         private ClockInterface $clock,
         private TrialBannerResolver $trialBannerResolver,
         private TranslatorInterface $translator,
-        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
-        private string $onboardingCouponCode = '',
-        #[Autowire(env: 'int:SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT')]
-        private int $couponPercent = 30,
+        private BillingMode $billingMode,
     ) {
     }
 
@@ -139,8 +141,8 @@ final readonly class RequestListener implements EventSubscriberInterface
                         new Response(
                             $this->twig->render('@SolidInvoiceSaas/subscription/trial_expired.html.twig', [
                                 'subscription' => $subscription,
-                                'coupon_code' => $this->onboardingCouponCode,
-                                'coupon_percent' => $this->couponPercent,
+                                'coupon_code' => $this->billingMode->couponCode(),
+                                'coupon_percent' => $this->billingMode->couponPercent(),
                             ]),
                         )
                     );

--- a/src/SaasBundle/EventSubscriber/RequestListener.php
+++ b/src/SaasBundle/EventSubscriber/RequestListener.php
@@ -26,6 +26,7 @@ use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -53,6 +54,7 @@ final readonly class RequestListener implements EventSubscriberInterface
         '_view_invoice_external',
         'billing_index',
         'saas_subscription_checkout',
+        'saas_subscription_welcome',
         'saas_subscription_plans',
         'saas_subscription_choose',
         'saas_subscription_change',
@@ -103,6 +105,20 @@ final readonly class RequestListener implements EventSubscriberInterface
 
         switch ($subscription->getStatus()) {
             case SubscriptionStatus::PENDING:
+                if ($this->billingMode->requiresCardForTrial()) {
+                    // Card-required onboarding funnels to one welcoming
+                    // activation page instead of the plan picker. Redirecting
+                    // (rather than rendering inline) keeps that page on a single
+                    // canonical URL, and because the redirect stands for as long
+                    // as the subscription is PENDING, a user who logs out and
+                    // comes back weeks later lands straight back on it.
+                    $event->setResponse(
+                        new RedirectResponse($this->urlGenerator->generate('saas_subscription_welcome'))
+                    );
+
+                    break;
+                }
+
                 $event->setResponse(
                     new Response(
                         $this->twig->render('@SolidInvoiceSaas/subscription/pending.html.twig', [

--- a/src/SaasBundle/EventSubscriber/RetiredPendingPlanListener.php
+++ b/src/SaasBundle/EventSubscriber/RetiredPendingPlanListener.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionExpiredEvent;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * Drops a scheduled plan change whose target plan has since been retired.
+ *
+ * A downgrade is stored as a `pendingPlan` FK and only applied when the
+ * provider reports the subscription expired at the end of the paid period.
+ * `SubscriptionManager::applyScheduledPlanChange()` does not check whether the
+ * target plan is still active, so a downgrade scheduled *before* a plan was
+ * retired would still land on it — silently reopening a closed tier for that
+ * tenant, with a 100-year end date and no external subscription id.
+ *
+ * Clearing the pending change here means the vendor listener falls through to
+ * expiring the subscription instead, which puts the tenant in front of the
+ * plan picker rather than on a plan that is no longer sold.
+ *
+ * Runs before SubscriptionEventSubscriber::onSubscriptionExpired (priority 0).
+ *
+ * @see \SolidInvoice\SaasBundle\Tests\EventSubscriber\RetiredPendingPlanListenerTest
+ */
+final readonly class RetiredPendingPlanListener
+{
+    public function __construct(
+        private SubscriptionRepositoryInterface $subscriptionRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    #[AsEventListener(event: SubscriptionExpiredEvent::class, priority: 10)]
+    public function onSubscriptionExpired(SubscriptionExpiredEvent $event): void
+    {
+        $subscription = $this->subscriptionRepository->findOneBy(['id' => $event->subscriptionId]);
+
+        if (! $subscription instanceof Subscription || ! $subscription->hasPendingPlanChange()) {
+            return;
+        }
+
+        $pendingPlan = $subscription->getPendingPlan();
+
+        if (! $pendingPlan instanceof Plan || $pendingPlan->isActive()) {
+            return;
+        }
+
+        $this->logger->warning(
+            'Discarding scheduled plan change: the target plan is no longer active.',
+            [
+                'subscription_id' => $event->subscriptionId->toBase58(),
+                'pending_plan' => $pendingPlan->getPlanId(),
+            ],
+        );
+
+        $subscription->setPendingPlan(null);
+        $subscription->setPendingPlanChangeAt(null);
+
+        $this->subscriptionRepository->save($subscription);
+    }
+}

--- a/src/SaasBundle/Onboarding/Step/TrialAboutToEndStep.php
+++ b/src/SaasBundle/Onboarding/Step/TrialAboutToEndStep.php
@@ -19,9 +19,9 @@ use SolidInvoice\ClientBundle\Repository\ClientRepository;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\SaasBundle\Onboarding\OnboardingContext;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsTaggedItem(priority: 50)]
@@ -32,12 +32,20 @@ final class TrialAboutToEndStep extends AbstractOnboardingEmailStep
         private readonly ClockInterface $clock,
         private readonly ClientRepository $clientRepository,
         private readonly InvoiceRepository $invoiceRepository,
-        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
-        private readonly string $couponCode = '',
-        #[Autowire(env: 'int:SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT')]
-        private readonly int $couponPercent = 30,
+        private readonly BillingMode $billingMode,
     ) {
         parent::__construct($translator);
+    }
+
+    /**
+     * A paid trial already has a card on file, so warning the user that it is
+     * about to end — and offering a coupon to convert — is meaningless. The
+     * subscription simply bills at the end of the trial.
+     */
+    #[Override]
+    public function shouldSend(OnboardingContext $context): bool
+    {
+        return ! $this->billingMode->requiresCardForTrial() && parent::shouldSend($context);
     }
 
     public static function key(): string
@@ -73,8 +81,8 @@ final class TrialAboutToEndStep extends AbstractOnboardingEmailStep
 
         return parent::templateContext($context) + [
             'days_remaining' => $daysRemaining,
-            'coupon_code' => $this->couponCode,
-            'coupon_percent' => $this->couponPercent,
+            'coupon_code' => $this->billingMode->couponCode(),
+            'coupon_percent' => $this->billingMode->couponPercent(),
             'usage_clients' => $this->clientRepository->getTotalClients(),
             'usage_invoices' => $this->invoiceRepository->getTotalInvoices(),
             'usage_collected' => $this->invoiceRepository->getCountByStatus(InvoiceStatus::Paid),

--- a/src/SaasBundle/Onboarding/Step/UpgradeOfferStep.php
+++ b/src/SaasBundle/Onboarding/Step/UpgradeOfferStep.php
@@ -15,8 +15,8 @@ namespace SolidInvoice\SaasBundle\Onboarding\Step;
 
 use Override;
 use SolidInvoice\SaasBundle\Onboarding\OnboardingContext;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsTaggedItem(priority: 40)]
@@ -24,12 +24,20 @@ final class UpgradeOfferStep extends AbstractOnboardingEmailStep
 {
     public function __construct(
         TranslatorInterface $translator,
-        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
-        private readonly string $couponCode = '',
-        #[Autowire(env: 'int:SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT')]
-        private readonly int $couponPercent = 30,
+        private readonly BillingMode $billingMode,
     ) {
         parent::__construct($translator);
+    }
+
+    /**
+     * The upgrade offer exists to convert a free trial before it lapses. A paid
+     * trial converts on its own when the provider bills the card on file, and
+     * the coupon it advertises cannot be redeemed on an existing subscription.
+     */
+    #[Override]
+    public function shouldSend(OnboardingContext $context): bool
+    {
+        return ! $this->billingMode->requiresCardForTrial() && parent::shouldSend($context);
     }
 
     public static function key(): string
@@ -46,8 +54,8 @@ final class UpgradeOfferStep extends AbstractOnboardingEmailStep
     protected function templateContext(OnboardingContext $context): array
     {
         return parent::templateContext($context) + [
-            'coupon_code' => $this->couponCode,
-            'coupon_percent' => $this->couponPercent,
+            'coupon_code' => $this->billingMode->couponCode(),
+            'coupon_percent' => $this->billingMode->couponPercent(),
         ];
     }
 }

--- a/src/SaasBundle/Plan/TrialPeriod.php
+++ b/src/SaasBundle/Plan/TrialPeriod.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Plan;
+
+use Carbon\CarbonInterval;
+use DateInterval;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+
+/**
+ * Reads a plan's trial length in whole days.
+ *
+ * Plan::trialDuration is a DateInterval, which cannot be reduced to a day
+ * count reliably on its own (`->days` is only populated on diff-derived
+ * intervals), so the conversion lives here rather than being repeated at each
+ * call site — including Twig, which cannot do it at all.
+ *
+ * @see \SolidInvoice\SaasBundle\Tests\Plan\TrialPeriodTest
+ */
+final readonly class TrialPeriod
+{
+    /**
+     * Whole days of trial the plan grants, or null when it has no trial
+     * configured (or one that rounds down to nothing).
+     */
+    public function days(Plan $plan): ?int
+    {
+        $trialDuration = $plan->getTrialDuration();
+
+        if (! $trialDuration instanceof DateInterval) {
+            return null;
+        }
+
+        $days = (int) CarbonInterval::instance($trialDuration)->total('days');
+
+        return $days > 0 ? $days : null;
+    }
+}

--- a/src/SaasBundle/Resources/config/routing.php
+++ b/src/SaasBundle/Resources/config/routing.php
@@ -18,6 +18,7 @@ use SolidInvoice\SaasBundle\Action\ConfirmPlanChangeAction;
 use SolidInvoice\SaasBundle\Action\SelectPlanAction;
 use SolidInvoice\SaasBundle\Action\SubscriptionOverviewAction;
 use SolidInvoice\SaasBundle\Action\TemplatePreviewAction;
+use SolidInvoice\SaasBundle\Action\WelcomeAction;
 use SolidInvoice\SaasBundle\Controller\PaymentSuccess;
 use SolidInvoice\SaasBundle\Controller\SubscribeController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -32,6 +33,10 @@ return static function (RoutingConfigurator $routingConfigurator): void {
 
     $routingConfigurator->add('saas_subscription_checkout', '/subscription/activate')
         ->controller(SubscribeController::class);
+
+    $routingConfigurator->add('saas_subscription_welcome', '/subscription/welcome')
+        ->controller(WelcomeAction::class)
+        ->methods(['GET']);
 
     $routingConfigurator->add('saas_subscription_plans', '/subscription/plans')
         ->controller(SelectPlanAction::class)

--- a/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/_plans_grid.html.twig
@@ -20,6 +20,10 @@
 {% set actionRoute = actionRoute|default('saas_subscription_choose') %}
 {% set csrfToken = csrfToken|default('choose_plan') %}
 
+{# When a card is required up front, the CTA promises the trial the payment
+ # provider will actually grant — or plain "Subscribe" when there is none. #}
+{% set paidTrial = toggle('saas_paid_trial') %}
+
 {# Free plan rendered separately below the main grid. #}
 {% set freePlan = null %}
 {% set paidPlans = [] %}
@@ -78,7 +82,16 @@
                             <input type="hidden" name="_token" value="{{ csrf_token(csrfToken) }}">
                             <button type="submit" class="btn w-100 {{ isRecommended ? 'btn-primary' : 'btn-outline-primary' }}">
                                 {{ ux_icon('tabler:credit-card', {width: 18, height: 18}) }}
-                                {{ 'saas.plan.choose'|trans }}
+                                {% if paidTrial %}
+                                    {% set planTrialDays = saas_plan_trial_days(plan) %}
+                                    {% if planTrialDays %}
+                                        {{ 'saas.plan.start_trial'|trans({'%days%': planTrialDays, '%count%': planTrialDays}) }}
+                                    {% else %}
+                                        {{ 'saas.plan.subscribe'|trans }}
+                                    {% endif %}
+                                {% else %}
+                                    {{ 'saas.plan.choose'|trans }}
+                                {% endif %}
                             </button>
                         </form>
                     {% endif %}

--- a/src/SaasBundle/Resources/views/subscription/pending.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/pending.html.twig
@@ -23,9 +23,13 @@
                 {{ ux_icon('tabler:rocket', {width: 32, height: 32}) }}
             </div>
 
-            <h1 class="subscription-title">{{ 'saas.pending.title'|trans }}</h1>
+            {% set paidTrial = toggle('saas_paid_trial') %}
+
+            <h1 class="subscription-title">
+                {{ (paidTrial ? 'saas.pending.title_paid_trial' : 'saas.pending.title')|trans }}
+            </h1>
             <p class="subscription-subtitle">
-                {{ 'saas.pending.subtitle'|trans }}
+                {{ (paidTrial ? 'saas.pending.subtitle_paid_trial' : 'saas.pending.subtitle')|trans }}
             </p>
 
             {# Plan picker #}
@@ -36,7 +40,7 @@
 
                 <p class="text-subtle small mt-3 mb-0">
                     {{ ux_icon('tabler:lock', {width: 14, height: 14, class: 'me-1'}) }}
-                    {{ 'saas.pending.secure_checkout'|trans }}
+                    {{ (paidTrial ? 'saas.pending.secure_checkout_paid_trial' : 'saas.pending.secure_checkout')|trans }}
                 </p>
             {% else %}
                 {# Fallback when no plans are configured — keep the original CTA so the user can still complete activation. #}

--- a/src/SaasBundle/Resources/views/subscription/pending.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/pending.html.twig
@@ -19,9 +19,13 @@
                 {{ ux_icon('tabler:rocket', {width: 32, height: 32}) }}
             </div>
 
-            <h1 class="subscription-title">{{ 'saas.pending.title'|trans }}</h1>
+            {% set paidTrial = toggle('saas_paid_trial') %}
+
+            <h1 class="subscription-title">
+                {{ (paidTrial ? 'saas.pending.title_paid_trial' : 'saas.pending.title')|trans }}
+            </h1>
             <p class="subscription-subtitle">
-                {{ 'saas.pending.subtitle'|trans }}
+                {{ (paidTrial ? 'saas.pending.subtitle_paid_trial' : 'saas.pending.subtitle')|trans }}
             </p>
 
             {# Plan picker #}
@@ -32,7 +36,7 @@
 
                 <p class="text-subtle small mt-3 mb-0">
                     {{ ux_icon('tabler:lock', {width: 14, height: 14, class: 'me-1'}) }}
-                    {{ 'saas.pending.secure_checkout'|trans }}
+                    {{ (paidTrial ? 'saas.pending.secure_checkout_paid_trial' : 'saas.pending.secure_checkout')|trans }}
                 </p>
             {% else %}
                 {# Fallback when no plans are configured — keep the original CTA so the user can still complete activation. #}

--- a/src/SaasBundle/Resources/views/subscription/welcome.html.twig
+++ b/src/SaasBundle/Resources/views/subscription/welcome.html.twig
@@ -1,0 +1,171 @@
+{#
+ # This file is part of SolidInvoice package.
+ #
+ # (c) Pierre du Plessis <open-source@solidworx.co>
+ #
+ # This source file is subject to the MIT license that is bundled
+ # with this source code in the file LICENSE.
+ #
+ # The card-required onboarding activation page. Expects:
+ #   - subscription: Subscription (PENDING)
+ #   - plan: Plan (the default plan the subscription will activate on)
+ #}
+
+{% extends '@SolidInvoiceCore/Layout/default_no_nav.html.twig' %}
+
+{% block heading %}
+    {% include '@SolidInvoiceSaas/subscription/_header.html.twig' %}
+{% endblock heading %}
+
+{% block content %}
+    {% import '@SolidInvoiceSaas/subscription/_plans_grid.html.twig' as grid %}
+    {% set availableCompanies = app.user.companies|filter(v => v.id != company_id()) %}
+    {% set trialDays = saas_plan_trial_days(plan) %}
+    {% set firstName = app.user.firstName|default('') %}
+    {% set price = plan.price|formatCurrency('USD') %}
+
+    <div class="subscription-page subscription-welcome-page">
+        <div class="subscription-container">
+            {# Hero #}
+            <div class="subscription-icon subscription-icon-info">
+                {{ ux_icon('tabler:rocket', {width: 32, height: 32}) }}
+            </div>
+
+            <h1 class="subscription-title">
+                {% if trialDays %}
+                    {{ (firstName is not empty ? 'saas.welcome.title' : 'saas.welcome.title_no_name')|trans({'%name%': firstName}) }}
+                {% else %}
+                    {{ 'saas.welcome.title_no_trial'|trans }}
+                {% endif %}
+            </h1>
+            <p class="subscription-subtitle">
+                {% if trialDays %}
+                    {{ 'saas.welcome.subtitle'|trans({'%days%': trialDays, '%count%': trialDays}) }}
+                {% else %}
+                    {{ 'saas.welcome.subtitle_no_trial'|trans }}
+                {% endif %}
+            </p>
+
+            {# The one plan on offer — shown, not chosen. #}
+            <div class="card welcome-plan text-start mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-3">
+                        <div>
+                            <div class="text-uppercase text-subtle small fw-semibold mb-1">
+                                {{ 'saas.welcome.plan_label'|trans }}
+                            </div>
+                            <h2 class="h3 mb-0">{{ plan.name }}</h2>
+                        </div>
+                        <div class="text-end welcome-plan-pricing">
+                            {% if trialDays %}
+                                <div class="welcome-plan-price text-primary">
+                                    {{ 'saas.welcome.plan_free_for'|trans({'%days%': trialDays, '%count%': trialDays}) }}
+                                </div>
+                                <div class="text-subtle small">{{ 'saas.welcome.plan_then'|trans({'%price%': price}) }}</div>
+                            {% else %}
+                                <div class="welcome-plan-price">{{ price }}</div>
+                                <div class="text-subtle small">{{ 'saas.plan.per_month'|trans }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+
+                    {% if plan.description is not empty %}
+                        <p class="text-subtle mb-3">{{ plan.description }}</p>
+                    {% endif %}
+
+                    {% if plan.features|length > 0 %}
+                        <div class="text-uppercase text-subtle small fw-semibold mb-2">
+                            {{ 'saas.welcome.included_heading'|trans }}
+                        </div>
+                        {{ grid.feature_list(plan.features) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            {# Reassurance — the three things that melt card hesitation. #}
+            <div class="row welcome-reassure g-3 text-start mb-4">
+                <div class="col-12 col-md-4">
+                    <div class="welcome-reassure-item">
+                        {{ ux_icon('tabler:shield-check', {width: 22, height: 22}) }}
+                        <div>
+                            <div class="fw-semibold">{{ 'saas.welcome.no_charge'|trans }}</div>
+                            {% if trialDays %}
+                                <div class="text-subtle small">{{ 'saas.welcome.no_charge_detail'|trans }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-4">
+                    <div class="welcome-reassure-item">
+                        {{ ux_icon('tabler:calendar-x', {width: 22, height: 22}) }}
+                        <div>
+                            <div class="fw-semibold">{{ 'saas.welcome.cancel_anytime'|trans }}</div>
+                            <div class="text-subtle small">{{ 'saas.welcome.cancel_anytime_detail'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-4">
+                    <div class="welcome-reassure-item">
+                        {{ ux_icon('tabler:lock', {width: 22, height: 22}) }}
+                        <div>
+                            <div class="fw-semibold">{{ 'saas.welcome.secure_checkout'|trans }}</div>
+                            <div class="text-subtle small">{{ 'saas.welcome.secure_checkout_detail'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {# Primary CTA — the only choice on the page. #}
+            <div class="subscription-actions">
+                <a href="{{ path('saas_subscription_checkout') }}" class="btn btn-primary btn-lg">
+                    {{ ux_icon('tabler:credit-card', {width: 20, height: 20}) }}
+                    {% if trialDays %}
+                        {{ 'saas.welcome.cta_trial'|trans({'%days%': trialDays, '%count%': trialDays}) }}
+                    {% else %}
+                        {{ 'saas.welcome.cta_no_trial'|trans }}
+                    {% endif %}
+                </a>
+            </div>
+            {% if trialDays %}
+                <p class="text-subtle small mt-2 mb-0">
+                    {{ ux_icon('tabler:lock', {width: 14, height: 14, class: 'me-1'}) }}
+                    {{ 'saas.welcome.cta_caption'|trans }}
+                </p>
+            {% endif %}
+
+            {# Edge case: the user just came back from checkout, webhook still in flight. #}
+            <twig:Ui:Alert type="info" class="mt-4 text-start">
+                <div class="d-flex align-items-start gap-2">
+                    {{ ux_icon('tabler:info-circle', {width: 20, height: 20}) }}
+                    <div>
+                        <strong>{{ 'saas.welcome.just_completed_title'|trans }}</strong><br>
+                        {{ 'saas.welcome.just_completed_message'|trans }}
+                    </div>
+                </div>
+            </twig:Ui:Alert>
+
+            {# The user has another company they can already use. #}
+            {% if availableCompanies|length > 0 %}
+                <twig:Ui:Alert type="info" class="mt-3 text-start">
+                    <div class="d-flex align-items-center gap-2">
+                        {{ ux_icon('tabler:building', {width: 20, height: 20}) }}
+                        <div>
+                            {{ 'saas.company.access_other'|trans }}
+                            <a href="{{ path('_switch_company', {'id': availableCompanies|first.id}) }}" class="alert-link">
+                                {{ 'saas.company.switch_to'|trans({'%company%': availableCompanies|first}) }}
+                            </a>
+                        </div>
+                    </div>
+                </twig:Ui:Alert>
+            {% endif %}
+
+            {# Help #}
+            <p class="text-subtle small mt-4 mb-0">
+                {{ 'saas.welcome.need_help'|trans }}
+                <a href="https://solidinvoice.co/contact" target="_blank" rel="external noreferrer noopener">
+                    {{ 'saas.action.contact_support_short'|trans }}
+                </a>
+            </p>
+        </div>
+    </div>
+{% endblock content %}

--- a/src/SaasBundle/Service/BillingMode.php
+++ b/src/SaasBundle/Service/BillingMode.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Service;
+
+use SolidWorx\Toggler\ToggleInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Single point of interpretation for how this deployment sells subscriptions.
+ *
+ * Keeping the toggle key in one place means callers depend on the intent
+ * ("does a trial require a card?") rather than on the toggle name, and gives
+ * tests a single seam to drive.
+ *
+ * @see \SolidInvoice\SaasBundle\Tests\Service\BillingModeTest
+ */
+final readonly class BillingMode
+{
+    public function __construct(
+        private ToggleInterface $toggle,
+        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
+        private string $couponCode = '',
+        #[Autowire(env: 'int:SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT')]
+        private int $couponPercent = 30,
+    ) {
+    }
+
+    /**
+     * True when the trial only starts after the user enters payment details at
+     * the payment provider. The provider owns the trial window; a variant with
+     * no trial configured simply charges on the first payment.
+     */
+    public function requiresCardForTrial(): bool
+    {
+        return $this->toggle->isActive('saas_paid_trial');
+    }
+
+    /**
+     * The onboarding coupon, or an empty string when it should not be offered.
+     *
+     * A paid trial already has a card on file and a discount applied at
+     * checkout, so there is nothing left for the user to redeem — suppressing
+     * it centrally keeps every consumer (banner, expired page, emails) honest.
+     */
+    public function couponCode(): string
+    {
+        return $this->requiresCardForTrial() ? '' : $this->couponCode;
+    }
+
+    public function couponPercent(): int
+    {
+        return $this->couponPercent;
+    }
+}

--- a/src/SaasBundle/Service/TrialBannerResolver.php
+++ b/src/SaasBundle/Service/TrialBannerResolver.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Service;
 
-use Carbon\CarbonInterval;
-use DateInterval;
 use Psr\Clock\ClockInterface;
-use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidInvoice\SaasBundle\Plan\TrialPeriod;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -33,10 +31,8 @@ final readonly class TrialBannerResolver
 {
     public function __construct(
         private ClockInterface $clock,
-        #[Autowire(env: 'SOLIDINVOICE_SAAS_ONBOARDING_COUPON_CODE')]
-        private string $couponCode = '',
-        #[Autowire(env: 'int:SOLIDINVOICE_SAAS_ONBOARDING_COUPON_PERCENT')]
-        private int $couponPercent = 30,
+        private BillingMode $billingMode,
+        private TrialPeriod $trialPeriod,
         #[Autowire(env: 'int:SOLIDINVOICE_SAAS_TRIAL_BANNER_DAYS')]
         private int $bannerDays = 7,
         #[Autowire(env: 'int:SOLIDINVOICE_SAAS_TRIAL_COUPON_DAYS')]
@@ -67,6 +63,13 @@ final readonly class TrialBannerResolver
             return null;
         }
 
+        // Below here the banner is a trial *incentive* — extend the trial, or
+        // redeem a coupon. A paid trial already has a card on file, so neither
+        // is on offer. The cancelled notice above still applies in both modes.
+        if ($this->billingMode->requiresCardForTrial()) {
+            return null;
+        }
+
         // A card is already on file (Lemon Squeezy is billing this trial); the
         // extension has already happened, so nudging them again is wrong.
         if ($subscription->isExternallyBilled()) {
@@ -90,13 +93,15 @@ final readonly class TrialBannerResolver
         // the "get N more days" copy always reflects the real trial the user
         // receives by adding a card. Without a trial length we cannot make that
         // promise, so no banner is shown.
-        $extensionDays = $this->trialExtensionDays($subscription->getPlan());
+        $extensionDays = $this->trialPeriod->days($subscription->getPlan());
 
         if ($extensionDays === null) {
             return null;
         }
 
-        if ($this->couponCode !== '' && $daysRemaining <= $this->couponDays) {
+        $couponCode = $this->billingMode->couponCode();
+
+        if ($couponCode !== '' && $daysRemaining <= $this->couponDays) {
             return new TrialBanner(
                 'info',
                 'tabler:gift',
@@ -104,11 +109,11 @@ final readonly class TrialBannerResolver
                 'saas.trial_banner.coupon.message',
                 [
                     '%days%' => $extensionDays,
-                    '%percent%' => $this->couponPercent,
-                    '%code%' => $this->couponCode,
+                    '%percent%' => $this->billingMode->couponPercent(),
+                    '%code%' => $couponCode,
                 ],
                 'saas.trial_banner.coupon.cta',
-                $this->couponCode,
+                $couponCode,
             );
         }
 
@@ -120,23 +125,5 @@ final readonly class TrialBannerResolver
             ['%days%' => $extensionDays],
             'saas.trial_banner.extend.cta',
         );
-    }
-
-    /**
-     * Whole days of trial the plan grants, derived from the Plan's trial
-     * duration (synced from the payment provider by the back-office). Null when
-     * the plan has no trial configured.
-     */
-    private function trialExtensionDays(Plan $plan): ?int
-    {
-        $trialDuration = $plan->getTrialDuration();
-
-        if (! $trialDuration instanceof DateInterval) {
-            return null;
-        }
-
-        $days = (int) CarbonInterval::instance($trialDuration)->total('days');
-
-        return $days > 0 ? $days : null;
     }
 }

--- a/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
@@ -42,16 +42,16 @@ final class SelectPlanActionTest extends TestCase
         $bus = new CollectingMessageBus();
 
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
-        $planRepository->expects(self::once())->method('findAllOrdered')->willReturn([
+        $planRepository->expects($this->once())->method('findAllOrdered')->willReturn([
             $this->makePlan('Free'),
             $this->makePlan('Solo'),
         ]);
 
         $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
-        $subscriptionProvider->expects(self::never())->method('getSubscriptionFor')->willReturn(null);
+        $subscriptionProvider->expects($this->never())->method('getSubscriptionFor')->willReturn(null);
 
         $companyRepository = $this->createMock(CompanyRepository::class);
-        $companyRepository->expects(self::never())->method('find')->willReturn(new Company());
+        $companyRepository->expects($this->never())->method('find')->willReturn(new Company());
 
         // CompanySelector is final; a real instance with no selected company
         // returns null from getCompany(), which short-circuits subscription
@@ -68,7 +68,7 @@ final class SelectPlanActionTest extends TestCase
         );
 
         $twig = $this->createMock(Environment::class);
-        $twig->expects(self::once())->method('render')->willReturn('<html></html>');
+        $twig->expects($this->once())->method('render')->willReturn('<html></html>');
 
         $container = new Container();
         $container->set('twig', $twig);
@@ -87,7 +87,7 @@ final class SelectPlanActionTest extends TestCase
         // The plan picker must never be reached in card-required onboarding —
         // the default plan is activated from the dedicated welcome page instead.
         $planRepository = $this->createMock(PlanRepositoryInterface::class);
-        $planRepository->expects(self::never())->method('findAllOrdered');
+        $planRepository->expects($this->never())->method('findAllOrdered');
 
         $subscriptionProvider = $this->createStub(SubscriptionProviderInterface::class);
         $companyRepository = $this->createStub(CompanyRepository::class);
@@ -102,7 +102,7 @@ final class SelectPlanActionTest extends TestCase
             BillingModeFactory::paidTrial(),
         );
 
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturn('/billing/subscription/welcome');
 
         $container = new Container();
@@ -124,7 +124,7 @@ final class SelectPlanActionTest extends TestCase
     private function makeTelemetry(CollectingMessageBus $bus): Telemetry
     {
         $vault = $this->createMock(AbstractVault::class);
-        $vault->expects(self::never())->method('generateKeys')->willReturn(true);
+        $vault->expects($this->never())->method('generateKeys')->willReturn(true);
 
         return new Telemetry(
             $bus,

--- a/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
+++ b/src/SaasBundle/Tests/Action/SelectPlanActionTest.php
@@ -24,11 +24,14 @@ use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Telemetry\Telemetry;
 use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
 use SolidInvoice\SaasBundle\Action\SelectPlanAction;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 #[CoversClass(SelectPlanAction::class)]
@@ -61,6 +64,7 @@ final class SelectPlanActionTest extends TestCase
             $companyRepository,
             $companySelector,
             $this->makeTelemetry($bus),
+            BillingModeFactory::freeTrial(),
         );
 
         $twig = $this->createMock(Environment::class);
@@ -76,6 +80,40 @@ final class SelectPlanActionTest extends TestCase
         self::assertCount(1, $bus->messages);
         self::assertSame('event', $bus->messages[0]->type);
         self::assertSame('saas_pricing_page_viewed', $bus->messages[0]->payload['event']);
+    }
+
+    public function testPaidTrialModeRedirectsToTheWelcomePage(): void
+    {
+        // The plan picker must never be reached in card-required onboarding —
+        // the default plan is activated from the dedicated welcome page instead.
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->expects(self::never())->method('findAllOrdered');
+
+        $subscriptionProvider = $this->createStub(SubscriptionProviderInterface::class);
+        $companyRepository = $this->createStub(CompanyRepository::class);
+        $companySelector = new CompanySelector($this->createStub(ManagerRegistry::class));
+
+        $action = new SelectPlanAction(
+            $planRepository,
+            $subscriptionProvider,
+            $companyRepository,
+            $companySelector,
+            $this->makeTelemetry(new CollectingMessageBus()),
+            BillingModeFactory::paidTrial(),
+        );
+
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturn('/billing/subscription/welcome');
+
+        $container = new Container();
+        $container->set('router', $router);
+
+        $action->setContainer($container);
+
+        $response = $action();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/billing/subscription/welcome', $response->getTargetUrl());
     }
 
     private function makePlan(string $name): Plan

--- a/src/SaasBundle/Tests/Action/WelcomeActionTest.php
+++ b/src/SaasBundle/Tests/Action/WelcomeActionTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Action;
+
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
+use SolidInvoice\CoreBundle\ConfigWriter;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\CoreBundle\Telemetry\Telemetry;
+use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
+use SolidInvoice\SaasBundle\Action\WelcomeAction;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Ulid;
+use Twig\Environment;
+
+#[CoversClass(WelcomeAction::class)]
+final class WelcomeActionTest extends TestCase
+{
+    public function testFreeTrialModeRedirectsToThePlanPicker(): void
+    {
+        // The welcome page belongs to card-required onboarding only; free-trial
+        // mode keeps the plan picker, and never even looks up a subscription.
+        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->expects(self::never())->method('getSubscriptionFor');
+
+        $action = $this->action(
+            BillingModeFactory::freeTrial(),
+            $this->createStub(CompanySelectorInterface::class),
+            $this->createStub(CompanyRepository::class),
+            $subscriptionProvider,
+            new CollectingMessageBus(),
+        );
+
+        $action->setContainer($this->routerContainer());
+
+        $response = $action();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/plans', $response->getTargetUrl());
+    }
+
+    public function testPaidTrialPendingRendersTheWelcomePageAndEmitsTelemetry(): void
+    {
+        $bus = new CollectingMessageBus();
+
+        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector->method('getCompany')->willReturn(new Ulid());
+
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository->method('find')->willReturn(new Company());
+
+        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->method('getSubscriptionFor')->willReturn(
+            $this->subscription(SubscriptionStatus::PENDING),
+        );
+
+        $action = $this->action(
+            BillingModeFactory::paidTrial(),
+            $companySelector,
+            $companyRepository,
+            $subscriptionProvider,
+            $bus,
+        );
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->with('@SolidInvoiceSaas/subscription/welcome.html.twig', self::anything())
+            ->willReturn('<html></html>');
+
+        $container = new Container();
+        $container->set('twig', $twig);
+
+        $action->setContainer($container);
+
+        $response = $action();
+
+        self::assertNotInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('<html></html>', (string) $response->getContent());
+        self::assertCount(1, $bus->messages);
+        self::assertSame('saas_welcome_page_viewed', $bus->messages[0]->payload['event']);
+    }
+
+    public function testPaidTrialWithoutSubscriptionRedirectsToTheDashboard(): void
+    {
+        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector->method('getCompany')->willReturn(null);
+
+        $action = $this->action(
+            BillingModeFactory::paidTrial(),
+            $companySelector,
+            $this->createStub(CompanyRepository::class),
+            $this->createStub(SubscriptionProviderInterface::class),
+            new CollectingMessageBus(),
+        );
+
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static fn (string $route): string => '/' . $route,
+        );
+
+        $container = new Container();
+        $container->set('router', $router);
+        $container->set('request_stack', $this->requestStackWithSession());
+
+        $action->setContainer($container);
+
+        $response = $action();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/_dashboard', $response->getTargetUrl());
+    }
+
+    public function testPaidTrialActiveSubscriptionRedirectsToBilling(): void
+    {
+        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector->method('getCompany')->willReturn(new Ulid());
+
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository->method('find')->willReturn(new Company());
+
+        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider->method('getSubscriptionFor')->willReturn(
+            $this->subscription(SubscriptionStatus::ACTIVE),
+        );
+
+        $action = $this->action(
+            BillingModeFactory::paidTrial(),
+            $companySelector,
+            $companyRepository,
+            $subscriptionProvider,
+            new CollectingMessageBus(),
+        );
+
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static fn (string $route): string => '/' . $route,
+        );
+
+        $container = new Container();
+        $container->set('router', $router);
+
+        $action->setContainer($container);
+
+        $response = $action();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/billing_index', $response->getTargetUrl());
+    }
+
+    private function action(
+        BillingMode $billingMode,
+        CompanySelectorInterface $companySelector,
+        CompanyRepository $companyRepository,
+        SubscriptionProviderInterface $subscriptionProvider,
+        CollectingMessageBus $bus,
+    ): WelcomeAction {
+        return new WelcomeAction(
+            $subscriptionProvider,
+            $companyRepository,
+            $companySelector,
+            $billingMode,
+            $this->makeTelemetry($bus),
+        );
+    }
+
+    private function subscription(SubscriptionStatus $status): Subscription
+    {
+        $plan = new Plan();
+        $plan->setName('Pro');
+        $plan->setPlanId('variant-123');
+        $plan->setPrice(1000);
+
+        $subscription = new Subscription();
+        $subscription->setPlan($plan);
+        $subscription->setStatus($status);
+
+        return $subscription;
+    }
+
+    private function routerContainer(): Container
+    {
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static fn (string $route): string => match ($route) {
+                'saas_subscription_plans' => '/plans',
+                default => '/' . $route,
+            },
+        );
+
+        $container = new Container();
+        $container->set('router', $router);
+
+        return $container;
+    }
+
+    private function requestStackWithSession(): RequestStack
+    {
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return $requestStack;
+    }
+
+    private function makeTelemetry(CollectingMessageBus $bus): Telemetry
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->expects(self::never())->method('generateKeys')->willReturn(true);
+
+        return new Telemetry(
+            $bus,
+            new ConfigWriter($vault, '/tmp/solidinvoice-test-config'),
+            DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]),
+            'build-123',
+            true,
+            'manual',
+            false,
+            'en',
+            null,
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Action/WelcomeActionTest.php
+++ b/src/SaasBundle/Tests/Action/WelcomeActionTest.php
@@ -226,8 +226,7 @@ final class WelcomeActionTest extends TestCase
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         return $requestStack;
     }

--- a/src/SaasBundle/Tests/Action/WelcomeActionTest.php
+++ b/src/SaasBundle/Tests/Action/WelcomeActionTest.php
@@ -48,7 +48,7 @@ final class WelcomeActionTest extends TestCase
         // The welcome page belongs to card-required onboarding only; free-trial
         // mode keeps the plan picker, and never even looks up a subscription.
         $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
-        $subscriptionProvider->expects(self::never())->method('getSubscriptionFor');
+        $subscriptionProvider->expects($this->never())->method('getSubscriptionFor');
 
         $action = $this->action(
             BillingModeFactory::freeTrial(),
@@ -70,13 +70,13 @@ final class WelcomeActionTest extends TestCase
     {
         $bus = new CollectingMessageBus();
 
-        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector = $this->createStub(CompanySelectorInterface::class);
         $companySelector->method('getCompany')->willReturn(new Ulid());
 
-        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository = $this->createStub(CompanyRepository::class);
         $companyRepository->method('find')->willReturn(new Company());
 
-        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider = $this->createStub(SubscriptionProviderInterface::class);
         $subscriptionProvider->method('getSubscriptionFor')->willReturn(
             $this->subscription(SubscriptionStatus::PENDING),
         );
@@ -90,7 +90,7 @@ final class WelcomeActionTest extends TestCase
         );
 
         $twig = $this->createMock(Environment::class);
-        $twig->expects(self::once())
+        $twig->expects($this->once())
             ->method('render')
             ->with('@SolidInvoiceSaas/subscription/welcome.html.twig', self::anything())
             ->willReturn('<html></html>');
@@ -110,7 +110,7 @@ final class WelcomeActionTest extends TestCase
 
     public function testPaidTrialWithoutSubscriptionRedirectsToTheDashboard(): void
     {
-        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector = $this->createStub(CompanySelectorInterface::class);
         $companySelector->method('getCompany')->willReturn(null);
 
         $action = $this->action(
@@ -121,7 +121,7 @@ final class WelcomeActionTest extends TestCase
             new CollectingMessageBus(),
         );
 
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $route): string => '/' . $route,
         );
@@ -140,13 +140,13 @@ final class WelcomeActionTest extends TestCase
 
     public function testPaidTrialActiveSubscriptionRedirectsToBilling(): void
     {
-        $companySelector = $this->createMock(CompanySelectorInterface::class);
+        $companySelector = $this->createStub(CompanySelectorInterface::class);
         $companySelector->method('getCompany')->willReturn(new Ulid());
 
-        $companyRepository = $this->createMock(CompanyRepository::class);
+        $companyRepository = $this->createStub(CompanyRepository::class);
         $companyRepository->method('find')->willReturn(new Company());
 
-        $subscriptionProvider = $this->createMock(SubscriptionProviderInterface::class);
+        $subscriptionProvider = $this->createStub(SubscriptionProviderInterface::class);
         $subscriptionProvider->method('getSubscriptionFor')->willReturn(
             $this->subscription(SubscriptionStatus::ACTIVE),
         );
@@ -159,7 +159,7 @@ final class WelcomeActionTest extends TestCase
             new CollectingMessageBus(),
         );
 
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $route): string => '/' . $route,
         );
@@ -207,7 +207,7 @@ final class WelcomeActionTest extends TestCase
 
     private function routerContainer(): Container
     {
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $route): string => match ($route) {
                 'saas_subscription_plans' => '/plans',
@@ -226,15 +226,13 @@ final class WelcomeActionTest extends TestCase
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
 
-        $requestStack = new RequestStack([$request]);
-
-        return $requestStack;
+        return new RequestStack([$request]);
     }
 
     private function makeTelemetry(CollectingMessageBus $bus): Telemetry
     {
         $vault = $this->createMock(AbstractVault::class);
-        $vault->expects(self::never())->method('generateKeys')->willReturn(true);
+        $vault->expects($this->never())->method('generateKeys')->willReturn(true);
 
         return new Telemetry(
             $bus,

--- a/src/SaasBundle/Tests/BillingModeFactory.php
+++ b/src/SaasBundle/Tests/BillingModeFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests;
+
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidWorx\Toggler\ToggleInterface;
+
+/**
+ * Builds a real BillingMode over a fake toggle, so tests exercise the same
+ * code path production does instead of mocking BillingMode itself.
+ */
+final class BillingModeFactory
+{
+    public static function freeTrial(string $couponCode = '', int $couponPercent = 30): BillingMode
+    {
+        return self::create(false, $couponCode, $couponPercent);
+    }
+
+    public static function paidTrial(string $couponCode = '', int $couponPercent = 30): BillingMode
+    {
+        return self::create(true, $couponCode, $couponPercent);
+    }
+
+    private static function create(bool $paidTrial, string $couponCode, int $couponPercent): BillingMode
+    {
+        $toggle = new readonly class($paidTrial) implements ToggleInterface {
+            public function __construct(
+                private bool $paidTrial,
+            ) {
+            }
+
+            public function isActive(string $feature, array $context = []): bool
+            {
+                return $feature === 'saas_paid_trial' && $this->paidTrial;
+            }
+        };
+
+        return new BillingMode($toggle, $couponCode, $couponPercent);
+    }
+}

--- a/src/SaasBundle/Tests/Checklist/ActivateSubscriptionItemTest.php
+++ b/src/SaasBundle/Tests/Checklist/ActivateSubscriptionItemTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Checklist;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelectorInterface;
+use SolidInvoice\CoreBundle\Repository\CompanyRepository;
+use SolidInvoice\SaasBundle\Checklist\ActivateSubscriptionItem;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
+
+#[CoversClass(ActivateSubscriptionItem::class)]
+final class ActivateSubscriptionItemTest extends TestCase
+{
+    public function testTheItemIsOfferedInFreeTrialMode(): void
+    {
+        self::assertTrue($this->item(BillingModeFactory::freeTrial())->active());
+    }
+
+    /**
+     * In paid-trial mode the company cannot reach the dashboard without an
+     * active subscription, so the prompt would always be redundant.
+     */
+    public function testTheItemIsHiddenInPaidTrialMode(): void
+    {
+        self::assertFalse($this->item(BillingModeFactory::paidTrial())->active());
+    }
+
+    private function item(BillingMode $billingMode): ActivateSubscriptionItem
+    {
+        return new ActivateSubscriptionItem(
+            $this->createStub(SubscriptionProviderInterface::class),
+            $this->createStub(CompanySelectorInterface::class),
+            $this->createStub(CompanyRepository::class),
+            $billingMode,
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
+++ b/src/SaasBundle/Tests/Controller/SubscribeControllerTest.php
@@ -29,6 +29,8 @@ use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Telemetry\Telemetry;
 use SolidInvoice\CoreBundle\Tests\Telemetry\CollectingMessageBus;
 use SolidInvoice\SaasBundle\Controller\SubscribeController;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
@@ -164,6 +166,61 @@ final class SubscribeControllerTest extends TestCase
     }
 
     /**
+     * The whole point of paid-trial mode: checkout is how the trial starts, so
+     * the first checkout must let Lemon Squeezy apply the variant's trial. The
+     * subscription is still PENDING here, which under the free-trial rules
+     * would have skipped the trial and charged the user immediately.
+     */
+    public function testPendingCheckoutGrantsTrialInPaidTrialMode(): void
+    {
+        $subscription = $this->trialSubscription(
+            SubscriptionStatus::PENDING,
+            CarbonImmutable::parse('2024-01-01'),
+        );
+
+        $options = $this->captureCheckoutOptions(
+            $subscription,
+            CarbonImmutable::parse('2024-01-01'),
+            BillingModeFactory::paidTrial(),
+        );
+
+        self::assertFalse($options->getValue(Options::SKIP_TRIAL));
+    }
+
+    public function testExternallyBilledCheckoutSkipsTrialInPaidTrialMode(): void
+    {
+        $subscription = $this->trialSubscription(
+            SubscriptionStatus::ACTIVE,
+            CarbonImmutable::parse('2024-02-01'),
+            'ls_existing_1',
+        );
+
+        $options = $this->captureCheckoutOptions(
+            $subscription,
+            CarbonImmutable::parse('2024-01-01'),
+            BillingModeFactory::paidTrial(),
+        );
+
+        self::assertTrue($options->getValue(Options::SKIP_TRIAL));
+    }
+
+    /**
+     * Free-trial mode must be unaffected by the paid-trial branch: a PENDING
+     * subscription there is a free-plan upgrade and is charged immediately.
+     */
+    public function testPendingCheckoutSkipsTrialInFreeTrialMode(): void
+    {
+        $subscription = $this->trialSubscription(
+            SubscriptionStatus::PENDING,
+            CarbonImmutable::parse('2024-01-01'),
+        );
+
+        $options = $this->captureCheckoutOptions($subscription, CarbonImmutable::parse('2024-01-01'));
+
+        self::assertTrue($options->getValue(Options::SKIP_TRIAL));
+    }
+
+    /**
      * @return array{0: RedirectResponse, 1: array<string, list<string|Stringable>>}
      */
     private function invokeController(?Throwable $exception): array
@@ -210,6 +267,7 @@ final class SubscribeControllerTest extends TestCase
             $this->createStub(EntityManagerInterface::class),
             $this->makeTelemetry(),
             $clock,
+            BillingModeFactory::freeTrial(),
         );
 
         $session = new Session(new MockArraySessionStorage());
@@ -281,8 +339,11 @@ final class SubscribeControllerTest extends TestCase
         return $subscription;
     }
 
-    private function captureCheckoutOptions(Subscription $subscription, DateTimeImmutable $now): Options
-    {
+    private function captureCheckoutOptions(
+        Subscription $subscription,
+        DateTimeImmutable $now,
+        ?BillingMode $billingMode = null,
+    ): Options {
         $capturedOptions = null;
 
         $paymentIntegration = $this->createMock(PaymentIntegrationInterface::class);
@@ -320,6 +381,7 @@ final class SubscribeControllerTest extends TestCase
             $this->createStub(EntityManagerInterface::class),
             $this->makeTelemetry(),
             $clock,
+            $billingMode ?? BillingModeFactory::freeTrial(),
         );
 
         $session = new Session(new MockArraySessionStorage());

--- a/src/SaasBundle/Tests/Email/OnboardingEmailSnapshotTest.php
+++ b/src/SaasBundle/Tests/Email/OnboardingEmailSnapshotTest.php
@@ -29,6 +29,7 @@ use SolidInvoice\SaasBundle\Onboarding\Step\TrialAboutToEndStep;
 use SolidInvoice\SaasBundle\Onboarding\Step\TurnInvoicesIntoPaymentsStep;
 use SolidInvoice\SaasBundle\Onboarding\Step\UpgradeOfferStep;
 use SolidInvoice\SaasBundle\Onboarding\Step\WelcomeStep;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidInvoice\Test\SaasKernel;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
@@ -193,7 +194,7 @@ final class OnboardingEmailSnapshotTest extends KernelTestCase
 
     private function upgradeOfferStep(): UpgradeOfferStep
     {
-        return new UpgradeOfferStep($this->translator, 'SOLID30');
+        return new UpgradeOfferStep($this->translator, BillingModeFactory::freeTrial('SOLID30'));
     }
 
     private function trialAboutToEndStep(): TrialAboutToEndStep
@@ -203,7 +204,7 @@ final class OnboardingEmailSnapshotTest extends KernelTestCase
             new MockClock(self::FROZEN_NOW),
             self::getContainer()->get(ClientRepository::class),
             self::getContainer()->get(InvoiceRepository::class),
-            'SOLID30',
+            BillingModeFactory::freeTrial('SOLID30'),
         );
     }
 }

--- a/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\EventSubscriber;
+
+use DateInterval;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Event\CompanyCreatedEvent;
+use SolidInvoice\SaasBundle\EventSubscriber\CompanyEventSubscriber;
+use SolidInvoice\SaasBundle\Plan\DefaultPlanProvider;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Entity\Trial;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+use SolidWorx\Platform\SaasBundle\Trial\TrialManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * In paid-trial mode the trial belongs to the payment provider, so signup must
+ * not start one locally — it leaves the subscription PENDING (which is what
+ * makes RequestListener gate the app) and sends the user to pick a plan.
+ *
+ * SubscriptionManager is final, so these assert the resulting subscription
+ * state rather than mocking the call.
+ */
+#[CoversClass(CompanyEventSubscriber::class)]
+final class CompanyEventSubscriberPaidTrialTest extends TestCase
+{
+    public function testPaidTrialModeLeavesTheSubscriptionPending(): void
+    {
+        [, $subscription] = $this->dispatchSignup(BillingModeFactory::paidTrial());
+
+        self::assertSame(SubscriptionStatus::PENDING, $subscription->getStatus());
+    }
+
+    public function testPaidTrialModeRedirectsToPlanSelection(): void
+    {
+        [$event] = $this->dispatchSignup(BillingModeFactory::paidTrial());
+
+        $response = $event->getResponse();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/billing/subscription/plans', $response->getTargetUrl());
+    }
+
+    /**
+     * The Trial row is the ledger the onboarding email scheduler joins against.
+     * Without it the whole sequence stops, not just the trial-specific emails.
+     */
+    public function testPaidTrialModeStillRecordsTheTrialLedgerRow(): void
+    {
+        $trialManager = $this->createMock(TrialManagerInterface::class);
+        $trialManager->method('userHasTrial')->willReturn(false);
+        $trialManager->expects(self::once())->method('createTrial')->willReturn(new Trial());
+
+        $this->dispatchSignup(BillingModeFactory::paidTrial(), $trialManager);
+    }
+
+    public function testPaidTrialModeDoesNotRecordASecondTrialForTheSameUser(): void
+    {
+        $trialManager = $this->createMock(TrialManagerInterface::class);
+        $trialManager->method('userHasTrial')->willReturn(true);
+        $trialManager->expects(self::never())->method('createTrial');
+
+        $this->dispatchSignup(BillingModeFactory::paidTrial(), $trialManager);
+    }
+
+    /**
+     * Free-trial mode must be untouched: a plan with a configured trial still
+     * starts one locally at signup, flipping the subscription to TRIAL.
+     */
+    public function testFreeTrialModeStillStartsATrialLocally(): void
+    {
+        [, $subscription] = $this->dispatchSignup(BillingModeFactory::freeTrial());
+
+        self::assertSame(SubscriptionStatus::TRIAL, $subscription->getStatus());
+    }
+
+    /**
+     * @return array{0: ResponseEvent, 1: Subscription}
+     */
+    private function dispatchSignup(
+        BillingMode $billingMode,
+        ?TrialManagerInterface $trialManager = null,
+    ): array {
+        $plan = new Plan();
+        $plan->setName('Pro');
+        $plan->setPlanId('variant-123');
+        $plan->setPrice(1000);
+        $plan->setTrialDuration(new DateInterval('P14D'));
+
+        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository->method('find')->willReturn($plan);
+        $planRepository->method('findDefault')->willReturn($plan);
+
+        // SubscriptionManager persists through save() on every mutation, so the
+        // last saved entity is the subscription in its final state.
+        $saved = null;
+        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository->method('save')->willReturnCallback(
+            static function (object $entity) use (&$saved): void {
+                if ($entity instanceof Subscription) {
+                    $saved = $entity;
+                }
+            },
+        );
+
+        $subscriptionManager = new SubscriptionManager(
+            $subscriptionRepository,
+            $planRepository,
+            $this->createStub(PaymentIntegrationInterface::class),
+        );
+
+        if (! $trialManager instanceof TrialManagerInterface) {
+            $trialManager = $this->createMock(TrialManagerInterface::class);
+            $trialManager->method('userHasTrial')->willReturn(false);
+            $trialManager->method('createTrial')->willReturn(new Trial());
+        }
+
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn(new User());
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('wrapInTransaction')->willReturnCallback(
+            static fn (callable $callback): mixed => $callback($entityManager),
+        );
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/billing/subscription/plans');
+
+        $subscriber = new CompanyEventSubscriber(
+            new DefaultPlanProvider($planRepository),
+            $subscriptionManager,
+            $security,
+            $trialManager,
+            $entityManager,
+            $urlGenerator,
+            $billingMode,
+        );
+
+        $company = new Company();
+        $event = new CompanyCreatedEvent($company);
+        $subscriber->onCompanyCreated($event);
+
+        $responseEvent = new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response(),
+        );
+
+        $subscriber->onResponse($responseEvent);
+
+        self::assertInstanceOf(Subscription::class, $saved);
+
+        return [$responseEvent, $saved];
+    }
+}

--- a/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
@@ -78,7 +78,7 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
     {
         $trialManager = $this->createMock(TrialManagerInterface::class);
         $trialManager->method('userHasTrial')->willReturn(false);
-        $trialManager->expects(self::once())->method('createTrial')->willReturn(new Trial());
+        $trialManager->expects($this->once())->method('createTrial')->willReturn(new Trial());
 
         $this->dispatchSignup(BillingModeFactory::paidTrial(), $trialManager);
     }
@@ -87,7 +87,7 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
     {
         $trialManager = $this->createMock(TrialManagerInterface::class);
         $trialManager->method('userHasTrial')->willReturn(true);
-        $trialManager->expects(self::never())->method('createTrial');
+        $trialManager->expects($this->never())->method('createTrial');
 
         $this->dispatchSignup(BillingModeFactory::paidTrial(), $trialManager);
     }
@@ -116,14 +116,14 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
         $plan->setPrice(1000);
         $plan->setTrialDuration(new DateInterval('P14D'));
 
-        $planRepository = $this->createMock(PlanRepositoryInterface::class);
+        $planRepository = $this->createStub(PlanRepositoryInterface::class);
         $planRepository->method('find')->willReturn($plan);
         $planRepository->method('findDefault')->willReturn($plan);
 
         // SubscriptionManager persists through save() on every mutation, so the
         // last saved entity is the subscription in its final state.
         $saved = null;
-        $subscriptionRepository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $subscriptionRepository = $this->createStub(SubscriptionRepositoryInterface::class);
         $subscriptionRepository->method('save')->willReturnCallback(
             static function (object $entity) use (&$saved): void {
                 if ($entity instanceof Subscription) {
@@ -139,20 +139,20 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
         );
 
         if (! $trialManager instanceof TrialManagerInterface) {
-            $trialManager = $this->createMock(TrialManagerInterface::class);
+            $trialManager = $this->createStub(TrialManagerInterface::class);
             $trialManager->method('userHasTrial')->willReturn(false);
             $trialManager->method('createTrial')->willReturn(new Trial());
         }
 
-        $security = $this->createMock(Security::class);
+        $security = $this->createStub(Security::class);
         $security->method('getUser')->willReturn(new User());
 
-        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
         $entityManager->method('wrapInTransaction')->willReturnCallback(
             static fn (callable $callback): mixed => $callback($entityManager),
         );
 
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $urlGenerator->method('generate')->willReturnCallback(
             static fn (string $route): string => match ($route) {
                 'saas_subscription_welcome' => '/billing/subscription/welcome',

--- a/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/CompanyEventSubscriberPaidTrialTest.php
@@ -44,7 +44,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * In paid-trial mode the trial belongs to the payment provider, so signup must
  * not start one locally — it leaves the subscription PENDING (which is what
- * makes RequestListener gate the app) and sends the user to pick a plan.
+ * makes RequestListener gate the app) and sends the user to the welcome page to
+ * activate the default plan.
  *
  * SubscriptionManager is final, so these assert the resulting subscription
  * state rather than mocking the call.
@@ -59,14 +60,14 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
         self::assertSame(SubscriptionStatus::PENDING, $subscription->getStatus());
     }
 
-    public function testPaidTrialModeRedirectsToPlanSelection(): void
+    public function testPaidTrialModeRedirectsToTheWelcomePage(): void
     {
         [$event] = $this->dispatchSignup(BillingModeFactory::paidTrial());
 
         $response = $event->getResponse();
 
         self::assertInstanceOf(RedirectResponse::class, $response);
-        self::assertSame('/billing/subscription/plans', $response->getTargetUrl());
+        self::assertSame('/billing/subscription/welcome', $response->getTargetUrl());
     }
 
     /**
@@ -152,7 +153,12 @@ final class CompanyEventSubscriberPaidTrialTest extends TestCase
         );
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator->method('generate')->willReturn('/billing/subscription/plans');
+        $urlGenerator->method('generate')->willReturnCallback(
+            static fn (string $route): string => match ($route) {
+                'saas_subscription_welcome' => '/billing/subscription/welcome',
+                default => '/billing/subscription/plans',
+            },
+        );
 
         $subscriber = new CompanyEventSubscriber(
             new DefaultPlanProvider($planRepository),

--- a/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
@@ -26,7 +26,9 @@ use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\SaasBundle\EventSubscriber\RequestListener;
+use SolidInvoice\SaasBundle\Plan\TrialPeriod;
 use SolidInvoice\SaasBundle\Service\TrialBannerResolver;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidInvoice\Test\SaasKernel;
 use SolidInvoice\UserBundle\Entity\User;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
@@ -410,6 +412,9 @@ final class RequestListenerTest extends KernelTestCase
         yield ['_switch_company'];
         yield ['_view_quote_external'];
         yield ['_view_invoice_external'];
+
+        // A blocked subscription must never trap the user in the app.
+        yield ['_logout'];
     }
 
     private function createListener(
@@ -479,10 +484,12 @@ final class RequestListenerTest extends KernelTestCase
 
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
+        $billingMode = BillingModeFactory::freeTrial($couponCode, $couponPercent);
+
         $trialBannerResolver = new TrialBannerResolver(
             $clock,
-            couponCode: $couponCode,
-            couponPercent: $couponPercent,
+            $billingMode,
+            new TrialPeriod(),
             bannerDays: 7,
             couponDays: 2,
         );
@@ -498,8 +505,7 @@ final class RequestListenerTest extends KernelTestCase
             $clock,
             $trialBannerResolver,
             $translator,
-            $couponCode,
-            $couponPercent,
+            $billingMode,
         );
     }
 

--- a/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RequestListenerTest.php
@@ -27,6 +27,7 @@ use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\SaasBundle\EventSubscriber\RequestListener;
 use SolidInvoice\SaasBundle\Plan\TrialPeriod;
+use SolidInvoice\SaasBundle\Service\BillingMode;
 use SolidInvoice\SaasBundle\Service\TrialBannerResolver;
 use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidInvoice\Test\SaasKernel;
@@ -38,6 +39,7 @@ use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
 use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -125,6 +127,31 @@ final class RequestListenerTest extends KernelTestCase
         $response = $event->getResponse();
         self::assertInstanceOf(Response::class, $response);
         self::assertStringContainsString('Pending Page', (string) $response->getContent());
+    }
+
+    public function testOnRequestWithPendingStatusInPaidTrialModeRedirectsToWelcome(): void
+    {
+        $subscription = $this->createSubscription(SubscriptionStatus::PENDING);
+        $listener = $this->createListener(
+            new User(),
+            subscription: $subscription,
+            billingMode: BillingModeFactory::paidTrial(),
+        );
+
+        $request = new Request();
+        $request->attributes->set('_route', '_dashboard');
+
+        $event = new RequestEvent(
+            M::mock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringContainsString('/subscription/welcome', $response->getTargetUrl());
     }
 
     public function testOnRequestWithPausedStatus(): void
@@ -425,6 +452,7 @@ final class RequestListenerTest extends KernelTestCase
         ?callable $onTrialExpiredRender = null,
         ?callable $onBannerRender = null,
         int $couponPercent = 30,
+        ?BillingMode $billingMode = null,
     ): RequestListener {
         // Get real services from container
         $companySelector = self::getContainer()->get(CompanySelector::class);
@@ -484,7 +512,7 @@ final class RequestListenerTest extends KernelTestCase
 
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
-        $billingMode = BillingModeFactory::freeTrial($couponCode, $couponPercent);
+        $billingMode ??= BillingModeFactory::freeTrial($couponCode, $couponPercent);
 
         $trialBannerResolver = new TrialBannerResolver(
             $clock,

--- a/src/SaasBundle/Tests/EventSubscriber/RetiredPendingPlanListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RetiredPendingPlanListenerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\EventSubscriber;
+
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use SolidInvoice\SaasBundle\EventSubscriber\RetiredPendingPlanListener;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Event\SubscriptionExpiredEvent;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(RetiredPendingPlanListener::class)]
+final class RetiredPendingPlanListenerTest extends TestCase
+{
+    /**
+     * A downgrade scheduled before the target plan was retired would otherwise
+     * be applied on expiry, silently reopening a closed tier for that tenant.
+     */
+    public function testAPendingChangeToARetiredPlanIsDiscarded(): void
+    {
+        $subscription = $this->subscriptionPendingChangeTo($this->plan(active: false));
+
+        $this->listenerFor($subscription)->onSubscriptionExpired($this->event());
+
+        self::assertNull($subscription->getPendingPlan());
+        self::assertNull($subscription->getPendingPlanChangeAt());
+        self::assertFalse($subscription->hasPendingPlanChange());
+    }
+
+    public function testAPendingChangeToAnActivePlanIsLeftAlone(): void
+    {
+        $activePlan = $this->plan(active: true);
+        $subscription = $this->subscriptionPendingChangeTo($activePlan);
+
+        $this->listenerFor($subscription)->onSubscriptionExpired($this->event());
+
+        self::assertSame($activePlan, $subscription->getPendingPlan());
+        self::assertTrue($subscription->hasPendingPlanChange());
+    }
+
+    public function testASubscriptionWithNoPendingChangeIsUntouched(): void
+    {
+        $subscription = new Subscription();
+        $subscription->setPlan($this->plan(active: true));
+
+        $this->listenerFor($subscription)->onSubscriptionExpired($this->event());
+
+        self::assertFalse($subscription->hasPendingPlanChange());
+    }
+
+    public function testAnUnknownSubscriptionIsIgnored(): void
+    {
+        $this->listenerFor(null)->onSubscriptionExpired($this->event());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function listenerFor(?Subscription $subscription): RetiredPendingPlanListener
+    {
+        $repository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $repository->method('findOneBy')->willReturn($subscription);
+
+        return new RetiredPendingPlanListener($repository, new NullLogger());
+    }
+
+    private function subscriptionPendingChangeTo(Plan $pendingPlan): Subscription
+    {
+        $subscription = new Subscription();
+        $subscription->setPlan($this->plan(active: true));
+        $subscription->setPendingPlan($pendingPlan);
+        $subscription->setPendingPlanChangeAt(CarbonImmutable::parse('2024-02-01'));
+
+        return $subscription;
+    }
+
+    private function plan(bool $active): Plan
+    {
+        $plan = new Plan();
+        $plan->setName('Free');
+        $plan->setPlanId('0');
+        $plan->setPrice(0);
+        $plan->setActive($active);
+
+        return $plan;
+    }
+
+    private function event(): SubscriptionExpiredEvent
+    {
+        return new SubscriptionExpiredEvent(new Ulid(), 'ls_sub_1', null);
+    }
+}

--- a/src/SaasBundle/Tests/EventSubscriber/RetiredPendingPlanListenerTest.php
+++ b/src/SaasBundle/Tests/EventSubscriber/RetiredPendingPlanListenerTest.php
@@ -72,7 +72,7 @@ final class RetiredPendingPlanListenerTest extends TestCase
 
     private function listenerFor(?Subscription $subscription): RetiredPendingPlanListener
     {
-        $repository = $this->createMock(SubscriptionRepositoryInterface::class);
+        $repository = $this->createStub(SubscriptionRepositoryInterface::class);
         $repository->method('findOneBy')->willReturn($subscription);
 
         return new RetiredPendingPlanListener($repository, new NullLogger());

--- a/src/SaasBundle/Tests/Onboarding/Step/TrialIncentiveStepSuppressionTest.php
+++ b/src/SaasBundle/Tests/Onboarding/Step/TrialIncentiveStepSuppressionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Onboarding\Step;
+
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Repository\ClientRepository;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
+use SolidInvoice\SaasBundle\Onboarding\OnboardingContext;
+use SolidInvoice\SaasBundle\Onboarding\Step\TrialAboutToEndStep;
+use SolidInvoice\SaasBundle\Onboarding\Step\UpgradeOfferStep;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
+use SolidInvoice\UserBundle\Entity\User;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Both of these emails exist to convert a free trial before it lapses. With a
+ * card already on file neither has anything to offer, so paid-trial mode must
+ * suppress them — while leaving the rest of the onboarding sequence intact.
+ */
+#[CoversClass(TrialAboutToEndStep::class)]
+#[CoversClass(UpgradeOfferStep::class)]
+final class TrialIncentiveStepSuppressionTest extends TestCase
+{
+    public function testTrialAboutToEndSendsInFreeTrialMode(): void
+    {
+        self::assertTrue(
+            $this->trialAboutToEndStep(BillingModeFactory::freeTrial('SAVE30'))->shouldSend($this->context()),
+        );
+    }
+
+    public function testTrialAboutToEndIsSuppressedInPaidTrialMode(): void
+    {
+        self::assertFalse(
+            $this->trialAboutToEndStep(BillingModeFactory::paidTrial('SAVE30'))->shouldSend($this->context()),
+        );
+    }
+
+    public function testUpgradeOfferSendsInFreeTrialMode(): void
+    {
+        self::assertTrue(
+            $this->upgradeOfferStep(BillingModeFactory::freeTrial('SAVE30'))->shouldSend($this->context()),
+        );
+    }
+
+    public function testUpgradeOfferIsSuppressedInPaidTrialMode(): void
+    {
+        self::assertFalse(
+            $this->upgradeOfferStep(BillingModeFactory::paidTrial('SAVE30'))->shouldSend($this->context()),
+        );
+    }
+
+    private function trialAboutToEndStep(BillingMode $billingMode): TrialAboutToEndStep
+    {
+        return new TrialAboutToEndStep(
+            $this->createStub(TranslatorInterface::class),
+            new MockClock('2024-01-05'),
+            $this->createStub(ClientRepository::class),
+            $this->createStub(InvoiceRepository::class),
+            $billingMode,
+        );
+    }
+
+    private function upgradeOfferStep(BillingMode $billingMode): UpgradeOfferStep
+    {
+        return new UpgradeOfferStep($this->createStub(TranslatorInterface::class), $billingMode);
+    }
+
+    private function context(): OnboardingContext
+    {
+        return new OnboardingContext(
+            new User(),
+            new Company(),
+            new Subscription(),
+            new Plan(),
+            CarbonImmutable::parse('2024-01-01'),
+            CarbonImmutable::parse('2024-01-15'),
+        );
+    }
+}

--- a/src/SaasBundle/Tests/Plan/TrialPeriodTest.php
+++ b/src/SaasBundle/Tests/Plan/TrialPeriodTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Plan;
+
+use DateInterval;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Plan\TrialPeriod;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+
+#[CoversClass(TrialPeriod::class)]
+final class TrialPeriodTest extends TestCase
+{
+    public function testAPlanWithoutATrialHasNoDays(): void
+    {
+        self::assertNull(new TrialPeriod()->days(new Plan()));
+    }
+
+    /**
+     * A zero-length trial is the "no trial, bill immediately" configuration and
+     * must not read as a one-day trial in the UI.
+     */
+    public function testAZeroLengthTrialHasNoDays(): void
+    {
+        self::assertNull(new TrialPeriod()->days($this->planWithTrial('PT0S')));
+    }
+
+    #[DataProvider('trialDurations')]
+    public function testTrialDurationIsReducedToWholeDays(string $duration, int $expected): void
+    {
+        self::assertSame($expected, new TrialPeriod()->days($this->planWithTrial($duration)));
+    }
+
+    /**
+     * A calendar-month trial has no exact day count without a reference date;
+     * Carbon cascades it at 4 weeks per month. Payment providers configure
+     * trials in days, so this only matters if a month interval is ever set by
+     * hand — assert the shape rather than pinning Carbon's factor.
+     */
+    public function testAMonthLongTrialIsApproximatedInDays(): void
+    {
+        $days = new TrialPeriod()->days($this->planWithTrial('P1M'));
+
+        self::assertNotNull($days);
+        self::assertGreaterThanOrEqual(28, $days);
+        self::assertLessThanOrEqual(31, $days);
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function trialDurations(): iterable
+    {
+        yield 'days' => ['P14D', 14];
+        yield 'a single day' => ['P1D', 1];
+        yield 'a fortnight' => ['P2W', 14];
+        yield 'hours rounding down' => ['PT36H', 1];
+    }
+
+    private function planWithTrial(string $duration): Plan
+    {
+        $plan = new Plan();
+        $plan->setTrialDuration(new DateInterval($duration));
+
+        return $plan;
+    }
+}

--- a/src/SaasBundle/Tests/Service/BillingModeTest.php
+++ b/src/SaasBundle/Tests/Service/BillingModeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Tests\Service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\SaasBundle\Service\BillingMode;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
+
+#[CoversClass(BillingMode::class)]
+final class BillingModeTest extends TestCase
+{
+    public function testFreeTrialModeDoesNotRequireACard(): void
+    {
+        self::assertFalse(BillingModeFactory::freeTrial()->requiresCardForTrial());
+    }
+
+    public function testPaidTrialModeRequiresACard(): void
+    {
+        self::assertTrue(BillingModeFactory::paidTrial()->requiresCardForTrial());
+    }
+
+    public function testCouponIsOfferedInFreeTrialMode(): void
+    {
+        $billingMode = BillingModeFactory::freeTrial('SAVE30', 30);
+
+        self::assertSame('SAVE30', $billingMode->couponCode());
+        self::assertSame(30, $billingMode->couponPercent());
+    }
+
+    /**
+     * A paid trial already has a card on file, so there is no coupon left to
+     * redeem. Suppressing it here is what silences the banner, the expired-trial
+     * page and the onboarding emails at once.
+     */
+    public function testCouponIsSuppressedInPaidTrialMode(): void
+    {
+        self::assertSame('', BillingModeFactory::paidTrial('SAVE30', 30)->couponCode());
+    }
+
+    public function testAnUnconfiguredCouponIsEmptyInEitherMode(): void
+    {
+        self::assertSame('', BillingModeFactory::freeTrial()->couponCode());
+        self::assertSame('', BillingModeFactory::paidTrial()->couponCode());
+    }
+}

--- a/src/SaasBundle/Tests/Service/TrialBannerResolverTest.php
+++ b/src/SaasBundle/Tests/Service/TrialBannerResolverTest.php
@@ -19,8 +19,10 @@ use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
+use SolidInvoice\SaasBundle\Plan\TrialPeriod;
 use SolidInvoice\SaasBundle\Service\TrialBanner;
 use SolidInvoice\SaasBundle\Service\TrialBannerResolver;
+use SolidInvoice\SaasBundle\Tests\BillingModeFactory;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
@@ -132,20 +134,56 @@ final class TrialBannerResolverTest extends TestCase
         self::assertNull($banner);
     }
 
+    /**
+     * Neither banner variant makes sense once a card is required up front: the
+     * trial cannot be extended and the coupon cannot be redeemed. This holds
+     * even in the window where a free trial would have shown one.
+     */
+    public function testNoBannerInPaidTrialMode(): void
+    {
+        $banner = $this->resolve(SubscriptionStatus::TRIAL, '2024-01-03', paidTrial: true);
+
+        self::assertNull($banner);
+    }
+
+    public function testBannerShowsInTheSameWindowInFreeTrialMode(): void
+    {
+        $banner = $this->resolve(SubscriptionStatus::TRIAL, '2024-01-03');
+
+        self::assertInstanceOf(TrialBanner::class, $banner);
+    }
+
+    /**
+     * Suppressing trial incentives must not suppress the cancelled notice —
+     * that one tells the user when they lose access and applies in both modes.
+     */
+    public function testCancelledBannerStillShowsInPaidTrialMode(): void
+    {
+        $banner = $this->resolve(SubscriptionStatus::CANCELLED, '2024-01-10', paidTrial: true);
+
+        self::assertInstanceOf(TrialBanner::class, $banner);
+        self::assertSame('saas.trial_banner.cancelled.title', $banner->titleKey);
+    }
+
     private function resolve(
         SubscriptionStatus $status,
         string $endDate,
         string $couponCode = 'SAVE30',
         ?string $subscriptionId = null,
         string $trialDuration = 'P14D',
+        bool $paidTrial = false,
     ): ?TrialBanner {
         $clock = $this->createStub(ClockInterface::class);
         $clock->method('now')->willReturn(new DateTimeImmutable(self::NOW));
 
+        $billingMode = $paidTrial
+            ? BillingModeFactory::paidTrial($couponCode)
+            : BillingModeFactory::freeTrial($couponCode);
+
         $resolver = new TrialBannerResolver(
             $clock,
-            couponCode: $couponCode,
-            couponPercent: 30,
+            $billingMode,
+            new TrialPeriod(),
             bannerDays: 7,
             couponDays: 2,
         );

--- a/src/SaasBundle/Twig/SubscriptionExtension.php
+++ b/src/SaasBundle/Twig/SubscriptionExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\SaasBundle\Twig;
+
+use Override;
+use SolidInvoice\SaasBundle\Plan\TrialPeriod;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes a plan's trial length to templates so plan-picker copy can promise
+ * the real number of days. Whether a card is required up front is already
+ * available in Twig as `toggle('saas_paid_trial')`.
+ */
+final class SubscriptionExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly TrialPeriod $trialPeriod,
+    ) {
+    }
+
+    /**
+     * @return list<TwigFunction>
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('saas_plan_trial_days', $this->planTrialDays(...)),
+        ];
+    }
+
+    public function planTrialDays(Plan $plan): ?int
+    {
+        return $this->trialPeriod->days($plan);
+    }
+}

--- a/src/SaasBundle/Twig/SubscriptionExtension.php
+++ b/src/SaasBundle/Twig/SubscriptionExtension.php
@@ -13,35 +13,23 @@ declare(strict_types=1);
 
 namespace SolidInvoice\SaasBundle\Twig;
 
-use Override;
 use SolidInvoice\SaasBundle\Plan\TrialPeriod;
 use SolidWorx\Platform\SaasBundle\Entity\Plan;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * Exposes a plan's trial length to templates so plan-picker copy can promise
  * the real number of days. Whether a card is required up front is already
  * available in Twig as `toggle('saas_paid_trial')`.
  */
-final class SubscriptionExtension extends AbstractExtension
+final readonly class SubscriptionExtension
 {
     public function __construct(
-        private readonly TrialPeriod $trialPeriod,
+        private TrialPeriod $trialPeriod,
     ) {
     }
 
-    /**
-     * @return list<TwigFunction>
-     */
-    #[Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('saas_plan_trial_days', $this->planTrialDays(...)),
-        ];
-    }
-
+    #[AsTwigFunction(name: 'saas_plan_trial_days')]
     public function planTrialDays(Plan $plan): ?int
     {
         return $this->trialPeriod->days($plan);

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -230,6 +230,7 @@ company:
         then: Then
         title: 'Create Your Company'
         trial_title: 'Start Your Free Trial'
+        trial_title_paid: 'Start Your Trial'
         trial_used: 'You have already used your free trial.'
         view_docs: 'View Documentation'
     select:
@@ -2002,12 +2003,17 @@ saas:
         just_completed_title: 'Just completed checkout?'
         need_help: 'Need a hand?'
         secure_checkout: 'Secure checkout · Cancel anytime · No hidden fees'
+        secure_checkout_paid_trial: 'Secure checkout · Cancel anytime during your trial · No hidden fees'
         subtitle: 'Pick a plan and start running your business with SolidInvoice in minutes.'
+        subtitle_paid_trial: 'Pick a plan and add your payment details to get started. You can cancel at any time.'
         switch_company: 'Switch to another company'
         title: 'Activate Your Subscription'
+        title_paid_trial: 'Choose Your Plan'
     plan:
         choose: 'Choose plan'
         continue_free: 'Continue with Free'
+        start_trial: '{1}Start 1-day trial|]1,Inf[Start %days%-day trial'
+        subscribe: Subscribe
         current: 'Current plan'
         included: Included
         just_getting_started: 'Just getting started?'

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1997,17 +1997,17 @@ saas:
         while_paused: 'While paused'
         while_paused_message: "Your data is safe and will be waiting for you. You won't be charged during this time, but you won't have access to features until you resume."
     pending:
-        activate: 'Activate Subscription'
+        activate: 'Get started'
         already_activated: 'Already activated?'
         just_completed_message: 'If you just completed the payment process, your subscription may take a moment to activate. You can refresh this page or wait a few seconds.'
         just_completed_title: 'Just completed checkout?'
         need_help: 'Need a hand?'
         secure_checkout: 'Secure checkout · Cancel anytime · No hidden fees'
         secure_checkout_paid_trial: 'Secure checkout · Cancel anytime during your trial · No hidden fees'
-        subtitle: 'Pick a plan and start running your business with SolidInvoice in minutes.'
+        subtitle: 'Choose a plan to unlock invoicing, online payments, and reports — then keep your business running. Change or cancel any time.'
         subtitle_paid_trial: 'Pick a plan and add your payment details to get started. You can cancel at any time.'
         switch_company: 'Switch to another company'
-        title: 'Activate Your Subscription'
+        title: 'Get full access to SolidInvoice'
         title_paid_trial: 'Choose Your Plan'
     plan:
         choose: 'Choose plan'
@@ -2059,6 +2059,28 @@ saas:
         promo_message: 'Activate your subscription now and use code <strong>%code%</strong> at checkout to get <strong>%percent%% off your first 3 months</strong>. Keep your invoices flowing without missing a beat.'
         subtitle: 'Your %days%-day trial ended on %date%. Activate your subscription at %price%/month to continue using SolidInvoice.'
         title: 'Your trial has ended'
+    welcome:
+        cancel_anytime: 'Cancel anytime'
+        cancel_anytime_detail: "Change your mind before your trial ends and you won't pay a cent."
+        cta_caption: "You won't be charged until your trial ends."
+        cta_no_trial: 'Unlock full access'
+        cta_trial: '{1}Start my 1-day free trial|]1,Inf[Start my %days%-day free trial'
+        included_heading: "What's included"
+        just_completed_message: 'If you just entered your payment details, it can take a few seconds to confirm. Refresh the page, or hold tight and it will update on its own.'
+        just_completed_title: 'Just finished checkout?'
+        need_help: 'Have a question before you start?'
+        no_charge: 'No charge today'
+        no_charge_detail: "We'll only bill you once your free trial ends."
+        plan_free_for: '{1}Free for 1 day|]1,Inf[Free for %days% days'
+        plan_label: 'Your plan'
+        plan_then: 'then %price%/month'
+        secure_checkout: 'Secure checkout'
+        secure_checkout_detail: 'Your card details are encrypted and handled by our payment provider.'
+        subtitle: "{1}Add your card to unlock a full day of everything SolidInvoice can do, free. We won't charge you until your trial ends, and you can cancel any time before then.|]1,Inf[Add your card to unlock %days% days of everything SolidInvoice can do, free. We won't charge you until your trial ends, and you can cancel any time before then."
+        subtitle_no_trial: 'Add your payment details to activate your subscription and start sending invoices, tracking payments, and getting paid — all from one place.'
+        title: 'Welcome aboard, %name%'
+        title_no_name: 'Welcome aboard'
+        title_no_trial: "You're one step from full access"
 save: Save
 search:
     and: and


### PR DESCRIPTION
## Summary

Adds a configurable second billing mode where the trial only starts once the user enters payment details at Lemon Squeezy, alongside today's card-free trial. Both modes coexist and are switched by a deployment-wide toggle. Separately, the free tier can be closed using the existing `Plan.active` flag while grandfathering existing free companies. Everything is contained in `src/SaasBundle` — no vendor changes.

| Config | Behaviour |
|---|---|
| `SOLIDINVOICE_SAAS_PAID_TRIAL=0` (default) | Today's free-trial behaviour, unchanged |
| `SOLIDINVOICE_SAAS_PAID_TRIAL=1` | Signup → plan picker → LS checkout; trial starts on the `subscription_created` webhook; no incentive banners/coupons/trial emails/checklist item |
| Free plan `active=false` | Free tier closed to new entry; existing free companies keep working |

A Lemon Squeezy variant with 0 trial days flows through the same path and activates on first payment.

## Key changes

- **`BillingMode` service** — single interpretation point for the toggle and coupon suppression; every consumer depends on it rather than the toggle string.
- **Fix inverted `skip_trial`** (`SubscribeController`) — in paid-trial mode the first checkout comes from a `PENDING`, never-billed subscription, which previously sent `skip_trial: true` and would have charged the user immediately instead of starting the trial. This is the core correctness fix.
- **`CompanyEventSubscriber`** — paid-trial signup leaves the subscription `PENDING` (the existing `RequestListener` gate locks the app until the webhook lands) and redirects to plan selection. Still records the `Trial` ledger row so the onboarding email scheduler keeps working.
- **Suppression** — extend/coupon banner, coupon code, `trial_about_to_end` + `upgrade_offer` emails, and the "Activate subscription" checklist item all go quiet in paid-trial mode. The cancelled-subscription notice and the other six onboarding emails still show.
- **Free tier** — closed via `Plan.active = false` (no new config). `RetiredPendingPlanListener` drops a downgrade scheduled *before* deactivation so it cannot silently reopen the retired tier for a tenant.
- **Copy** — company-creation, pending, and plan-picker templates adapt for paid-trial mode; `TrialPeriod` extracted for reuse and `saas_plan_trial_days()` exposed to Twig.
- **`_logout`** added to `RequestListener`'s skipped routes so a blocked subscription never traps the user.

## Testing

- `bin/phpunit` — full suite: **2253 tests, 2238 passed, 15 skipped, 0 failures**.
- `bin/phpstan analyse` — clean (only the 2 pre-existing `DeleteActionTest` container errors remain).
- `bin/ecs check` / `bin/rector --dry-run` — clean.
- `toggle:list` confirms `saas_paid_trial` defaults off, flips on with the env var, and resolves in self-hosted mode.

## Notes

- Syncing trial days from Lemon Squeezy is out of scope; `Plan::trialDuration` is assumed populated in production (it has no production callers, only manual seeding). Dev fixtures set no trial duration, so both modes need a duration seeded to exercise locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)