### PR TITLE
fix(frankenphp): allow --domain with --disable-https for reverse proxy hostname routing

### DIFF
--- a/frankenphp/app.go
+++ b/frankenphp/app.go
@@ -25,12 +25,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/common-nighthawk/go-figure"
 	"github.com/dunglas/frankenphp"
-	"github.com/go-playground/validator/v10"
 	"github.com/luno/jettison/log"
 	"github.com/luno/lu"
 	"github.com/luno/lu/process"
 
 	"github.com/spf13/cobra"
+
+	"solidinvoice/internal/serverconfig"
 
 	// plug in Caddy modules here.
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
@@ -245,6 +246,10 @@ func setupCommands() {
 				return fmt.Errorf("--lets-encrypt requires --domain")
 			}
 
+			if enableLetsEncrypt && disableHttps {
+				return fmt.Errorf("--lets-encrypt cannot be used with --disable-https")
+			}
+
 			// Validate custom SSL certificate
 			if sslCertFile != "" || sslKeyFile != "" {
 				if sslCertFile == "" || sslKeyFile == "" {
@@ -290,37 +295,16 @@ func setupCommands() {
 			}
 
 			// Build server name
-			var serverName string
-			if domain != "" {
-				if disableHttps {
-					return errors.New("disabling HTTPS is not allowed when specifying a domain")
-				}
-
-				validate := validator.New(validator.WithRequiredStructEnabled())
-				if errs := validate.Var(domain, "required,hostname"); errs != nil {
-					return errs
-				}
-
-				if enableLetsEncrypt {
-					serverName = fmt.Sprintf("https://%s", domain)
-				} else {
-					serverName = fmt.Sprintf("https://%s:%s", domain, httpPort)
-				}
-			} else {
-				protocol := "https"
-				if disableHttps {
-					protocol = "http"
-				}
-
-				if os.Getenv("SOLIDINVOICE_DOCKER") == "true" {
-					serverName = fmt.Sprintf("%s://:%s", protocol, httpPort)
-				} else {
-					serverName = fmt.Sprintf("%s://%s:%s, %s://localhost:%s",
-						protocol, serverIp, httpPort, protocol, httpPort)
-					if serverIp != "127.0.0.1" {
-						serverName += fmt.Sprintf(", %s://127.0.0.1:%s", protocol, httpPort)
-					}
-				}
+			serverName, err := serverconfig.BuildServerName(serverconfig.Params{
+				Domain:            domain,
+				DisableHttps:      disableHttps,
+				EnableLetsEncrypt: enableLetsEncrypt,
+				HttpPort:          httpPort,
+				ServerIp:          serverIp,
+				Docker:            os.Getenv("SOLIDINVOICE_DOCKER") == "true",
+			})
+			if err != nil {
+				return err
 			}
 
 			must(os.Setenv("SERVER_NAME", serverName))
@@ -605,7 +589,7 @@ func setupCommands() {
 	runCmd.PersistentFlags().StringVar(&domain, "domain", "", "The domain name to use for the application. When specifying a domain, an SSL certificate will automatically be generated for you")
 	runCmd.PersistentFlags().StringVar(&httpPort, "port", defaultPort, "The default port to use for the application. When specifying a domain to use, the port will default to 443")
 	runCmd.PersistentFlags().StringVar(&serverIp, "server-ip", defaultServerIp, "If you have multiple IP addresses on your server, specify the IP address to use. By default, the server will bind to all IP addresses")
-	runCmd.PersistentFlags().BoolVar(&disableHttps, "disable-https", false, "Disable HTTPS. The application will only be accessible using http://. This setting is not recommended, unless you are setting up a reverse proxy which will use https")
+	runCmd.PersistentFlags().BoolVar(&disableHttps, "disable-https", false, "Disable HTTPS. The application will only be accessible using http://. This setting is not recommended, unless you are setting up a reverse proxy which will handle https. Combine with --domain to specify the hostname Caddy should accept when behind a reverse proxy (e.g. --disable-https --domain solidinvoice.example.com)")
 	runCmd.PersistentFlags().BoolVar(&enableLetsEncrypt, "lets-encrypt", false, "Enable Let's Encrypt for automatic SSL certificates (requires --domain)")
 	runCmd.PersistentFlags().StringVar(&sslCertFile, "ssl-cert", "", "Path to custom SSL certificate file (requires --ssl-key and --domain)")
 	runCmd.PersistentFlags().StringVar(&sslKeyFile, "ssl-key", "", "Path to custom SSL private key file (requires --ssl-cert and --domain)")

--- a/frankenphp/internal/serverconfig/server_name.go
+++ b/frankenphp/internal/serverconfig/server_name.go
@@ -1,0 +1,60 @@
+package serverconfig
+
+import (
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// Params holds the inputs needed to construct the Caddy SERVER_NAME value.
+type Params struct {
+	Domain            string
+	DisableHttps      bool
+	EnableLetsEncrypt bool
+	HttpPort          string
+	ServerIp          string
+	Docker            bool
+}
+
+// BuildServerName returns the Caddy SERVER_NAME string for the given parameters.
+//
+// When a reverse proxy sits in front of SolidInvoice and forwards requests
+// with a Host header that differs from the machine's IP address, Caddy must
+// be told about that hostname so it can match incoming requests correctly.
+// Use Domain + DisableHttps together to tell Caddy to accept requests for the
+// given hostname over plain HTTP (the reverse proxy handles TLS):
+//
+//	solidinvoice run --domain solidinvoice.example.com --disable-https
+func BuildServerName(p Params) (string, error) {
+	if p.Domain != "" {
+		validate := validator.New(validator.WithRequiredStructEnabled())
+		if errs := validate.Var(p.Domain, "required,hostname"); errs != nil {
+			return "", errs
+		}
+
+		if p.DisableHttps {
+			return fmt.Sprintf("http://%s:%s", p.Domain, p.HttpPort), nil
+		}
+		if p.EnableLetsEncrypt {
+			return fmt.Sprintf("https://%s", p.Domain), nil
+		}
+		return fmt.Sprintf("https://%s:%s", p.Domain, p.HttpPort), nil
+	}
+
+	protocol := "https"
+	if p.DisableHttps {
+		protocol = "http"
+	}
+
+	if p.Docker {
+		return fmt.Sprintf("%s://:%s", protocol, p.HttpPort), nil
+	}
+
+	serverName := fmt.Sprintf("%s://%s:%s, %s://localhost:%s",
+		protocol, p.ServerIp, p.HttpPort, protocol, p.HttpPort)
+	if p.ServerIp != "127.0.0.1" {
+		serverName += fmt.Sprintf(", %s://127.0.0.1:%s", protocol, p.HttpPort)
+	}
+
+	return serverName, nil
+}

--- a/frankenphp/internal/serverconfig/server_name.go
+++ b/frankenphp/internal/serverconfig/server_name.go
@@ -28,7 +28,7 @@ type Params struct {
 func BuildServerName(p Params) (string, error) {
 	if p.Domain != "" {
 		validate := validator.New(validator.WithRequiredStructEnabled())
-		if errs := validate.Var(p.Domain, "required,hostname"); errs != nil {
+		if errs := validate.Var(p.Domain, "required,hostname_rfc1123"); errs != nil {
 			return "", errs
 		}
 

--- a/frankenphp/internal/serverconfig/server_name_test.go
+++ b/frankenphp/internal/serverconfig/server_name_test.go
@@ -1,0 +1,135 @@
+package serverconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"solidinvoice/internal/serverconfig"
+)
+
+func TestBuildServerName(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  serverconfig.Params
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "domain with self-signed https",
+			params: serverconfig.Params{
+				Domain:   "example.com",
+				HttpPort: "8765",
+			},
+			want: "https://example.com:8765",
+		},
+		{
+			name: "domain with lets-encrypt",
+			params: serverconfig.Params{
+				Domain:            "example.com",
+				EnableLetsEncrypt: true,
+				HttpPort:          "8765",
+			},
+			want: "https://example.com",
+		},
+		{
+			name: "domain with disable-https (reverse proxy scenario, fixes #2581)",
+			params: serverconfig.Params{
+				Domain:       "example.com",
+				DisableHttps: true,
+				HttpPort:     "8765",
+			},
+			want: "http://example.com:8765",
+		},
+		{
+			name: "no domain, disable-https, server IP differs from 127.0.0.1",
+			params: serverconfig.Params{
+				DisableHttps: true,
+				HttpPort:     "8765",
+				ServerIp:     "192.168.1.100",
+			},
+			want: "http://192.168.1.100:8765, http://localhost:8765, http://127.0.0.1:8765",
+		},
+		{
+			name: "no domain, disable-https, server IP is 127.0.0.1",
+			params: serverconfig.Params{
+				DisableHttps: true,
+				HttpPort:     "8765",
+				ServerIp:     "127.0.0.1",
+			},
+			want: "http://127.0.0.1:8765, http://localhost:8765",
+		},
+		{
+			name: "no domain, https, server IP differs from 127.0.0.1",
+			params: serverconfig.Params{
+				HttpPort: "8765",
+				ServerIp: "192.168.1.100",
+			},
+			want: "https://192.168.1.100:8765, https://localhost:8765, https://127.0.0.1:8765",
+		},
+		{
+			name: "docker mode, disable-https",
+			params: serverconfig.Params{
+				DisableHttps: true,
+				HttpPort:     "8765",
+				Docker:       true,
+			},
+			want: "http://:8765",
+		},
+		{
+			name: "docker mode, https",
+			params: serverconfig.Params{
+				HttpPort: "8765",
+				Docker:   true,
+			},
+			want: "https://:8765",
+		},
+		{
+			name: "invalid domain returns error",
+			params: serverconfig.Params{
+				Domain:   "not a valid domain!!!",
+				HttpPort: "8765",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := serverconfig.BuildServerName(tt.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildServerName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BuildServerName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildServerNameDomainWithDisableHttps is the key regression test for issue #2581.
+// Before the fix, --domain + --disable-https was rejected at the command level with
+// "disabling HTTPS is not allowed when specifying a domain".
+// After the fix, BuildServerName returns an http:// URL so Caddy accepts requests
+// forwarded by a reverse proxy with the correct Host header.
+func TestBuildServerNameDomainWithDisableHttps(t *testing.T) {
+	params := serverconfig.Params{
+		Domain:       "solidinvoice.example.com",
+		DisableHttps: true,
+		HttpPort:     "8765",
+	}
+
+	got, err := serverconfig.BuildServerName(params)
+	if err != nil {
+		t.Fatalf("BuildServerName() must not error for domain + disable-https, got: %v", err)
+	}
+	if !strings.HasPrefix(got, "http://") {
+		t.Errorf("expected http:// scheme for --domain + --disable-https, got: %s", got)
+	}
+	if strings.Contains(got, "https://") {
+		t.Errorf("unexpected https:// in server name for --domain + --disable-https, got: %s", got)
+	}
+	if !strings.Contains(got, "solidinvoice.example.com") {
+		t.Errorf("expected domain in server name, got: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2581

### Root cause

When SolidInvoice runs without `--domain`, Caddy's `SERVER_NAME` is set to specific IP addresses (e.g. `https://192.168.1.100:8765, https://localhost:8765`). An external reverse proxy (HAProxy, Nginx, Traefik) forwards requests with a `Host` header matching the public domain (e.g. `solidinvoice.foobar.com`). Because that hostname doesn't match any Caddy site block, Caddy returns a blank 200 response.

The `--disable-https` flag was already documented as the reverse-proxy flag, but the code rejected combining it with `--domain` with the error `"disabling HTTPS is not allowed when specifying a domain"`. That validation was backwards: specifying a domain is exactly what a reverse-proxy deployment needs so Caddy accepts requests for that hostname.

### Fix

- **Remove the erroneous restriction** that blocked `--domain` + `--disable-https`
- When `--domain` + `--disable-https` are used together, `BuildServerName` now returns `http://domain:port` so Caddy's site block matches requests forwarded by the reverse proxy with the correct `Host` header
- **Add a proper validation** that `--lets-encrypt` and `--disable-https` are mutually exclusive (they were already logically incompatible but had no explicit error)
- **Update `--disable-https` flag description** to document the `--domain` combination

### Typical usage after fix

```sh
# Caddy accepts requests with Host: solidinvoice.foobar.com from the reverse proxy
solidinvoice run --disable-https --domain solidinvoice.foobar.com
```

### Refactoring for testability

The `frankenphp` main package cannot be unit-tested in isolation due to CGo (PHP/FrankenPHP headers) and `//go:embed` constraints. The server-name-building logic is extracted into `frankenphp/internal/serverconfig` — a pure-Go package with no CGo dependencies — so it can be tested standalone:

```
frankenphp/
  internal/
    serverconfig/
      server_name.go       # BuildServerName + Params
      server_name_test.go  # 10 tests
```

### Tests

10 tests in `frankenphp/internal/serverconfig/server_name_test.go`, all passing:

| Test | Purpose |
|------|---------|
| `domain with self-signed https` | baseline HTTPS with domain |
| `domain with lets-encrypt` | Let's Encrypt path |
| `domain with disable-https (reverse proxy scenario, fixes #2581)` | **regression** — was broken before |
| `no domain, disable-https, server IP differs from 127.0.0.1` | existing behaviour preserved |
| `no domain, disable-https, server IP is 127.0.0.1` | loopback edge case |
| `no domain, https, server IP differs from 127.0.0.1` | baseline HTTPS no domain |
| `docker mode, disable-https` | Docker wildcard bind |
| `docker mode, https` | Docker wildcard bind with TLS |
| `invalid domain returns error` | validation |
| `TestBuildServerNameDomainWithDisableHttps` | key regression: http:// scheme, correct domain |

---
_Generated by [Claude Code](https://claude.ai/code/session_011ja53F5JUxQG8dgntXS9Sb)_