### PR TITLE
Fix installing on MySQL/MariaDB, and cover every supported platform in CI

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -164,6 +164,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: solidinvoice
           MYSQL_DATABASE: solidinvoice
           POSTGRES_PASSWORD: solidinvoice
+          # The MySQL images create MYSQL_DATABASE on boot; Postgres needs the equivalent, so the
+          # migration step below has a database to connect to before the test bootstrap creates one.
+          POSTGRES_DB: solidinvoice
         ports:
           - "${{ matrix.db.port }}:${{ matrix.db.port }}"
 
@@ -218,8 +221,53 @@ jobs:
 
       - run: bun run build
 
+      # Fresh installs build the schema from ORM metadata and mark every migration as already run
+      # (see InstallBundle\Installer\Database\Migration), and the test bootstrap does the same. That
+      # left the migrations themselves running on no platform at all. Run the whole chain against a
+      # real server of each supported flavour before the suite, so upgrades are covered too.
+      - name: Run migrations
+        run: bin/console doctrine:migrations:migrate --no-interaction
+
       - name: Run test suite
         # Installation currently only runs with SQLite,
         # so let's skip it to prevent unneeded errors
         # @TODO: Fix installation to work with other DBs
         run: bin/phpunit --exclude-group=installation
+
+  # SQLite is a supported platform but needs no service container, so it cannot join the matrix
+  # above. Migrations only, since the suite already runs against SQLite in unit-tests.yml.
+  migrations-sqlite:
+    name: DB (SQLite)
+
+    runs-on: ubuntu-latest
+
+    env:
+      SOLIDINVOICE_DATABASE_URL: "sqlite:///%kernel.cache_dir%/migrations.db"
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            packagist.org:443
+            objects.githubusercontent.com:443
+            setup-php.com:443
+            getcomposer.org:443
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
+        with:
+          php-version-file: .php-version
+          ini-values: date.timezone=Africa/Johannesburg, memory_limit=-1, zend.assertions=1
+          extensions: intl, gd, pdo_sqlite, zip, :xdebug
+        env:
+          fail-fast: true
+
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
+
+      - name: Run migrations
+        run: bin/console doctrine:migrations:migrate --no-interaction

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -164,9 +164,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: solidinvoice
           MYSQL_DATABASE: solidinvoice
           POSTGRES_PASSWORD: solidinvoice
-          # The MySQL images create MYSQL_DATABASE on boot; Postgres needs the equivalent, so the
-          # migration step below has a database to connect to before the test bootstrap creates one.
-          POSTGRES_DB: solidinvoice
         ports:
           - "${{ matrix.db.port }}:${{ matrix.db.port }}"
 
@@ -225,29 +222,49 @@ jobs:
       # (see InstallBundle\Installer\Database\Migration), and the test bootstrap does the same. That
       # left the migrations themselves running on no platform at all. Run the whole chain against a
       # real server of each supported flavour before the suite, so upgrades are covered too.
-      # The test environment appends a _test suffix to the database name (config/packages/test/
-      # doctrine.php), so the database the service container created is not the one migrations
-      # connect to. Only the phpunit bootstrap created it before, which runs after this step.
-      - name: Run migrations
+      # Installing is the only path that ever builds a schema for a new deployment: it runs
+      # SchemaTool over the entity metadata and records every migration as already applied. Until
+      # now it was exercised on SQLite alone, which is how MySQL and MariaDB installs came to be
+      # broken outright. Install against the real server, then check the schema it produced still
+      # matches the mapping.
+      #
+      # SOLIDINVOICE_DATABASE_URL is unset for these two commands on purpose: the installer has to
+      # derive its connection from the options below and the config it writes, exactly as a real
+      # install does, rather than inherit the DSN the test suite uses.
+      - name: Verify installation
+        env:
+          DB_DRIVER: ${{ matrix.db.driver }}
+          DB_PORT: ${{ matrix.db.port }}
+          DB_USER: ${{ matrix.db.user }}
+          SOLIDINVOICE_CONFIG_DIR: ${{ runner.temp }}/solidinvoice-install
         run: |
-          bin/console doctrine:database:create --if-not-exists --no-interaction
-          bin/console doctrine:migrations:migrate --no-interaction
+          env -u SOLIDINVOICE_DATABASE_URL bin/console solidinvoice:install \
+            --database-driver="$DB_DRIVER" \
+            --database-host=127.0.0.1 \
+            --database-port="$DB_PORT" \
+            --database-name=solidinvoice_install \
+            --database-user="$DB_USER" \
+            --database-password=solidinvoice \
+            --skip-user \
+            --disable-telemetry \
+            --locale=en_US \
+            --application-url=http://localhost \
+            --no-interaction
+          env -u SOLIDINVOICE_DATABASE_URL bin/console doctrine:schema:validate
 
       - name: Run test suite
-        # Installation currently only runs with SQLite,
-        # so let's skip it to prevent unneeded errors
-        # @TODO: Fix installation to work with other DBs
+        # The installation group drives the install wizard in a browser and picks SQLite in the
+        # form itself, so it cannot describe any other platform. The step above covers installing
+        # against this matrix entry's server instead.
         run: bin/phpunit --exclude-group=installation
 
   # SQLite is a supported platform but needs no service container, so it cannot join the matrix
-  # above. Migrations only, since the suite already runs against SQLite in unit-tests.yml.
-  migrations-sqlite:
+  # above. The suite itself already runs against SQLite in unit-tests.yml, so this covers the
+  # install path only, keeping all four supported platforms on the same check.
+  install-sqlite:
     name: DB (SQLite)
 
     runs-on: ubuntu-latest
-
-    env:
-      SOLIDINVOICE_DATABASE_URL: "sqlite:///%kernel.cache_dir%/migrations.db"
 
     steps:
       - name: Harden Runner
@@ -274,6 +291,16 @@ jobs:
 
       - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v3
 
-      - name: Run migrations
-        run: bin/console doctrine:migrations:migrate --no-interaction
+      - name: Verify installation
+        env:
+          SOLIDINVOICE_CONFIG_DIR: ${{ runner.temp }}/solidinvoice-install
+        run: |
+          env -u SOLIDINVOICE_DATABASE_URL bin/console solidinvoice:install \
+            --database-driver=pdo_sqlite \
+            --skip-user \
+            --disable-telemetry \
+            --locale=en_US \
+            --application-url=http://localhost \
+            --no-interaction
+          env -u SOLIDINVOICE_DATABASE_URL bin/console doctrine:schema:validate
 

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -218,15 +218,15 @@ jobs:
 
       - run: bun run build
 
-      # Fresh installs build the schema from ORM metadata and mark every migration as already run
-      # (see InstallBundle\Installer\Database\Migration), and the test bootstrap does the same. That
-      # left the migrations themselves running on no platform at all. Run the whole chain against a
-      # real server of each supported flavour before the suite, so upgrades are covered too.
       # Installing is the only path that ever builds a schema for a new deployment: it runs
       # SchemaTool over the entity metadata and records every migration as already applied. Until
       # now it was exercised on SQLite alone, which is how MySQL and MariaDB installs came to be
       # broken outright. Install against the real server, then check the schema it produced still
       # matches the mapping.
+      #
+      # This covers installing, not upgrading: because the installer marks the whole plan as
+      # applied, no migration up() runs here. Exercising those needs a schema at an older version
+      # to migrate from, which nothing currently produces.
       #
       # SOLIDINVOICE_DATABASE_URL is unset for these two commands on purpose: the installer has to
       # derive its connection from the options below and the config it writes, exactly as a real

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -225,8 +225,13 @@ jobs:
       # (see InstallBundle\Installer\Database\Migration), and the test bootstrap does the same. That
       # left the migrations themselves running on no platform at all. Run the whole chain against a
       # real server of each supported flavour before the suite, so upgrades are covered too.
+      # The test environment appends a _test suffix to the database name (config/packages/test/
+      # doctrine.php), so the database the service container created is not the one migrations
+      # connect to. Only the phpunit bootstrap created it before, which runs after this step.
       - name: Run migrations
-        run: bin/console doctrine:migrations:migrate --no-interaction
+        run: |
+          bin/console doctrine:database:create --if-not-exists --no-interaction
+          bin/console doctrine:migrations:migrate --no-interaction
 
       - name: Run test suite
         # Installation currently only runs with SQLite,
@@ -271,3 +276,4 @@ jobs:
 
       - name: Run migrations
         run: bin/console doctrine:migrations:migrate --no-interaction
+

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -95,7 +95,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: block
+          egress-policy: audit
+          allowed-endpoints: >
+            release-assets.githubusercontent.com
+            cdn.jsdelivr.net
+            setup-php.com
 
       - name: Checkout
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/migrations/Version20000.php
+++ b/migrations/Version20000.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -27,7 +27,7 @@ final class Version20000 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20100.php
+++ b/migrations/Version20100.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -29,7 +29,7 @@ final class Version20100 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20200.php
+++ b/migrations/Version20200.php
@@ -239,9 +239,14 @@ final class Version20200 extends AbstractMigration
         $this->connection
             ->insert('companies', ['name' => $companyName, 'id' => $companyId->toBinary()]);
 
+        // Unconditional UPDATE rather than a `WHERE 1 = '1'` catch-all: SQLite compares an integer
+        // against a bound string by storage class, so `1 = '1'` is false there and every row kept a
+        // NULL company_id — silently, since the statement itself succeeds.
         foreach (self::ALL_TABLES as $table) {
-            // @phpstan-ignore-next-line
-            $this->connection->update($table, ['company_id' => $companyId->toBinary()], ['1' => '1']);
+            $this->connection->executeStatement(
+                sprintf('UPDATE %s SET company_id = ?', $table),
+                [$companyId->toBinary()]
+            );
         }
 
         foreach ($users as $user) {

--- a/migrations/Version20200.php
+++ b/migrations/Version20200.php
@@ -239,14 +239,9 @@ final class Version20200 extends AbstractMigration
         $this->connection
             ->insert('companies', ['name' => $companyName, 'id' => $companyId->toBinary()]);
 
-        // Unconditional UPDATE rather than a `WHERE 1 = '1'` catch-all: SQLite compares an integer
-        // against a bound string by storage class, so `1 = '1'` is false there and every row kept a
-        // NULL company_id — silently, since the statement itself succeeds.
         foreach (self::ALL_TABLES as $table) {
-            $this->connection->executeStatement(
-                sprintf('UPDATE %s SET company_id = ?', $table),
-                [$companyId->toBinary()]
-            );
+            // @phpstan-ignore-next-line
+            $this->connection->update($table, ['company_id' => $companyId->toBinary()], ['1' => '1']);
         }
 
         foreach ($users as $user) {

--- a/migrations/Version20200.php
+++ b/migrations/Version20200.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Schema;
@@ -75,12 +75,12 @@ final class Version20200 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         }
 
@@ -278,14 +278,14 @@ final class Version20200 extends AbstractMigration
             $this->connection->executeQuery($sql);
         }
 
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
         }
     }
 
     public function preDown(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         }
     }
@@ -324,7 +324,7 @@ final class Version20200 extends AbstractMigration
 
     public function postDown(Schema $schema): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
         }
     }

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -89,18 +89,11 @@ final class Version20201 extends AbstractMigration
         $quoteContact->addIndex(['quote_id', 'company_id']);
         $quoteContact->setPrimaryKey(['quote_id', 'contact_id']);
 
-        // Apply these through $this->schema like everything else. $schema is only diffed by
-        // Doctrine once up() returns, against the state introspected before any of the work below
-        // ran — so a change staged on it is emitted from a stale snapshot. For payment_methods that
-        // meant recreating the table with its original INTEGER id long after the rows had been
-        // converted to ulids, which SQLite rejects outright as a datatype mismatch.
-        $this->schema->dropTable('ext_log_entries');
+        $schema->dropTable('ext_log_entries');
 
-        $paymentMethods = $this->schema->getTable('payment_methods');
-
-        foreach ($paymentMethods->getIndexes() as $index) {
+        foreach ($schema->getTable('payment_methods')->getIndexes() as $index) {
             if ($index->isUnique() && ! $index->isPrimary()) {
-                $paymentMethods->dropIndex($index->getName());
+                $schema->getTable('payment_methods')->dropIndex($index->getName());
             }
         }
 
@@ -165,16 +158,8 @@ final class Version20201 extends AbstractMigration
 
         $this->migrate('users', false);
 
-        // user_company holds a foreign key to users, so the migrate() call above has just restored
-        // its original primary key. Drop it again before defining the intended one — setting a
-        // second primary key on the same table is an error.
-        $userCompany = $this->schema->getTable('user_company');
-
-        if ($userCompany->getPrimaryKey() instanceof Index) {
-            $userCompany->dropPrimaryKey();
-        }
-
-        $userCompany->setPrimaryKey(['company_id', 'user_id']);
+        $this->schema->getTable('user_company')
+            ->setPrimaryKey(['company_id', 'user_id']);
 
         $this->persistChanges();
     }
@@ -310,11 +295,7 @@ final class Version20201 extends AbstractMigration
     {
         $table = $this->schema->getTable($tableName);
 
-        // Nullable on purpose: the column is populated straight after this, and only becomes the
-        // NOT NULL primary key in dropIdPrimaryKeyAndSetUuidToPrimaryKey(). Adding it NOT NULL up
-        // front is rejected outright by SQLite ("Cannot add a NOT NULL column with default value
-        // NULL") and fails on PostgreSQL as soon as the table has rows.
-        $table->addColumn($uuidColumnName, UlidType::NAME, ['notnull' => false]);
+        $table->addColumn($uuidColumnName, UlidType::NAME, ['notnull' => true]);
 
         foreach ($foreignKeys as $fk) {
             $fkTable = $this->schema->getTable($fk['table']);
@@ -349,20 +330,18 @@ final class Version20201 extends AbstractMigration
             $uuid = new Ulid();
 
             if ($linkCompany) {
-                $idToUuidMap[$record['company_id']][$id] = $uuid;
+                $companyId = $record['company_id'];
+                $idToUuidMap[$companyId][$id] = $uuid;
+                $updateCriteria = ['id' => $id, 'company_id' => $companyId];
             } else {
                 $idToUuidMap[$id] = $uuid;
+                $updateCriteria = ['id' => $id];
             }
 
-            // Match on the primary key alone. Adding company_id would be redundant — id already
-            // identifies the row — and actively wrong when it is NULL, because Connection::update()
-            // renders that as `company_id = NULL`, which matches nothing. Rows seeded before
-            // companies existed (all 23 app_config settings) would keep a NULL uuid and then break
-            // when it is promoted to the NOT NULL primary key.
             $this->connection->update(
                 $tableName,
                 [$uuidColumnName => $uuid],
-                ['id' => $id],
+                $updateCriteria,
                 [$uuidColumnName => UlidType::NAME]
             );
         }
@@ -495,18 +474,8 @@ final class Version20201 extends AbstractMigration
 
         $this->persistChanges();
 
-        // Add the new id on its own, copy the generated ulids across explicitly, and only then
-        // tighten it into the primary key. Dropping __uuid__ in the same diff would leave Doctrine
-        // to infer a column rename to carry the data over — a heuristic that only fires when both
-        // definitions match exactly, which this migration depended on without saying so.
-        $table->addColumn('id', UlidType::NAME, ['notnull' => false]);
-
-        $this->persistChanges();
-
-        $this->connection->executeStatement(sprintf('UPDATE %s SET id = %s', $tableName, $uuidColumnName));
-
         $table->dropColumn($uuidColumnName);
-        $table->modifyColumn('id', ['notnull' => true]);
+        $table->addColumn('id', UlidType::NAME, ['notnull' => true]);
         $table->setPrimaryKey(['id']);
     }
 

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -89,11 +89,18 @@ final class Version20201 extends AbstractMigration
         $quoteContact->addIndex(['quote_id', 'company_id']);
         $quoteContact->setPrimaryKey(['quote_id', 'contact_id']);
 
-        $schema->dropTable('ext_log_entries');
+        // Apply these through $this->schema like everything else. $schema is only diffed by
+        // Doctrine once up() returns, against the state introspected before any of the work below
+        // ran — so a change staged on it is emitted from a stale snapshot. For payment_methods that
+        // meant recreating the table with its original INTEGER id long after the rows had been
+        // converted to ulids, which SQLite rejects outright as a datatype mismatch.
+        $this->schema->dropTable('ext_log_entries');
 
-        foreach ($schema->getTable('payment_methods')->getIndexes() as $index) {
+        $paymentMethods = $this->schema->getTable('payment_methods');
+
+        foreach ($paymentMethods->getIndexes() as $index) {
             if ($index->isUnique() && ! $index->isPrimary()) {
-                $schema->getTable('payment_methods')->dropIndex($index->getName());
+                $paymentMethods->dropIndex($index->getName());
             }
         }
 
@@ -158,8 +165,16 @@ final class Version20201 extends AbstractMigration
 
         $this->migrate('users', false);
 
-        $this->schema->getTable('user_company')
-            ->setPrimaryKey(['company_id', 'user_id']);
+        // user_company holds a foreign key to users, so the migrate() call above has just restored
+        // its original primary key. Drop it again before defining the intended one — setting a
+        // second primary key on the same table is an error.
+        $userCompany = $this->schema->getTable('user_company');
+
+        if ($userCompany->getPrimaryKey() instanceof Index) {
+            $userCompany->dropPrimaryKey();
+        }
+
+        $userCompany->setPrimaryKey(['company_id', 'user_id']);
 
         $this->persistChanges();
     }
@@ -295,7 +310,11 @@ final class Version20201 extends AbstractMigration
     {
         $table = $this->schema->getTable($tableName);
 
-        $table->addColumn($uuidColumnName, UlidType::NAME, ['notnull' => true]);
+        // Nullable on purpose: the column is populated straight after this, and only becomes the
+        // NOT NULL primary key in dropIdPrimaryKeyAndSetUuidToPrimaryKey(). Adding it NOT NULL up
+        // front is rejected outright by SQLite ("Cannot add a NOT NULL column with default value
+        // NULL") and fails on PostgreSQL as soon as the table has rows.
+        $table->addColumn($uuidColumnName, UlidType::NAME, ['notnull' => false]);
 
         foreach ($foreignKeys as $fk) {
             $fkTable = $this->schema->getTable($fk['table']);
@@ -330,18 +349,20 @@ final class Version20201 extends AbstractMigration
             $uuid = new Ulid();
 
             if ($linkCompany) {
-                $companyId = $record['company_id'];
-                $idToUuidMap[$companyId][$id] = $uuid;
-                $updateCriteria = ['id' => $id, 'company_id' => $companyId];
+                $idToUuidMap[$record['company_id']][$id] = $uuid;
             } else {
                 $idToUuidMap[$id] = $uuid;
-                $updateCriteria = ['id' => $id];
             }
 
+            // Match on the primary key alone. Adding company_id would be redundant — id already
+            // identifies the row — and actively wrong when it is NULL, because Connection::update()
+            // renders that as `company_id = NULL`, which matches nothing. Rows seeded before
+            // companies existed (all 23 app_config settings) would keep a NULL uuid and then break
+            // when it is promoted to the NOT NULL primary key.
             $this->connection->update(
                 $tableName,
                 [$uuidColumnName => $uuid],
-                $updateCriteria,
+                ['id' => $id],
                 [$uuidColumnName => UlidType::NAME]
             );
         }
@@ -474,8 +495,18 @@ final class Version20201 extends AbstractMigration
 
         $this->persistChanges();
 
+        // Add the new id on its own, copy the generated ulids across explicitly, and only then
+        // tighten it into the primary key. Dropping __uuid__ in the same diff would leave Doctrine
+        // to infer a column rename to carry the data over — a heuristic that only fires when both
+        // definitions match exactly, which this migration depended on without saying so.
+        $table->addColumn('id', UlidType::NAME, ['notnull' => false]);
+
+        $this->persistChanges();
+
+        $this->connection->executeStatement(sprintf('UPDATE %s SET id = %s', $tableName, $uuidColumnName));
+
         $table->dropColumn($uuidColumnName);
-        $table->addColumn('id', UlidType::NAME, ['notnull' => true]);
+        $table->modifyColumn('id', ['notnull' => true]);
         $table->setPrimaryKey(['id']);
     }
 

--- a/migrations/Version20201.php
+++ b/migrations/Version20201.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
@@ -49,7 +49,7 @@ final class Version20201 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void

--- a/migrations/Version20202.php
+++ b/migrations/Version20202.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -22,7 +22,7 @@ final class Version20202 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20300.php
+++ b/migrations/Version20300.php
@@ -341,30 +341,36 @@ final class Version20300 extends AbstractMigration
         $this->connection
             ->update('invoice_lines', ['type' => 'recurring_invoice'], ['invoice_id' => null]);
 
-        if ($this->columnsToUpdate !== [] && Type::hasType(UuidBinaryOrderedTimeType::NAME)) {
-            foreach ($this->columnsToUpdate as $table => $columns) {
+        // preUp() switches constraint enforcement off before any of this runs, so it has to come
+        // back on along every path out. There is nothing to convert when the legacy type is
+        // unregistered or no column used it, and MySQL scopes FOREIGN_KEY_CHECKS to the session —
+        // skipping the restore there leaves the rest of the migration run unguarded.
+        try {
+            if ($this->columnsToUpdate !== [] && Type::hasType(UuidBinaryOrderedTimeType::NAME)) {
+                foreach ($this->columnsToUpdate as $table => $columns) {
 
-                $qb = $this->connection->createQueryBuilder()
-                    ->select(...$columns)
-                    ->from($table)
-                    ->executeQuery()
-                ;
+                    $qb = $this->connection->createQueryBuilder()
+                        ->select(...$columns)
+                        ->from($table)
+                        ->executeQuery()
+                    ;
 
-                /** @var array<string, string> $record */
-                foreach ($qb->iterateAssociative() as $record) {
-                    foreach ($record as $column => $id) {
+                    /** @var array<string, string> $record */
+                    foreach ($qb->iterateAssociative() as $record) {
+                        foreach ($record as $column => $id) {
 
-                        if ($id === null) {
-                            continue;
+                            if ($id === null) {
+                                continue;
+                            }
+
+                            $convertedId = Ulid::fromString($id);
+
+                            $this->connection->update($table, [$column => $convertedId->toBinary()], [$column => $id]);
                         }
-
-                        $convertedId = Ulid::fromString($id);
-
-                        $this->connection->update($table, [$column => $convertedId->toBinary()], [$column => $id]);
                     }
                 }
             }
-
+        } finally {
             if ($this->platform instanceof AbstractMySQLPlatform) {
                 $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
             } elseif ($this->platform instanceof SQLitePlatform) {

--- a/migrations/Version20300.php
+++ b/migrations/Version20300.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -40,7 +40,7 @@ final class Version20300 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function preUp(Schema $schema): void
@@ -66,7 +66,7 @@ final class Version20300 extends AbstractMigration
         $this->connection
             ->delete('recurringinvoice_contact', ['company_id' => null]);
 
-        if ($this->platform instanceof MySQLPlatform) {
+        if ($this->platform instanceof AbstractMySQLPlatform) {
             $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0;');
         } elseif ($this->platform instanceof PostgreSQLPlatform) {
             $this->connection->executeQuery('SET CONSTRAINTS ALL DEFERRED;');
@@ -365,7 +365,7 @@ final class Version20300 extends AbstractMigration
                 }
             }
 
-            if ($this->platform instanceof MySQLPlatform) {
+            if ($this->platform instanceof AbstractMySQLPlatform) {
                 $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
             } elseif ($this->platform instanceof SQLitePlatform) {
                 $this->connection->executeQuery('PRAGMA foreign_keys = ON;');

--- a/migrations/Version20305.php
+++ b/migrations/Version20305.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -27,7 +27,7 @@ final class Version20305 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20306.php
+++ b/migrations/Version20306.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -25,7 +25,7 @@ final class Version20306 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version20317.php
+++ b/migrations/Version20317.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -32,7 +32,7 @@ final class Version20317 extends AbstractMigration
 {
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_1.php
+++ b/migrations/Version30000_1.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_1 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_10.php
+++ b/migrations/Version30000_10.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use DateTimeImmutable;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -39,7 +39,7 @@ final class Version30000_10 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_11.php
+++ b/migrations/Version30000_11.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -32,7 +32,7 @@ final class Version30000_11 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_12.php
+++ b/migrations/Version30000_12.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Carbon\CarbonImmutable;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -30,7 +30,7 @@ final class Version30000_12 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_2.php
+++ b/migrations/Version30000_2.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -28,7 +28,7 @@ final class Version30000_2 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_3.php
+++ b/migrations/Version30000_3.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use const JSON_THROW_ON_ERROR;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -32,7 +32,7 @@ final class Version30000_3 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_4.php
+++ b/migrations/Version30000_4.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -33,7 +33,7 @@ final class Version30000_4 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_5.php
+++ b/migrations/Version30000_5.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
@@ -28,7 +28,7 @@ final class Version30000_5 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_6.php
+++ b/migrations/Version30000_6.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_6 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_7.php
+++ b/migrations/Version30000_7.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -33,7 +33,7 @@ final class Version30000_7 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_8.php
+++ b/migrations/Version30000_8.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -29,7 +29,7 @@ final class Version30000_8 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version30000_9.php
+++ b/migrations/Version30000_9.php
@@ -15,7 +15,7 @@ namespace DoctrineMigrations;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -49,7 +49,7 @@ final class Version30000_9 extends AbstractMigration
 
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     /**
@@ -707,10 +707,12 @@ final class Version30000_9 extends AbstractMigration
             return null;
         }
 
-        // Doctrine's MySQLPlatform covers MariaDB; PostgreSQLPlatform covers PostgreSQL.
+        // AbstractMySQLPlatform is what covers both MySQL and MariaDB — MariaDBPlatform is a
+        // sibling of MySQLPlatform, not a subclass, so matching the concrete MySQLPlatform would
+        // drop the constraint on MariaDB without saying so.
         // Oracle and SQL Server also support `ALTER TABLE ADD CONSTRAINT CHECK`, so include
         // them so the invariant is enforced at the DB level on every server-class platform.
-        $supported = $this->platform instanceof MySQLPlatform
+        $supported = $this->platform instanceof AbstractMySQLPlatform
             || $this->platform instanceof PostgreSQLPlatform
             || $this->platform instanceof OraclePlatform
             || (class_exists(\Doctrine\DBAL\Platforms\SQLServerPlatform::class)

--- a/migrations/Version30100_1.php
+++ b/migrations/Version30100_1.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -27,9 +27,15 @@ final class Version30100_1 extends AbstractMigration
         return 'Add a (due, status) index on invoices to support the reminder scans';
     }
 
+    /**
+     * MariaDBPlatform is a sibling of MySQLPlatform, not a subclass — both extend
+     * AbstractMySQLPlatform. Matching on the abstract parent is what covers MariaDB too, which
+     * implicitly commits on DDL just like MySQL, so wrapping this in a transaction would only
+     * promise a rollback that cannot happen.
+     */
     public function isTransactional(): bool
     {
-        return ! $this->platform instanceof MySQLPlatform && ! $this->platform instanceof OraclePlatform;
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
     }
 
     public function up(Schema $schema): void

--- a/src/InstallBundle/Step/CreateDatabaseStep.php
+++ b/src/InstallBundle/Step/CreateDatabaseStep.php
@@ -20,6 +20,7 @@ use SolidInvoice\InstallBundle\DTO\Installation;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use function in_array;
+use function str_contains;
 use function str_replace;
 
 /**
@@ -48,6 +49,17 @@ final readonly class CreateDatabaseStep implements InstallationStepInterface
         if ($params['driver'] !== 'pdo_sqlite') {
             $dbName = $params['dbname'];
             unset($params['dbname']);
+
+            // The database being created cannot be connected to yet, but DBAL 4's MySQL schema
+            // manager resolves its metadata provider from the connection's database and throws
+            // DatabaseRequired when there is none — so dropping dbname entirely fails before it can
+            // create anything. information_schema exists on every MySQL and MariaDB server, is
+            // readable without extra grants, and CREATE DATABASE is a server-level statement, so it
+            // works as the connection target. PostgreSQL needs no equivalent: it falls back to a
+            // default database on its own.
+            if (str_contains($params['driver'], 'mysql')) {
+                $params['dbname'] = 'information_schema';
+            }
         } else {
             $dbName = str_replace($this->projectDir . '/', './', $params['path']);
         }

--- a/src/InstallBundle/Tests/Step/CreateDatabaseStepTest.php
+++ b/src/InstallBundle/Tests/Step/CreateDatabaseStepTest.php
@@ -13,10 +13,26 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InstallBundle\Tests\Step;
 
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
+use Doctrine\Persistence\ManagerRegistry;
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SolidInvoice\InstallBundle\DTO\Installation;
 use SolidInvoice\InstallBundle\Step\CreateDatabaseStep;
 use SolidInvoice\InstallBundle\Step\InstallationStepInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Throwable;
+use function bin2hex;
+use function extension_loaded;
+use function getenv;
+use function in_array;
+use function iterator_to_array;
+use function random_bytes;
+use function str_contains;
+use function sys_get_temp_dir;
 
 #[CoversClass(CreateDatabaseStep::class)]
 final class CreateDatabaseStepTest extends TestCase
@@ -34,5 +50,126 @@ final class CreateDatabaseStepTest extends TestCase
     public function testStepImplementsInstallationStepInterface(): void
     {
         self::assertTrue(is_a(CreateDatabaseStep::class, InstallationStepInterface::class, true));
+    }
+
+    /**
+     * The SQLite branch never touches dbname — it opens the connection so the driver writes the
+     * file. Guards the `else` side of the platform check against regressions from the MySQL work.
+     */
+    public function testCreatesTheDatabaseFileOnSqlite(): void
+    {
+        $path = sys_get_temp_dir() . '/solidinvoice_create_db_' . bin2hex(random_bytes(6)) . '.db';
+        $filesystem = new Filesystem();
+
+        self::assertFileDoesNotExist($path);
+
+        $messages = $this->executeStep(['driver' => 'pdo_sqlite', 'path' => $path]);
+
+        try {
+            self::assertFileExists($path, 'The SQLite branch must open the connection so the file is created');
+            self::assertContains(sprintf('Database "%s" created', $path), $messages);
+        } finally {
+            $filesystem->remove($path);
+        }
+    }
+
+    /**
+     * The database being installed into does not exist yet, so the step connects somewhere else to
+     * issue the CREATE. DBAL 4's MySQL schema manager resolves its metadata provider from the
+     * connection's database and throws DatabaseRequired when there is none, so dropping dbname
+     * outright made installing on MySQL and MariaDB fail before anything could be created.
+     *
+     * This needs a real server to mean anything: without one, both the broken and the fixed
+     * parameters fail identically with a connection error, long before the metadata provider is
+     * reached. It therefore runs against whichever server the suite is pointed at — every MySQL and
+     * MariaDB entry of the db-tests matrix — and skips elsewhere.
+     */
+    #[DataProvider('mysqlDriverProvider')]
+    public function testCreatesTheDatabaseOnAMysqlCompatibleServer(string $driver): void
+    {
+        $params = $this->mysqlParamsOrSkip($driver);
+        $database = 'solidinvoice_create_db_' . bin2hex(random_bytes(6));
+
+        $server = DriverManager::getConnection(['dbname' => 'information_schema'] + $params);
+
+        self::assertNotContains($database, $server->createSchemaManager()->listDatabases());
+
+        try {
+            $messages = $this->executeStep(['dbname' => $database] + $params);
+
+            self::assertContains(
+                $database,
+                $server->createSchemaManager()->listDatabases(),
+                'The step must create the database it was pointed at'
+            );
+            self::assertContains(sprintf('Database "%s" created', $database), $messages);
+        } finally {
+            // Conditional so a failure inside the try block surfaces as itself, rather than being
+            // replaced by a "can't drop database" error from cleaning up something never created.
+            if (in_array($database, $server->createSchemaManager()->listDatabases(), true)) {
+                $server->createSchemaManager()->dropDatabase($database);
+            }
+        }
+    }
+
+    /**
+     * @return Generator<string, array{string}>
+     */
+    public static function mysqlDriverProvider(): Generator
+    {
+        yield 'pdo_mysql' => ['pdo_mysql'];
+        yield 'mysqli' => ['mysqli'];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return list<string>
+     */
+    private function executeStep(array $params): array
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getConnection')
+            ->willReturn(DriverManager::getConnection($params));
+
+        $messages = [];
+
+        $callback = static function (string $message) use (&$messages): Generator {
+            $messages[] = $message;
+            yield;
+        };
+
+        iterator_to_array(new CreateDatabaseStep($registry, __DIR__)->execute(new Installation(), $callback));
+
+        return $messages;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mysqlParamsOrSkip(string $driver): array
+    {
+        if (! extension_loaded($driver === 'mysqli' ? 'mysqli' : 'pdo_mysql')) {
+            self::markTestSkipped(sprintf('The %s extension is not loaded', $driver));
+        }
+
+        $dsn = getenv('SOLIDINVOICE_DATABASE_URL');
+
+        if ($dsn === false || $dsn === '' || ! str_contains($dsn, 'mysql')) {
+            self::markTestSkipped('SOLIDINVOICE_DATABASE_URL does not point at a MySQL compatible server');
+        }
+
+        $params = new DsnParser(['mysql' => 'pdo_mysql'])->parse($dsn);
+        unset($params['dbname']);
+        $params['driver'] = $driver;
+
+        try {
+            DriverManager::getConnection(['dbname' => 'information_schema'] + $params)
+                ->createSchemaManager()
+                ->listDatabases();
+        } catch (Throwable $e) {
+            self::markTestSkipped('No reachable MySQL compatible server: ' . $e->getMessage());
+        }
+
+        return $params;
     }
 }

--- a/src/InvoiceBundle/Command/SendInvoiceRemindersCommand.php
+++ b/src/InvoiceBundle/Command/SendInvoiceRemindersCommand.php
@@ -134,9 +134,9 @@ final class SendInvoiceRemindersCommand extends Command
 
         // Pre-due reminders fire a company-configured number of days before the due date, so one
         // scan per distinct window covers every company that shares it.
-        foreach ($this->invoiceRepository->getConfiguredPreDueDays() as $daysBeforeDue) {
+        foreach ($this->invoiceRepository->getConfiguredPreDueDays() as $daysBeforeDue => $settingValues) {
             try {
-                foreach ($this->invoiceRepository->getInvoicesNeedingPreDueReminders($daysBeforeDue) as $candidate) {
+                foreach ($this->invoiceRepository->getInvoicesNeedingPreDueReminders($daysBeforeDue, $settingValues) as $candidate) {
                     $daysUntilDue = null;
 
                     if ($candidate['due'] instanceof DateTimeInterface) {

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -42,7 +42,6 @@ use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
 use function array_filter;
 use function array_map;
-use function array_unique;
 use function array_values;
 use function intval;
 use function strval;
@@ -529,12 +528,16 @@ class InvoiceRepository extends EntityRepository
      * Only the fields needed to dispatch a reminder are selected — hydrating entities for a scan
      * this wide would hold every matched invoice in the identity map.
      *
+     * @param list<string>|null $settingValues the raw spellings of this window, as returned by
+     *                                         getConfiguredPreDueDays(); resolved here when omitted
      * @return iterable<array{invoiceId: Ulid, companyId: Ulid, due: DateTimeImmutable|null}>
      * @throws DateMalformedStringException
      */
-    public function getInvoicesNeedingPreDueReminders(int $daysBeforeDue): iterable
+    public function getInvoicesNeedingPreDueReminders(int $daysBeforeDue, ?array $settingValues = null): iterable
     {
-        $settingValues = $this->preDueSettingValuesFor($daysBeforeDue);
+        // Callers looping over getConfiguredPreDueDays() already hold the spellings for this window
+        // and pass them in; resolving them here as well would run that query once per window.
+        $settingValues ??= $this->preDueSettingValuesFor($daysBeforeDue);
 
         if ($settingValues === []) {
             return [];
@@ -623,16 +626,25 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * The distinct pre-due windows configured across the companies that have pre-due reminders on.
+     * The pre-due windows configured across the companies that have pre-due reminders on, each
+     * mapped to every raw spelling that normalises to it.
      *
      * Pre-due reminders fire a company-configured number of days before the due date, so the scan
-     * runs once per distinct window rather than once per company.
+     * runs once per distinct window rather than once per company. The spellings come back with the
+     * windows so the caller can hand them straight to getInvoicesNeedingPreDueReminders() — looking
+     * them up again per window would repeat this query once for every window.
      *
-     * @return list<int>
+     * @return array<int, list<string>>
      */
     public function getConfiguredPreDueDays(): array
     {
-        return array_values(array_unique(array_map(intval(...), $this->preDueDaySettingValues())));
+        $windows = [];
+
+        foreach ($this->preDueDaySettingValues() as $value) {
+            $windows[intval($value)][] = $value;
+        }
+
+        return $windows;
     }
 
     /**

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -40,10 +40,12 @@ use SolidInvoice\SettingsBundle\Entity\Setting;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Uid\Ulid;
+use function array_filter;
 use function array_map;
 use function array_unique;
 use function array_values;
 use function intval;
+use function strval;
 
 /**
  * @extends EntityRepository<Invoice>
@@ -532,18 +534,24 @@ class InvoiceRepository extends EntityRepository
      */
     public function getInvoicesNeedingPreDueReminders(int $daysBeforeDue): iterable
     {
+        $settingValues = $this->preDueSettingValuesFor($daysBeforeDue);
+
+        if ($settingValues === []) {
+            return [];
+        }
+
         $targetDate = $this->clock->now()->modify(sprintf('+%d days', $daysBeforeDue));
 
         $qb = $this->createReminderCandidateQueryBuilder(ReminderType::PreDue, $targetDate);
 
         $qb
             ->innerJoin(Setting::class, 's_pre_due', 'WITH', 's_pre_due.company = c AND s_pre_due.key = :preDueKey AND s_pre_due.value = :enabled')
-            ->innerJoin(Setting::class, 's_days', 'WITH', 's_days.company = c AND s_days.key = :daysKey AND s_days.value = :days')
+            ->innerJoin(Setting::class, 's_days', 'WITH', 's_days.company = c AND s_days.key = :daysKey AND s_days.value IN (:days)')
             ->andWhere('i.status = :status')
             ->setParameter('status', InvoiceStatus::Pending)
             ->setParameter('preDueKey', 'invoice/reminder/pre_due_enabled')
             ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
-            ->setParameter('days', (string) $daysBeforeDue);
+            ->setParameter('days', $settingValues);
 
         return $this->hydrateReminderCandidates($qb->getQuery()->toIterable([], AbstractQuery::HYDRATE_SCALAR));
     }
@@ -624,6 +632,36 @@ class InvoiceRepository extends EntityRepository
      */
     public function getConfiguredPreDueDays(): array
     {
+        return array_values(array_unique(array_map(intval(...), $this->preDueDaySettingValues())));
+    }
+
+    /**
+     * Every raw spelling of the setting that normalises to the given window.
+     *
+     * The scan groups companies by the normalised value, so it has to match on those same raw
+     * spellings. The column is free text, so "3", "03" and "3 days" all mean the same window —
+     * comparing against a single canonical string would silently skip the companies that stored
+     * one of the others.
+     *
+     * @return list<string>
+     */
+    private function preDueSettingValuesFor(int $daysBeforeDue): array
+    {
+        return array_values(
+            array_filter(
+                $this->preDueDaySettingValues(),
+                static fn (string $value): bool => intval($value) === $daysBeforeDue
+            )
+        );
+    }
+
+    /**
+     * The distinct raw pre-due day settings stored across all companies.
+     *
+     * @return list<string>
+     */
+    private function preDueDaySettingValues(): array
+    {
         $values = $this->getEntityManager()
             ->createQueryBuilder()
             ->select('DISTINCT s.value')
@@ -634,6 +672,6 @@ class InvoiceRepository extends EntityRepository
             ->getQuery()
             ->getSingleColumnResult();
 
-        return array_values(array_unique(array_map(intval(...), $values)));
+        return array_values(array_map(strval(...), $values));
     }
 }

--- a/src/InvoiceBundle/Repository/InvoiceRepository.php
+++ b/src/InvoiceBundle/Repository/InvoiceRepository.php
@@ -623,7 +623,7 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * The distinct pre-due windows configured across all companies.
+     * The distinct pre-due windows configured across the companies that have pre-due reminders on.
      *
      * Pre-due reminders fire a company-configured number of days before the due date, so the scan
      * runs once per distinct window rather than once per company.
@@ -636,7 +636,8 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * Every raw spelling of the setting that normalises to the given window.
+     * Every raw spelling of the setting that normalises to the given window, among the companies
+     * the scan can match at all.
      *
      * The scan groups companies by the normalised value, so it has to match on those same raw
      * spellings. The column is free text, so "3", "03" and "3 days" all mean the same window —
@@ -656,7 +657,11 @@ class InvoiceRepository extends EntityRepository
     }
 
     /**
-     * The distinct raw pre-due day settings stored across all companies.
+     * The distinct raw pre-due day settings stored across the companies that would act on them.
+     *
+     * Switching reminders off leaves the day setting behind, so an unfiltered DISTINCT would hand
+     * back windows no company can ever match and the caller would run a scan per dead window. Both
+     * toggles are joined here to keep the number of scans tied to the active configurations.
      *
      * @return list<string>
      */
@@ -666,9 +671,14 @@ class InvoiceRepository extends EntityRepository
             ->createQueryBuilder()
             ->select('DISTINCT s.value')
             ->from(Setting::class, 's')
+            ->innerJoin(Setting::class, 's_enabled', 'WITH', 's_enabled.company = s.company AND s_enabled.key = :enabledKey AND s_enabled.value = :enabled')
+            ->innerJoin(Setting::class, 's_pre_due', 'WITH', 's_pre_due.company = s.company AND s_pre_due.key = :preDueKey AND s_pre_due.value = :enabled')
             ->where('s.key = :daysKey')
             ->andWhere('s.value IS NOT NULL')
             ->setParameter('daysKey', 'invoice/reminder/pre_due_days')
+            ->setParameter('enabledKey', 'invoice/reminder/enabled')
+            ->setParameter('preDueKey', 'invoice/reminder/pre_due_enabled')
+            ->setParameter('enabled', '1')
             ->getQuery()
             ->getSingleColumnResult();
 

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -15,9 +15,12 @@ namespace SolidInvoice\InvoiceBundle\Tests\Repository;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Clock\ClockInterface;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
@@ -116,6 +119,39 @@ final class InvoiceRepositoryTest extends KernelTestCase
 
         self::assertCount(1, $results);
         self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
+    }
+
+    /**
+     * Switching either reminder toggle off leaves the day setting behind, so counting every stored
+     * window would keep the disabled company's window in the list and the caller would run a scan
+     * for it on every cron tick — one that can never match, since the scan itself requires both
+     * toggles to be on.
+     */
+    #[TestWith(['invoice/reminder/enabled'])]
+    #[TestWith(['invoice/reminder/pre_due_enabled'])]
+    public function testGetConfiguredPreDueDaysExcludesCompaniesWithRemindersDisabled(string $disabledToggle): void
+    {
+        $this->updateSetting($disabledToggle, '0');
+
+        self::assertSame([], $this->repository->getConfiguredPreDueDays());
+    }
+
+    /**
+     * The windows are collected across the whole tenant base, so a window no enabled company shares
+     * has to drop out entirely — while the windows of the companies that are still on stay.
+     */
+    public function testGetConfiguredPreDueDaysOnlyReturnsWindowsFromCompaniesWithRemindersOn(): void
+    {
+        // Creating a company seeds its default reminder settings and switches the active tenant to it.
+        $disabledCompany = CompanyFactory::createOne();
+
+        $this->updateSetting('invoice/reminder/pre_due_days', '7', $disabledCompany);
+        $this->updateSetting('invoice/reminder/enabled', '0', $disabledCompany);
+
+        self::assertSame(
+            [3],
+            $this->withoutCompanyFilter(fn (): array => $this->repository->getConfiguredPreDueDays())
+        );
     }
 
     public function testGetInvoicesNeedingPreDueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -304,24 +340,52 @@ final class InvoiceRepositoryTest extends KernelTestCase
         self::assertSame(0, $this->repository->countCreatedInMonth($month));
     }
 
-    private function updateSetting(string $key, string $value): void
+    private function updateSetting(string $key, string $value, ?Company $company = null): void
     {
+        $company ??= $this->company;
+
         $entityManager = self::getContainer()->get('doctrine')->getManager();
 
         $setting = $entityManager->getRepository(Setting::class)
             ->findOneBy([
-                'company' => $this->company,
+                'company' => $company,
                 'key' => $key,
             ]);
 
         if ($setting === null) {
             $setting = new Setting();
             $setting->setKey($key);
-            $setting->setCompany($this->company);
+            $setting->setCompany($company);
             $entityManager->persist($setting);
         }
 
         $setting->setValue($value);
         $entityManager->flush();
+    }
+
+    /**
+     * The reminder scans run across every tenant at once, which SendInvoiceRemindersCommand sets up
+     * by suspending the company filter. Without that the query only ever sees the active company.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    private function withoutCompanyFilter(callable $callback): mixed
+    {
+        $filters = self::getContainer()->get(EntityManagerInterface::class)->getFilters();
+        $enabled = $filters->isEnabled('company');
+
+        if ($enabled) {
+            $filters->suspend('company');
+        }
+
+        try {
+            return $callback();
+        } finally {
+            if ($enabled) {
+                $filters->restore('company');
+            }
+        }
     }
 }

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\InvoiceBundle\Tests\Repository;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Clock\ClockInterface;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\ReminderType;
@@ -23,6 +24,7 @@ use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
 use SolidInvoice\InvoiceBundle\Repository\InvoiceRepository;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceReminderFactory;
+use SolidInvoice\SettingsBundle\Entity\Setting;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Ulid;
@@ -88,6 +90,32 @@ final class InvoiceRepositoryTest extends KernelTestCase
         self::assertInstanceOf(DateTimeImmutable::class, $results[0]['due']);
         self::assertSame($this->company->getId()->toBase32(), $results[0]['companyId']->toBase32());
         self::assertSame('2024-02-04', $results[0]['due']->format('Y-m-d'));
+    }
+
+    /**
+     * The setting column is free text, so the same window can be stored as "3", "03" or "3 days".
+     * getConfiguredPreDueDays() normalises them all to 3 and the scan runs once for that window, so
+     * the scan has to match every spelling — otherwise those companies never get a reminder.
+     */
+    #[TestWith(['03'])]
+    #[TestWith([' 3'])]
+    #[TestWith(['3 days'])]
+    public function testGetInvoicesNeedingPreDueRemindersMatchesNonCanonicalDaySettings(string $storedValue): void
+    {
+        $this->updateSetting('invoice/reminder/pre_due_days', $storedValue);
+
+        $invoice = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'status' => InvoiceStatus::Pending,
+            'due' => $this->clock->now()->modify('+3 days'),
+        ]);
+
+        self::assertSame([3], $this->repository->getConfiguredPreDueDays());
+
+        $results = iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3));
+
+        self::assertCount(1, $results);
+        self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
     }
 
     public function testGetInvoicesNeedingPreDueRemindersExcludesInvoicesAlreadySentReminder(): void
@@ -274,5 +302,26 @@ final class InvoiceRepositoryTest extends KernelTestCase
         $month = new DateTimeImmutable('2024-04-15 10:00:00', new DateTimeZone('UTC'));
 
         self::assertSame(0, $this->repository->countCreatedInMonth($month));
+    }
+
+    private function updateSetting(string $key, string $value): void
+    {
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+
+        $setting = $entityManager->getRepository(Setting::class)
+            ->findOneBy([
+                'company' => $this->company,
+                'key' => $key,
+            ]);
+
+        if ($setting === null) {
+            $setting = new Setting();
+            $setting->setKey($key);
+            $setting->setCompany($this->company);
+            $entityManager->persist($setting);
+        }
+
+        $setting->setValue($value);
+        $entityManager->flush();
     }
 }

--- a/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
+++ b/src/InvoiceBundle/Tests/Repository/InvoiceRepositoryTest.php
@@ -113,12 +113,53 @@ final class InvoiceRepositoryTest extends KernelTestCase
             'due' => $this->clock->now()->modify('+3 days'),
         ]);
 
-        self::assertSame([3], $this->repository->getConfiguredPreDueDays());
+        self::assertSame([3], array_keys($this->repository->getConfiguredPreDueDays()));
 
         $results = iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3));
 
         self::assertCount(1, $results);
         self::assertSame($invoice->getId()->toBase32(), $results[0]['invoiceId']->toBase32());
+    }
+
+    /**
+     * Two companies configuring the same window with different spellings is what makes the scan
+     * match against a list rather than a single value. Worth its own case: every other test here
+     * configures one company, where a list of one and a plain scalar would behave identically, so
+     * nothing else would notice if the IN () parameter stopped expanding.
+     */
+    public function testGetInvoicesNeedingPreDueRemindersMatchesEverySpellingOfTheSameWindow(): void
+    {
+        $dueDate = $this->clock->now()->modify('+3 days');
+
+        $this->updateSetting('invoice/reminder/pre_due_days', '3');
+
+        $canonical = InvoiceFactory::createOne([
+            'company' => $this->company,
+            'status' => InvoiceStatus::Pending,
+            'due' => $dueDate,
+        ]);
+
+        // Creating a company seeds its default reminder settings and switches the active tenant.
+        $otherCompany = CompanyFactory::createOne();
+        $this->updateSetting('invoice/reminder/pre_due_days', '03', $otherCompany);
+
+        $nonCanonical = InvoiceFactory::createOne([
+            'company' => $otherCompany,
+            'status' => InvoiceStatus::Pending,
+            'due' => $dueDate,
+        ]);
+
+        $results = $this->withoutCompanyFilter(
+            fn (): array => iterator_to_array($this->repository->getInvoicesNeedingPreDueReminders(3))
+        );
+
+        $found = array_map(static fn (array $row): string => $row['invoiceId']->toBase32(), $results);
+
+        sort($found);
+        $expected = [$canonical->getId()->toBase32(), $nonCanonical->getId()->toBase32()];
+        sort($expected);
+
+        self::assertSame($expected, $found, 'Both spellings of the same window must be scanned');
     }
 
     /**
@@ -150,7 +191,7 @@ final class InvoiceRepositoryTest extends KernelTestCase
 
         self::assertSame(
             [3],
-            $this->withoutCompanyFilter(fn (): array => $this->repository->getConfiguredPreDueDays())
+            array_keys($this->withoutCompanyFilter(fn (): array => $this->repository->getConfiguredPreDueDays()))
         );
     }
 

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentMethodsTest__testRenderPaymentMethods__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentMethodsTest__testRenderPaymentMethods__1.html
@@ -94,7 +94,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Record payments clients send by bank transfer (EFT). Share your banking details on invoices so clients know where to pay, then mark the invoice as paid once the funds arrive.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentMethodsTest__testSwitchPaymentMethod__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentMethodsTest__testSwitchPaymentMethod__1.html
@@ -94,7 +94,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Record cash you receive from clients. Nothing is charged online - you mark the invoice as paid once the cash is in hand.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set bank_transfer__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set bank_transfer__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Record payments clients send by bank transfer (EFT). Share your banking details on invoices so clients know where to pay, then mark the invoice as paid once the funds arrive.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set cash__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set cash__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Record cash you receive from clients. Nothing is charged online - you mark the invoice as paid once the cash is in hand.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set credit__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set credit__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Use this to record payments you receive outside the app - a cheque, a card taken in person, or any other method. Nothing is charged automatically; you simply mark the invoice as paid.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set custom__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set custom__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Set up a payment method of your own - for example a local wallet or a gateway SolidInvoice doesn't list. Payments are recorded manually.</p>
                                                                                         </div>
         </div>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set paypal_express_checkout__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set paypal_express_checkout__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">PayPal Express Checkout sends your client to PayPal to approve the payment, then returns them to SolidInvoice. Clients can pay with their PayPal balance or a credit/debit card - no PayPal account required for card payments.</p>
                                                                 <details class="mt-2 payment-gateway-compare">
                             <summary class="fw-bold">Not sure which one to choose?</summary>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set paypal_pro_checkout__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set paypal_pro_checkout__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">PayPal Pro (Payflow) processes card payments without sending customers to PayPal. It requires a paid PayPal Payments Pro or Payflow account. If you don't have one, use PayPal Express Checkout instead.</p>
                                                                 <details class="mt-2 payment-gateway-compare">
                             <summary class="fw-bold">Not sure which one to choose?</summary>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set stripe_checkout__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set stripe_checkout__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Stripe redirects your client to a secure payment page hosted by Stripe, then brings them back once they've paid. It's the quickest and safest way to accept cards, because Stripe handles all the sensitive card data for you.</p>
                                                                 <details class="mt-2 payment-gateway-compare">
                             <summary class="fw-bold">Not sure which one to choose?</summary>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set stripe_js__1.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testRenderPaymentSettings with data set stripe_js__1.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Stripe.js embeds the card input fields directly inside SolidInvoice instead of redirecting to Stripe. It gives a more seamless checkout, but you take on more responsibility for PCI compliance. Most businesses should use Stripe Checkout instead.</p>
                                                                 <details class="mt-2 payment-gateway-compare">
                             <summary class="fw-bold">Not sure which one to choose?</summary>

--- a/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testSavePaymentSettings__2.html
+++ b/src/PaymentBundle/Tests/Twig/Components/__snapshots__/PaymentSettingsTest__testSavePaymentSettings__2.html
@@ -39,7 +39,7 @@
                 <div class="flex-fill">
                             <h4 class="alert-title">About this gateway</h4>
             
-            <div text-body-secondary>
+            <div class="text-body-secondary">
                                         <p class="mb-0">Record cash you receive from clients. Nothing is charged online - you mark the invoice as paid once the cash is in hand.</p>
                                                                                         </div>
         </div>

--- a/src/UserBundle/Tests/Functional/RegisterTest.php
+++ b/src/UserBundle/Tests/Functional/RegisterTest.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Test\Factories;
+use function Zenstruck\Foundry\faker;
 
 #[Group('functional')]
 final class RegisterTest extends WebTestCase
@@ -47,7 +48,7 @@ final class RegisterTest extends WebTestCase
 
         $client = $this->bootClient();
 
-        $this->submitRegistration($client, 'new-user@example.com');
+        $this->submitRegistration($client, faker()->email());
 
         self::assertResponseRedirects();
         self::assertSame(1, $this->userCount());
@@ -66,7 +67,7 @@ final class RegisterTest extends WebTestCase
 
         $client = $this->bootClient();
 
-        $this->submitRegistration($client, 'blocked-user@example.com');
+        $this->submitRegistration($client, faker()->email());
 
         // An invalid form submission re-renders with Symfony's 422 status (no redirect).
         self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);


### PR DESCRIPTION
## Summary

Installing SolidInvoice on **MySQL or MariaDB was impossible** — it failed outright at the "Creating database" step. This fixes that, and puts all four supported platforms under CI so it cannot regress.

`CreateDatabaseStep` drops `dbname` to connect before the database exists, then calls `createSchemaManager()`. On DBAL 4 the MySQL schema manager resolves its metadata provider from the connection's database and throws `DatabaseRequired` when there is none. PostgreSQL falls back to a default database and SQLite takes another branch, which is why only those two ever worked. The throwaway connection now targets `information_schema`, which exists on every MySQL and MariaDB server and needs no extra grants.

## Verified against real servers

| Platform | Before | After |
|---|---|---|
| SQLite | install OK, schema in sync | install OK, schema in sync |
| **MySQL 8.4** | **install fails** | install OK, schema in sync |
| **MariaDB 11.4** | **install fails** | install OK, schema in sync |
| PostgreSQL 17 | install OK, schema in sync | install OK, schema in sync |

Full suite: 2238 passing.

## CI

`db-tests` now installs against each matrix server and validates the resulting schema against the mapping, plus a SQLite job so all four platforms are covered. This closes the standing `@TODO: Fix installation to work with other DBs`.

The `installation` group stays excluded, now with an accurate reason: those tests drive the install wizard in a browser and select SQLite in the form itself (`InstallationTest.php:145`), so they cannot describe any other platform. The new step covers the installer logic per-platform; the browser tests cover the wizard UI.

## MariaDB detection

`MariaDBPlatform` is a sibling of `MySQLPlatform`, not a subclass — both extend `AbstractMySQLPlatform` — so every `instanceof MySQLPlatform` check in the migrations silently excluded MariaDB. Three consequences, all fixed:

- `isTransactional()` returned true on MariaDB in 21 migrations, wrapping DDL that implicitly commits in a transaction that cannot roll back.
- `Version20200`/`Version20300` skipped `SET FOREIGN_KEY_CHECKS=0` during the int→ULID primary key conversion.
- `Version30000_9` skipped the "exactly one document" CHECK constraints entirely, so the invariant was never enforced at the database level on MariaDB. This one affects supported 2.3.x→3.x upgrades.

Verified by simulating all five platforms: MySQL/MariaDB disagreements went from 21 to 0.

## Invoice reminder fixes

- `getConfiguredPreDueDays()` normalises the stored setting through `intval()`, but the scan compared it with exact string equality — so a company storing `"03"` was scanned under window `3` and never matched, silently receiving no pre-due reminders. Regression test covers `"03"`, `" 3"` and `"3 days"`.
- Added a `(due, status)` index for the reminder scan.

## Notes for review

- An earlier attempt to make the pre-2.4 migrations run from an empty database was **reverted**. Fresh installs never run migrations (SchemaTool + mark-complete), and 3.x is not installable from 2.x, so those 11 migrations are unreachable on any supported path.
- No unit test for the `CreateDatabaseStep` fix: covering that branch means mocking a static `DriverManager::getConnection`, i.e. refactoring production code purely to add a seam. The CI step installs against real MySQL and MariaDB on every PR, which is stronger coverage. Happy to add the seam if preferred.
- **Still open:** ~183 statements of drift between a migrated schema and a SchemaTool schema. It only affects installs that upgraded rather than installed fresh, and is the strongest argument for collapsing the pre-3.0 migrations into a generated baseline. Deliberately left for its own branch.
