### PR TITLE
fix: propagate company from client in TaxIdentifier::setClient() to prevent 500 on API create (fixes #2579)

### DIFF
--- a/src/TaxBundle/Entity/TaxIdentifier.php
+++ b/src/TaxBundle/Entity/TaxIdentifier.php
@@ -142,6 +142,10 @@ class TaxIdentifier implements Stringable
     {
         $this->client = $client;
 
+        if ($client !== null) {
+            $this->setCompany($client->getCompany());
+        }
+
         return $this;
     }
 

--- a/src/TaxBundle/Tests/Entity/TaxIdentifierTest.php
+++ b/src/TaxBundle/Tests/Entity/TaxIdentifierTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\TaxBundle\Tests\Entity;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\TaxBundle\Entity\TaxIdentifier;
+
+#[CoversClass(TaxIdentifier::class)]
+final class TaxIdentifierTest extends TestCase
+{
+    public function testSetClientInheritsCompanyFromClient(): void
+    {
+        $company = new Company();
+
+        $client = $this->createMock(Client::class);
+        $client->method('getCompany')->willReturn($company);
+
+        $identifier = new TaxIdentifier();
+        $identifier->setClient($client);
+
+        self::assertSame($company, $identifier->getCompany());
+    }
+
+    public function testSetClientToNullDoesNotOverwriteExistingCompany(): void
+    {
+        $company = new Company();
+
+        $identifier = new TaxIdentifier();
+        $identifier->setCompany($company);
+        $identifier->setClient(null);
+
+        self::assertSame($company, $identifier->getCompany());
+    }
+
+    public function testSetClientReturnsFluentInterface(): void
+    {
+        $identifier = new TaxIdentifier();
+
+        self::assertSame($identifier, $identifier->setClient(null));
+    }
+}

--- a/src/TaxBundle/Tests/Functional/Api/TaxIdentifierTest.php
+++ b/src/TaxBundle/Tests/Functional/Api/TaxIdentifierTest.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\TaxBundle\Tests\Functional\Api;
 
 use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\TaxBundle\Entity\TaxIdentifier;
@@ -46,6 +47,26 @@ final class TaxIdentifierTest extends ApiTestCase
         self::assertTrue(Ulid::isValid($result['id'], Ulid::FORMAT_BASE_32));
         self::assertSame('VAT', $result['label']);
         self::assertSame('GB123456789', $result['value']);
+        self::assertTrue($result['primary']);
+    }
+
+    public function testCreateWithClient(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+
+        $data = [
+            'label' => 'VAT',
+            'value' => 'LV40001234567',
+            'primary' => true,
+            'client' => $this->getIriFromResource($client),
+        ];
+
+        $result = $this->requestPost('/api/tax-identifiers', $data);
+
+        self::assertArrayHasKey('id', $result);
+        self::assertTrue(Ulid::isValid($result['id'], Ulid::FORMAT_BASE_32));
+        self::assertSame('VAT', $result['label']);
+        self::assertSame('LV40001234567', $result['value']);
         self::assertTrue($result['primary']);
     }
 


### PR DESCRIPTION
## Summary

When creating a `TaxIdentifier` via the REST API with a `client` field, Symfony's validator fires before Doctrine's `prePersist` lifecycle listener has a chance to set `$company` on the entity. Because `SameCompanyAsClientValidator` calls `$value->getCompany()` during validation, and `$company` is a typed property (`protected Company $company`) with no default, PHP throws a fatal "Typed property must not be accessed before initialization" error, resulting in a 500 response.

## Root cause

`TaxIdentifier::setClient()` set `$this->client` but never called `$this->setCompany()`. The `CompanyAware` trait declares `$company` as a typed property with no initializer, so any access before the property is set throws. `CompanyListener::prePersist()` would eventually set it — but validation runs first.

## Changes

- `src/TaxBundle/Entity/TaxIdentifier.php` — added a call to `$this->setCompany($client->getCompany())` inside `setClient()` when `$client` is non-null, so the property is always initialized before validators run
- `src/TaxBundle/Tests/Entity/TaxIdentifierTest.php` — new unit tests covering: company inheritance from client, null-client does not overwrite existing company, fluent interface return
- `src/TaxBundle/Tests/Functional/Api/TaxIdentifierTest.php` — new functional test `testCreateWithClient()` that POSTs a tax identifier with a client IRI and asserts a 201 response with correct data

## Testing

- [x] Existing test suite passes (`bin/phpunit`)
- [x] New unit tests reproduce the bug on unfixed code and pass with the fix
- [x] New functional API test verifies the full POST flow with a client field
- [x] ECS passes (`bin/ecs check`)
- [x] PHPStan passes on changed files (129 pre-existing unmatched-baseline errors exist on `3.1.x` unmodified — confirmed with `git stash` before analysis)

Closes #2579

---
_Generated by [Claude Code](https://claude.ai/code/session_01TncTw7ejdQK2y84J7jwh9o)_