### PR TITLE
Store line quantity as an exact decimal instead of a float

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -252,7 +252,10 @@
         "psr-4": {
             "App\\Mate\\": "mate/src/",
             "SolidInvoice\\Test\\": "tests/Test"
-        }
+        },
+        "classmap": [
+            "migrations/"
+        ]
     },
     "config": {
         "allow-plugins": {

--- a/config/packages/doctrine.php
+++ b/config/packages/doctrine.php
@@ -18,6 +18,7 @@ use SolidInvoice\CoreBundle\Doctrine\Filter\ArchivableFilter;
 use SolidInvoice\CoreBundle\Doctrine\Filter\CompanyFilter;
 use SolidInvoice\CoreBundle\Doctrine\Function\ToNumberFunction;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 
 return App::config([
     'doctrine' => [
@@ -35,6 +36,9 @@ return App::config([
             'types' => [
                 BigIntegerType::NAME => [
                     'class' => BigIntegerType::class,
+                ],
+                QuantityType::NAME => [
+                    'class' => QuantityType::class,
                 ],
             ],
         ],

--- a/docs/docs/invoices/creating-an-invoice.md
+++ b/docs/docs/invoices/creating-an-invoice.md
@@ -42,7 +42,7 @@ Each line item has four fields:
 | --- | --- |
 | **Description** | What the service or product is. Supports multiple lines. |
 | **Price** | The unit price. |
-| **Qty** | The quantity. Defaults to `1`. |
+| **Qty** | The quantity. Defaults to `1`. Fractional quantities are supported to six decimal places, so you can bill part-hours, metered usage or weights exactly. |
 | **Tax** | An optional tax rate to apply to this line. Tax rates are managed in `System` → `Taxes`. |
 
 The **Total** column and the **Summary** panel on the right update in real time as you type.

--- a/migrations/Version30100_2.php
+++ b/migrations/Version30100_2.php
@@ -34,6 +34,16 @@ final class Version30100_2 extends AbstractMigration
 {
     private const array TABLES = ['invoice_lines', 'quote_lines'];
 
+    /**
+     * Frozen at the values {@see QuantityType} used when this migration was written, rather
+     * than read from its constants: a migration has to keep describing the schema it
+     * produced, so that a later migration that changes the scale has the right starting
+     * point to diff against.
+     */
+    private const int PRECISION = 20;
+
+    private const int SCALE = 6;
+
     public function getDescription(): string
     {
         return 'Store invoice and quote line quantities as DECIMAL(20, 6) instead of a float';
@@ -43,9 +53,9 @@ final class Version30100_2 extends AbstractMigration
     {
         foreach (self::TABLES as $tableName) {
             $column = $schema->getTable($tableName)->getColumn('qty');
-            $column->setType(Type::getType(Types::DECIMAL));
-            $column->setPrecision(QuantityType::PRECISION);
-            $column->setScale(QuantityType::SCALE);
+            $column->setType(Type::getType(QuantityType::NAME));
+            $column->setPrecision(self::PRECISION);
+            $column->setScale(self::SCALE);
         }
     }
 

--- a/migrations/Version30100_2.php
+++ b/migrations/Version30100_2.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+
+/**
+ * Store line quantities as exact decimals instead of floats.
+ *
+ * `price × qty` was the one place where an exactly-computed monetary value was multiplied
+ * by a float, so the line total depended on how the host happened to round. Existing
+ * values convert cleanly: every quantity that a float column could hold exactly is
+ * representable in `DECIMAL(20, 6)`, and anything beyond six decimals was noise from the
+ * float representation rather than a quantity anyone entered.
+ *
+ * See {@see QuantityType} for why 20 and 6.
+ */
+final class Version30100_2 extends AbstractMigration
+{
+    private const array TABLES = ['invoice_lines', 'quote_lines'];
+
+    public function getDescription(): string
+    {
+        return 'Store invoice and quote line quantities as DECIMAL(20, 6) instead of a float';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TABLES as $tableName) {
+            $column = $schema->getTable($tableName)->getColumn('qty');
+            $column->setType(Type::getType(Types::DECIMAL));
+            $column->setPrecision(QuantityType::PRECISION);
+            $column->setScale(QuantityType::SCALE);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TABLES as $tableName) {
+            $column = $schema->getTable($tableName)->getColumn('qty');
+            $column->setType(Type::getType(Types::FLOAT));
+            $column->setPrecision(10);
+            $column->setScale(0);
+        }
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -883,12 +883,6 @@ parameters:
 			path: src/InvoiceBundle/Entity/Line.php
 
 		-
-			message: '#^Property SolidInvoice\\InvoiceBundle\\Entity\\Line\:\:\$qty type mapping mismatch\: property can contain float\|null but database expects float\|int\.$#'
-			identifier: doctrine.columnType
-			count: 1
-			path: src/InvoiceBundle/Entity/Line.php
-
-		-
 			message: '#^Property SolidInvoice\\InvoiceBundle\\Entity\\Line\:\:\$updated type mapping mismatch\: property can contain DateTimeImmutable\|null but database expects DateTimeImmutable\.$#'
 			identifier: doctrine.columnType
 			count: 1
@@ -1628,12 +1622,6 @@ parameters:
 
 		-
 			message: '#^Property SolidInvoice\\QuoteBundle\\Entity\\Line\:\:\$description type mapping mismatch\: property can contain string\|null but database expects string\.$#'
-			identifier: doctrine.columnType
-			count: 1
-			path: src/QuoteBundle/Entity/Line.php
-
-		-
-			message: '#^Property SolidInvoice\\QuoteBundle\\Entity\\Line\:\:\$qty type mapping mismatch\: property can contain float\|null but database expects float\|int\.$#'
 			identifier: doctrine.columnType
 			count: 1
 			path: src/QuoteBundle/Entity/Line.php

--- a/src/ApiBundle/GraphQl/Type/BigNumberTypeConverter.php
+++ b/src/ApiBundle/GraphQl/Type/BigNumberTypeConverter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\GraphQl\Type;
+
+use ApiPlatform\GraphQl\Type\TypeConverterInterface;
+use ApiPlatform\Metadata\GraphQl\Operation;
+use Brick\Math\BigNumber;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Override;
+use SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Maps {@see BigNumber} properties to the GraphQL `Float` type.
+ *
+ * `BigNumber` is not an API Platform resource, so the stock converter has nothing to map it
+ * to and the schema builder falls back to `Int`. That is wrong for every one of them:
+ * {@see BigIntegerNormalizer} emits a float — a monetary amount divided back out of the
+ * minor unit, or a line quantity, which can carry six decimal places.
+ *
+ * @see \SolidInvoice\ApiBundle\Tests\GraphQl\Type\BigNumberTypeConverterTest
+ */
+#[AsDecorator(decorates: 'api_platform.graphql.type_converter')]
+final readonly class BigNumberTypeConverter implements TypeConverterInterface
+{
+    public function __construct(
+        private TypeConverterInterface $decorated,
+    ) {
+    }
+
+    /**
+     * Deprecated in API Platform 4.2, and dead on this stack: the interface types this
+     * parameter as `Symfony\Component\PropertyInfo\Type`, which Symfony 8 removed in
+     * favour of TypeInfo. The parameter is therefore declared `mixed` — naming a class
+     * that does not exist would be a lie — and the call is passed straight through.
+     *
+     * @param mixed $type a `Symfony\Component\PropertyInfo\Type` on Symfony 7 and below
+     */
+    #[Override]
+    public function convertType(mixed $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth): GraphQLType | string | null
+    {
+        return $this->decorated->convertType($type, $input, $rootOperation, $resourceClass, $rootResource, $property, $depth);
+    }
+
+    public function convertPhpType(Type $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth): GraphQLType | string | null
+    {
+        if ($type->isIdentifiedBy(TypeIdentifier::OBJECT) && $type->isIdentifiedBy(BigNumber::class)) {
+            return GraphQLType::float();
+        }
+
+        return $this->decorated->convertPhpType($type, $input, $rootOperation, $resourceClass, $rootResource, $property, $depth);
+    }
+
+    #[Override]
+    public function resolveType(string $type): ?GraphQLType
+    {
+        return $this->decorated->resolveType($type);
+    }
+}

--- a/src/ApiBundle/Serializer/Normalizer/BigIntegerNormalizer.php
+++ b/src/ApiBundle/Serializer/Normalizer/BigIntegerNormalizer.php
@@ -28,13 +28,24 @@ use function is_a;
 final class BigIntegerNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     /**
+     * Context flag marking whether the {@see BigNumber} being (de)normalized is a monetary
+     * amount held in the minor unit, and therefore needs scaling by 100 across the API
+     * boundary. Defaults to true, since most of them are.
+     *
+     * Set it to false with {@see \Symfony\Component\Serializer\Attribute\Context} on any
+     * `BigNumber` property that is a plain number — a line quantity, for instance, which
+     * is exposed exactly as it is stored.
+     */
+    public const string MONETARY = 'monetary_amount';
+
+    /**
      * @throws MathException
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): BigNumber
     {
         $data = is_float($data) ? (string) $data : $data;
 
-        if ($context['api_denormalize'] ?? false) {
+        if (($context['api_denormalize'] ?? false) && ($context[self::MONETARY] ?? true)) {
             return BigNumber::of($data)->toBigDecimal()->multipliedBy(100);
         }
 
@@ -53,7 +64,7 @@ final class BigIntegerNormalizer implements NormalizerInterface, DenormalizerInt
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): float
     {
-        if (isset($context['api_attribute'])) {
+        if (isset($context['api_attribute']) && ($context[self::MONETARY] ?? true)) {
             return $object->toBigDecimal()->dividedBy(100, 2, RoundingMode::HalfEven)->toFloat();
         }
 

--- a/src/ApiBundle/Serializer/Normalizer/BigIntegerNormalizer.php
+++ b/src/ApiBundle/Serializer/Normalizer/BigIntegerNormalizer.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use function is_a;
+use function sprintf;
 
 /**
  * @see \SolidInvoice\ApiBundle\Tests\Serializer\Normalizer\BigIntegerNormalizerTest
@@ -43,7 +44,10 @@ final class BigIntegerNormalizer implements NormalizerInterface, DenormalizerInt
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): BigNumber
     {
-        $data = is_float($data) ? (string) $data : $data;
+        // JSON numbers arrive as floats. `(string)` would serialise them at PHP's `precision`
+        // ini setting, so the same payload could denormalize differently from one host to
+        // the next; %.14G pins that to the historical default and makes it deterministic.
+        $data = is_float($data) ? sprintf('%.14G', $data) : $data;
 
         if (($context['api_denormalize'] ?? false) && ($context[self::MONETARY] ?? true)) {
             return BigNumber::of($data)->toBigDecimal()->multipliedBy(100);

--- a/src/ApiBundle/Tests/GraphQl/Type/BigNumberTypeConverterTest.php
+++ b/src/ApiBundle/Tests/GraphQl/Type/BigNumberTypeConverterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ApiBundle\Tests\GraphQl\Type;
+
+use ApiPlatform\GraphQl\Type\TypeConverterInterface;
+use ApiPlatform\Metadata\GraphQl\Query;
+use Brick\Math\BigDecimal;
+use Brick\Math\BigNumber;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\ApiBundle\GraphQl\Type\BigNumberTypeConverter;
+use SolidInvoice\InvoiceBundle\Entity\Line;
+use Symfony\Component\TypeInfo\Type;
+
+final class BigNumberTypeConverterTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * `BigNumber` is not a resource, so without this the schema builder falls back to
+     * `Int` — which cannot carry a fractional quantity or a de-scaled money amount.
+     */
+    public function testConvertsBigNumberToFloat(): void
+    {
+        $decorated = M::mock(TypeConverterInterface::class);
+        $decorated->shouldNotReceive('convertPhpType');
+
+        $converter = new BigNumberTypeConverter($decorated);
+
+        self::assertSame(
+            GraphQLType::float(),
+            $converter->convertPhpType(Type::object(BigNumber::class), false, new Query(), Line::class, Line::class, 'qty', 0)
+        );
+    }
+
+    public function testConvertsBigNumberSubclassesToFloat(): void
+    {
+        $decorated = M::mock(TypeConverterInterface::class);
+        $decorated->shouldNotReceive('convertPhpType');
+
+        $converter = new BigNumberTypeConverter($decorated);
+
+        self::assertSame(
+            GraphQLType::float(),
+            $converter->convertPhpType(Type::object(BigDecimal::class), false, new Query(), Line::class, Line::class, 'qty', 0)
+        );
+    }
+
+    public function testDelegatesEverythingElse(): void
+    {
+        $expected = GraphQLType::string();
+
+        $decorated = M::mock(TypeConverterInterface::class);
+        $decorated->shouldReceive('convertPhpType')
+            ->once()
+            ->andReturn($expected);
+
+        $converter = new BigNumberTypeConverter($decorated);
+
+        self::assertSame(
+            $expected,
+            $converter->convertPhpType(Type::string(), false, new Query(), Line::class, Line::class, 'description', 0)
+        );
+    }
+
+    public function testResolveTypeIsDelegated(): void
+    {
+        $expected = GraphQLType::int();
+
+        $decorated = M::mock(TypeConverterInterface::class);
+        $decorated->shouldReceive('resolveType')
+            ->once()
+            ->with('Int')
+            ->andReturn($expected);
+
+        self::assertSame($expected, new BigNumberTypeConverter($decorated)->resolveType('Int'));
+    }
+}

--- a/src/ClientBundle/Entity/Client.php
+++ b/src/ClientBundle/Entity/Client.php
@@ -153,6 +153,10 @@ class Client implements Stringable
      */
     #[ApiProperty(example: ['/api/clients/3fa85f64-5717-4562-b3fc-2c963f66afa6/contact/3fa85f64-5717-4562-b3fc-2c963f66afa6'], iris: ['https://schema.org/Person'])]
     #[ORM\OneToMany(targetEntity: Contact::class, mappedBy: 'client', cascade: ['persist', 'remove'], fetch: 'EXTRA_LAZY', orphanRemoval: true)]
+    // Without an explicit order the database is free to return contacts in any order, and
+    // PostgreSQL does. Ids are ULIDs, so ordering by id is insertion order — what MySQL and
+    // SQLite happened to give already, which is why this only ever surfaced on PostgreSQL.
+    #[ORM\OrderBy(['id' => 'ASC'])]
     #[Assert\Count(
         min: 1,
         minMessage: 'client.constraint.contacts.min',

--- a/src/ClientBundle/Tests/Functional/ContactOrderingTest.php
+++ b/src/ClientBundle/Tests/Functional/ContactOrderingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * A client's contacts are rendered into invoice and quote forms, so the order they come
+ * back in is user-visible and ends up in snapshots. Without an explicit order the database
+ * chooses, and PostgreSQL does not choose insertion order.
+ */
+#[Group('functional')]
+final class ContactOrderingTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+
+    public function testContactsAreReturnedInInsertionOrder(): void
+    {
+        $client = ClientFactory::createOne(['name' => 'Ordering Test', 'currencyCode' => 'USD']);
+
+        $expected = [];
+
+        foreach (['Aaron', 'Zoe', 'Mia', 'Ben'] as $firstName) {
+            $contact = ContactFactory::createOne([
+                'firstName' => $firstName,
+                'lastName' => 'Example',
+                'email' => strtolower($firstName) . '@example.com',
+                'client' => $client,
+            ]);
+
+            $expected[] = $contact->getId()->toRfc4122();
+        }
+
+        $id = $client->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Client::class, $id);
+
+        self::assertInstanceOf(Client::class, $reloaded);
+
+        $actual = array_map(
+            static fn ($contact): string => $contact->getId()->toRfc4122(),
+            $reloaded->getContacts()->toArray()
+        );
+
+        // Ids are ULIDs, so insertion order is id order; the point is that it is stable at
+        // all, on every platform, rather than whatever the query planner returns.
+        self::assertSame($expected, array_values($actual));
+    }
+}

--- a/src/ClientBundle/Tests/Functional/ContactOrderingTest.php
+++ b/src/ClientBundle/Tests/Functional/ContactOrderingTest.php
@@ -30,7 +30,7 @@ final class ContactOrderingTest extends KernelTestCase
 {
     use DoctrineTestTrait;
 
-    public function testContactsAreReturnedInInsertionOrder(): void
+    public function testContactsAreReturnedInAscendingIdOrder(): void
     {
         $client = ClientFactory::createOne(['name' => 'Ordering Test', 'currencyCode' => 'USD']);
 
@@ -47,6 +47,11 @@ final class ContactOrderingTest extends KernelTestCase
             $expected[] = $contact->getId()->toRfc4122();
         }
 
+        // The mapping promises ascending id, not insertion order. Those coincide while ULID
+        // generation is monotonic, which is what makes the invoice-form snapshots stable,
+        // but asserting the weaker contract keeps this test about the ORDER BY.
+        sort($expected);
+
         $id = $client->getId();
         $this->em->clear();
 
@@ -59,8 +64,6 @@ final class ContactOrderingTest extends KernelTestCase
             $reloaded->getContacts()->toArray()
         );
 
-        // Ids are ULIDs, so insertion order is id order; the point is that it is stable at
-        // all, on every platform, rather than whatever the query planner returns.
         self::assertSame($expected, array_values($actual));
     }
 }

--- a/src/CoreBundle/Doctrine/Type/QuantityType.php
+++ b/src/CoreBundle/Doctrine/Type/QuantityType.php
@@ -88,6 +88,25 @@ final class QuantityType extends Type
         ]);
     }
 
+    /**
+     * The single rule for what a quantity is allowed to be: at most {@see self::SCALE}
+     * decimal places, rounded half-even, in canonical form.
+     *
+     * Every entry point has to apply this at the moment the quantity is set, not when it
+     * is written. A line total is computed in `PrePersist`, so a quantity carrying more
+     * decimals than the column can hold would be multiplied at full precision and stored
+     * against a rounded quantity — reloading the invoice and recomputing would then give a
+     * different total.
+     *
+     * @throws MathException
+     */
+    public static function normalize(BigNumber $quantity): BigDecimal
+    {
+        return $quantity->toBigDecimal()
+            ->toScale(self::SCALE, RoundingMode::HalfEven)
+            ->strippedOfTrailingZeros();
+    }
+
     #[Override]
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?BigDecimal
     {
@@ -99,8 +118,7 @@ final class QuantityType extends Type
             // SQLite hands back a float or an int for this column; every other platform
             // returns the decimal as a string. Formatting the float to the column scale
             // recovers the stored value without going through PHP's `precision` setting.
-            return BigDecimal::of(is_float($value) ? sprintf('%.*F', self::SCALE, $value) : $value)
-                ->strippedOfTrailingZeros();
+            return self::normalize(BigDecimal::of(is_float($value) ? sprintf('%.*F', self::SCALE, $value) : $value));
         } catch (MathException $e) {
             throw ValueNotConvertible::new($value, self::NAME, $e->getMessage(), $e);
         }
@@ -115,7 +133,8 @@ final class QuantityType extends Type
 
         if ($value instanceof BigNumber) {
             try {
-                return (string) $value->toBigDecimal()->toScale(self::SCALE, RoundingMode::HalfEven);
+                // toScale() only pads here: normalize() has already rounded to the scale.
+                return (string) self::normalize($value)->toScale(self::SCALE);
             } catch (MathException $e) {
                 throw SerializationFailed::new($value, self::NAME, $e->getMessage(), $e);
             }

--- a/src/CoreBundle/Doctrine/Type/QuantityType.php
+++ b/src/CoreBundle/Doctrine/Type/QuantityType.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Doctrine\Type;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigNumber;
+use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\Exception\SerializationFailed;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
+use Doctrine\DBAL\Types\Type;
+use Override;
+use function is_float;
+use function sprintf;
+
+/**
+ * Exact decimal quantity, stored as `DECIMAL(20, 6)` and exposed as a {@see BigNumber}.
+ *
+ * Quantities feed straight into the line total (`price × qty`), so they have to be as
+ * exact as the monetary values they multiply — see {@see BigIntegerType}. A float column
+ * cannot do that: the stored value is rounded to whatever the nearest IEEE-754 double is,
+ * and reading it back out through `(string)` re-rounds it at PHP's `precision` ini
+ * setting, so the same row can produce different totals on differently configured hosts.
+ *
+ * ### Why scale 6
+ *
+ * Six decimal places covers every quantity we have seen billed in practice, with headroom:
+ *
+ * - fractional hours to four places (`0.0833` = 5 minutes) — the case that motivated this;
+ * - metered usage priced per unit (bandwidth, API calls, storage-hours);
+ * - weights and volumes in metric units (a milligram is `0.000001` kg).
+ *
+ * It is also comfortably above what e-invoicing formats expect of a quantity: Peppol BIS
+ * Billing 3.0 and Factur-X/ZUGFeRD both cap `InvoicedQuantity` at four decimals, so a
+ * SolidInvoice line can always be represented in those formats without rounding.
+ *
+ * ### Why precision 20
+ *
+ * 20 total digits leaves 14 for the integral part — a hundred trillion units — which no
+ * realistic line item approaches, while staying inside the limits of every platform we
+ * support (MySQL caps `DECIMAL` at 65 digits, PostgreSQL far higher). 20 is also the
+ * number of digits in a 64-bit integer, matching the `BIGINT` columns the monetary
+ * amounts use, so the two halves of `price × qty` have symmetric headroom.
+ *
+ * ### SQLite
+ *
+ * SQLite has no exact decimal storage class: a `NUMERIC(20, 6)` column falls back to
+ * `REAL` (a double) for fractional values. Quantities are therefore only exact on SQLite
+ * up to a double's ~15 significant digits — well beyond anything enterable, but not the
+ * full 20 the column advertises. MySQL, MariaDB and PostgreSQL store the full precision.
+ *
+ * @see \SolidInvoice\CoreBundle\Tests\Doctrine\Type\QuantityTypeTest
+ */
+final class QuantityType extends Type
+{
+    public const string NAME = 'Quantity';
+
+    public const int PRECISION = 20;
+
+    public const int SCALE = 6;
+
+    /**
+     * Precision and scale are fixed here rather than read from `$column` so the DDL can
+     * never drift from the scale {@see self::convertToDatabaseValue()} rounds to.
+     */
+    #[Override]
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getDecimalTypeDeclarationSQL([
+            'precision' => self::PRECISION,
+            'scale' => self::SCALE,
+        ]);
+    }
+
+    #[Override]
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?BigDecimal
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            // SQLite hands back a float or an int for this column; every other platform
+            // returns the decimal as a string. Formatting the float to the column scale
+            // recovers the stored value without going through PHP's `precision` setting.
+            return BigDecimal::of(is_float($value) ? sprintf('%.*F', self::SCALE, $value) : $value)
+                ->strippedOfTrailingZeros();
+        } catch (MathException $e) {
+            throw ValueNotConvertible::new($value, self::NAME, $e->getMessage(), $e);
+        }
+    }
+
+    #[Override]
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BigNumber) {
+            try {
+                return (string) $value->toBigDecimal()->toScale(self::SCALE, RoundingMode::HalfEven);
+            } catch (MathException $e) {
+                throw SerializationFailed::new($value, self::NAME, $e->getMessage(), $e);
+            }
+        }
+
+        throw InvalidType::new($value, self::NAME, [BigNumber::class]);
+    }
+}

--- a/src/CoreBundle/Doctrine/Type/QuantityType.php
+++ b/src/CoreBundle/Doctrine/Type/QuantityType.php
@@ -73,15 +73,18 @@ final class QuantityType extends Type
     public const int SCALE = 6;
 
     /**
-     * Precision and scale are fixed here rather than read from `$column` so the DDL can
-     * never drift from the scale {@see self::convertToDatabaseValue()} rounds to.
+     * The constants are a default, not an override: a caller that declares its own
+     * precision and scale — the entity mapping, or a migration freezing the shape it
+     * produced — gets exactly what it asked for. Declaring nothing gets `DECIMAL(20, 6)`,
+     * so a column can never silently end up narrower than the scale
+     * {@see self::convertToDatabaseValue()} rounds to.
      */
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getDecimalTypeDeclarationSQL([
-            'precision' => self::PRECISION,
-            'scale' => self::SCALE,
+            'precision' => $column['precision'] ?? self::PRECISION,
+            'scale' => $column['scale'] ?? self::SCALE,
         ]);
     }
 

--- a/src/CoreBundle/Entity/LineInterface.php
+++ b/src/CoreBundle/Entity/LineInterface.php
@@ -30,9 +30,9 @@ interface LineInterface
 
     public function getPrice(): BigNumber;
 
-    public function setQty(float $qty): self;
+    public function setQty(BigNumber | int | string $qty): self;
 
-    public function getQty(): ?float;
+    public function getQty(): BigNumber;
 
     public function setTotal(BigNumber | int | string $total): self;
 

--- a/src/CoreBundle/Form/Transformer/QuantityTransformer.php
+++ b/src/CoreBundle/Form/Transformer/QuantityTransformer.php
@@ -16,7 +16,6 @@ namespace SolidInvoice\CoreBundle\Form\Transformer;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
-use Brick\Math\RoundingMode;
 use Locale;
 use NumberFormatter;
 use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
@@ -40,16 +39,16 @@ use function trim;
  * regardless of locale (matching what `NumberToLocalizedStringTransformer` does when
  * `grouping` is off), and only the locale's separator is used when rendering.
  *
+ * Rounding is deliberately not done here. `setQty()` applies
+ * {@see QuantityType::normalize()} to whatever it is given, so a form submission and an
+ * API call rounding the same beyond-scale quantity land on the same value. A second rule
+ * in this class would silently make the two entry points disagree.
+ *
  * @implements DataTransformerInterface<BigNumber, string>
  * @see \SolidInvoice\CoreBundle\Tests\Form\Transformer\QuantityTransformerTest
  */
 final readonly class QuantityTransformer implements DataTransformerInterface
 {
-    public function __construct(
-        private int $scale = QuantityType::SCALE,
-    ) {
-    }
-
     /**
      * @param mixed $value the form hands over whatever the model holds, unchecked
      */
@@ -64,9 +63,7 @@ final readonly class QuantityTransformer implements DataTransformerInterface
         }
 
         try {
-            $decimal = $value->toBigDecimal()
-                ->toScale($this->scale, RoundingMode::HalfEven)
-                ->strippedOfTrailingZeros();
+            $decimal = QuantityType::normalize($value);
         } catch (MathException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }
@@ -99,9 +96,7 @@ final readonly class QuantityTransformer implements DataTransformerInterface
         $value = str_replace(',', '.', $value);
 
         try {
-            return BigDecimal::of($value)
-                ->toScale($this->scale, RoundingMode::HalfUp)
-                ->strippedOfTrailingZeros();
+            return BigDecimal::of($value);
         } catch (MathException $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/CoreBundle/Form/Transformer/QuantityTransformer.php
+++ b/src/CoreBundle/Form/Transformer/QuantityTransformer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Form\Transformer;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigNumber;
+use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use Locale;
+use NumberFormatter;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use function is_string;
+use function str_replace;
+use function trim;
+
+/**
+ * View transformer for line quantities, replacing the float-based one that
+ * {@see \Symfony\Component\Form\Extension\Core\Type\NumberType} installs by default.
+ *
+ * A quantity is stored as an exact decimal ({@see QuantityType}), and routing it through
+ * `NumberToLocalizedStringTransformer` would push it through a float on every render and
+ * every submit — which is exactly what this whole column change exists to remove. Going
+ * straight between the string in the input and the {@see BigNumber} on the entity keeps
+ * every digit the user typed.
+ *
+ * Quantities are never grouped, so both `.` and `,` are accepted as the decimal separator
+ * regardless of locale (matching what `NumberToLocalizedStringTransformer` does when
+ * `grouping` is off), and only the locale's separator is used when rendering.
+ *
+ * @implements DataTransformerInterface<BigNumber, string>
+ * @see \SolidInvoice\CoreBundle\Tests\Form\Transformer\QuantityTransformerTest
+ */
+final readonly class QuantityTransformer implements DataTransformerInterface
+{
+    public function __construct(
+        private int $scale = QuantityType::SCALE,
+    ) {
+    }
+
+    /**
+     * @param mixed $value the form hands over whatever the model holds, unchecked
+     */
+    public function transform(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        if (! $value instanceof BigNumber) {
+            throw new TransformationFailedException('Expected a BigNumber.');
+        }
+
+        try {
+            $decimal = $value->toBigDecimal()
+                ->toScale($this->scale, RoundingMode::HalfEven)
+                ->strippedOfTrailingZeros();
+        } catch (MathException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return str_replace('.', $this->decimalSeparator(), (string) $decimal);
+    }
+
+    /**
+     * @param mixed $value submitted data is a string for a scalar field, but an array when
+     *                     the field is submitted as one, so it has to be checked
+     */
+    public function reverseTransform(mixed $value): ?BigNumber
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new TransformationFailedException('Expected a string.');
+        }
+
+        // Non-breaking and narrow non-breaking spaces come back from browsers that
+        // auto-format the field; plain spaces are used as a group separator in some locales.
+        $value = trim(str_replace(["\xc2\xa0", "\xe2\x80\xaf", ' '], '', $value));
+
+        if ($value === '') {
+            return null;
+        }
+
+        $value = str_replace(',', '.', $value);
+
+        try {
+            return BigDecimal::of($value)
+                ->toScale($this->scale, RoundingMode::HalfUp)
+                ->strippedOfTrailingZeros();
+        } catch (MathException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    private function decimalSeparator(): string
+    {
+        $separator = new NumberFormatter(Locale::getDefault(), NumberFormatter::DECIMAL)
+            ->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+
+        return $separator === false ? '.' : $separator;
+    }
+}

--- a/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
+++ b/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
@@ -153,7 +153,12 @@ final class LineQuantityRegressionTest extends TestCase
      */
     public function testAQuantityWithMoreDigitsThanAFloatCanCarrySurvives(): void
     {
-        // 15 significant digits — one more than PHP's default `precision` of 14 emits.
+        // The legacy path only lost digits while `precision` emitted fewer than 15 of them,
+        // which is PHP's default. State that rather than assume it: on a host configured
+        // otherwise the float cast below keeps every digit and the comparison is vacuous.
+        self::assertLessThan(15, (int) ini_get('precision'));
+
+        // 15 significant digits — one more than a `precision` of 14 emits.
         $qty = '123456789.123456';
 
         $line = new Line();

--- a/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
+++ b/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
@@ -153,11 +153,6 @@ final class LineQuantityRegressionTest extends TestCase
      */
     public function testAQuantityWithMoreDigitsThanAFloatCanCarrySurvives(): void
     {
-        // The legacy path only lost digits while `precision` emitted fewer than 15 of them,
-        // which is PHP's default. State that rather than assume it: on a host configured
-        // otherwise the float cast below keeps every digit and the comparison is vacuous.
-        self::assertLessThan(15, (int) ini_get('precision'));
-
         // 15 significant digits — one more than a `precision` of 14 emits.
         $qty = '123456789.123456';
 
@@ -166,8 +161,20 @@ final class LineQuantityRegressionTest extends TestCase
 
         self::assertSame('12345678912.345600', (string) $line->updateTotal()->getTotal());
 
-        $legacy = BigDecimal::of(100)->multipliedBy(LineQuantityCorpus::legacyQtyString((float) $qty));
+        // Pin `precision` rather than assert on it: the point is to reproduce what the old
+        // float path did, and a host that sets 15 or more would keep every digit and make
+        // the comparison below vacuous. Restored in `finally` so a failure cannot leak it.
+        $precision = ini_get('precision');
+        ini_set('precision', '14');
 
+        try {
+            $legacy = BigDecimal::of(100)->multipliedBy(LineQuantityCorpus::legacyQtyString((float) $qty));
+        } finally {
+            ini_set('precision', $precision === false ? '14' : $precision);
+        }
+
+        // The float rendered as "123456789.12346" — the fifteenth digit is gone.
+        self::assertSame('12345678912.34600', (string) $legacy);
         self::assertFalse(
             $line->getTotal()->isEqualTo($legacy),
             'This quantity is supposed to be one the old float path could not carry'

--- a/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
+++ b/src/CoreBundle/Tests/Billing/LineQuantityRegressionTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Billing;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigRational;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+use SolidInvoice\CoreBundle\Tests\Fixtures\LineQuantityCorpus;
+use SolidInvoice\InvoiceBundle\Entity\Line;
+use SolidInvoice\QuoteBundle\Entity\Line as QuoteLine;
+use function sprintf;
+
+/**
+ * Proves that storing `qty` as an exact decimal instead of a float does not move a single
+ * existing invoice total, and that the new arithmetic is exact.
+ *
+ * Every case runs the whole corpus in one test rather than one case per data set, so a
+ * regression reports how many lines moved, not just the first.
+ *
+ * @see LineQuantityCorpus
+ */
+final class LineQuantityRegressionTest extends TestCase
+{
+    /**
+     * The line total as it was computed before this change: an exact price multiplied by
+     * the float quantity cast to a string, which serialises at PHP's `precision` setting.
+     */
+    private function legacyTotal(int $price, float $qty): BigDecimal
+    {
+        return BigDecimal::of($price)->multipliedBy(LineQuantityCorpus::legacyQtyString($qty));
+    }
+
+    /**
+     * The line total after the migration: the quantity read back out of the decimal column
+     * and multiplied straight into the price.
+     */
+    private function migratedTotal(int $price, float $qty): BigDecimal
+    {
+        $line = new Line();
+        $line->setPrice($price);
+        $line->setQty(
+            new QuantityType()->convertToPHPValue(LineQuantityCorpus::migrated($qty), new MySQLPlatform())
+                ?? BigDecimal::zero()
+        );
+
+        return $line->updateTotal()->getTotal()->toBigDecimal();
+    }
+
+    /**
+     * The stored total is what an invoice actually carries: minor units, rounded half-even.
+     */
+    private function stored(BigDecimal $total): string
+    {
+        return (string) new BigIntegerType()->convertToDatabaseValue($total, new MySQLPlatform());
+    }
+
+    public function testEveryStoredTotalInTheCorpusIsUnchanged(): void
+    {
+        $moved = [];
+
+        foreach (LineQuantityCorpus::lines() as [$price, $qty]) {
+            $legacy = $this->stored($this->legacyTotal($price, $qty));
+            $migrated = $this->stored($this->migratedTotal($price, $qty));
+
+            if ($legacy !== $migrated) {
+                $moved[] = sprintf('%d × %s: %s -> %s', $price, (string) $qty, $legacy, $migrated);
+            }
+        }
+
+        self::assertSame([], $moved, 'Stored line totals changed for these corpus lines');
+    }
+
+    public function testEveryUnroundedTotalInTheCorpusIsUnchanged(): void
+    {
+        $moved = [];
+
+        foreach (LineQuantityCorpus::lines() as [$price, $qty]) {
+            $legacy = $this->legacyTotal($price, $qty);
+            $migrated = $this->migratedTotal($price, $qty);
+
+            if (! $legacy->isEqualTo($migrated)) {
+                $moved[] = sprintf('%d × %s: %s -> %s', $price, (string) $qty, (string) $legacy, (string) $migrated);
+            }
+        }
+
+        self::assertSame([], $moved, 'Unrounded line totals changed for these corpus lines');
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function exactProducts(): iterable
+    {
+        foreach (LineQuantityCorpus::prices() as $price) {
+            foreach (LineQuantityCorpus::fullScaleQuantities() as $qty) {
+                yield sprintf('%d x %s', $price, $qty) => [$price, $qty];
+            }
+        }
+    }
+
+    /**
+     * `price × qty` against a reference that cannot round: an exact rational.
+     */
+    #[DataProvider('exactProducts')]
+    public function testTheProductIsExact(int $price, string $qty): void
+    {
+        $line = new Line();
+        $line->setPrice($price);
+        $line->setQty($qty);
+
+        $expected = BigRational::of($price)->multipliedBy(BigRational::of($qty));
+
+        self::assertTrue(
+            $expected->isEqualTo($line->updateTotal()->getTotal()),
+            sprintf('Expected %s, got %s', (string) $expected->toBigDecimal(), (string) $line->getTotal())
+        );
+    }
+
+    #[DataProvider('exactProducts')]
+    public function testQuoteLinesUseTheSameArithmetic(int $price, string $qty): void
+    {
+        $invoiceLine = new Line();
+        $invoiceLine->setPrice($price)->setQty($qty);
+
+        $quoteLine = new QuoteLine();
+        $quoteLine->setPrice($price)->setQty($qty);
+
+        self::assertSame(
+            (string) $invoiceLine->updateTotal()->getTotal(),
+            (string) $quoteLine->updateTotal()->getTotal()
+        );
+    }
+
+    /**
+     * The failure this change exists to remove: a quantity with more significant digits
+     * than PHP's `precision` setting emits used to be silently truncated on its way into
+     * the multiplication, so the line total came out short.
+     */
+    public function testAQuantityWithMoreDigitsThanAFloatCanCarrySurvives(): void
+    {
+        // 15 significant digits — one more than PHP's default `precision` of 14 emits.
+        $qty = '123456789.123456';
+
+        $line = new Line();
+        $line->setPrice(100)->setQty($qty);
+
+        self::assertSame('12345678912.345600', (string) $line->updateTotal()->getTotal());
+
+        $legacy = BigDecimal::of(100)->multipliedBy(LineQuantityCorpus::legacyQtyString((float) $qty));
+
+        self::assertFalse(
+            $line->getTotal()->isEqualTo($legacy),
+            'This quantity is supposed to be one the old float path could not carry'
+        );
+    }
+
+    public function testTheStoredQuantityRoundsHalfEvenAtTheScaleLimit(): void
+    {
+        $type = new QuantityType();
+        $platform = new MySQLPlatform();
+
+        self::assertSame('0.000002', $type->convertToDatabaseValue(BigDecimal::of('0.0000015'), $platform));
+        self::assertSame('0.000000', $type->convertToDatabaseValue(BigDecimal::of('0.0000005'), $platform));
+        self::assertSame('0.000002', $type->convertToDatabaseValue(BigDecimal::of('0.0000025'), $platform));
+    }
+}

--- a/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
+++ b/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
@@ -49,11 +49,21 @@ final class QuantityTypeTest extends TestCase
     }
 
     #[DataProvider('platforms')]
-    public function testDeclaresAFixedPrecisionAndScale(AbstractPlatform $platform, string $expected): void
+    public function testDeclaresTheDefaultPrecisionAndScale(AbstractPlatform $platform, string $expected): void
     {
-        // The precision and scale in the mapping are deliberately ignored, so the DDL can
-        // never drift from the scale convertToDatabaseValue() rounds to.
-        self::assertSame($expected, $this->type->getSQLDeclaration(['precision' => 4, 'scale' => 1], $platform));
+        // A column that declares nothing must not end up narrower than the scale
+        // convertToDatabaseValue() rounds to.
+        self::assertSame($expected, $this->type->getSQLDeclaration([], $platform));
+    }
+
+    #[DataProvider('platforms')]
+    public function testHonoursAnExplicitlyDeclaredPrecisionAndScale(AbstractPlatform $platform): void
+    {
+        // A migration freezes the shape it produced, so it has to win over the constants.
+        self::assertSame(
+            'NUMERIC(14, 4)',
+            $this->type->getSQLDeclaration(['precision' => 14, 'scale' => 4], $platform)
+        );
     }
 
     public function testConvertsNullBothWays(): void

--- a/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
+++ b/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
@@ -39,21 +39,21 @@ final class QuantityTypeTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{AbstractPlatform, string}>
+     * @return iterable<string, array{AbstractPlatform}>
      */
     public static function platforms(): iterable
     {
-        yield 'mysql' => [new MySQLPlatform(), 'NUMERIC(20, 6)'];
-        yield 'postgres' => [new PostgreSQLPlatform(), 'NUMERIC(20, 6)'];
-        yield 'sqlite' => [new SQLitePlatform(), 'NUMERIC(20, 6)'];
+        yield 'mysql' => [new MySQLPlatform()];
+        yield 'postgres' => [new PostgreSQLPlatform()];
+        yield 'sqlite' => [new SQLitePlatform()];
     }
 
     #[DataProvider('platforms')]
-    public function testDeclaresTheDefaultPrecisionAndScale(AbstractPlatform $platform, string $expected): void
+    public function testDeclaresTheDefaultPrecisionAndScale(AbstractPlatform $platform): void
     {
         // A column that declares nothing must not end up narrower than the scale
         // convertToDatabaseValue() rounds to.
-        self::assertSame($expected, $this->type->getSQLDeclaration([], $platform));
+        self::assertSame('NUMERIC(20, 6)', $this->type->getSQLDeclaration([], $platform));
     }
 
     #[DataProvider('platforms')]
@@ -126,7 +126,7 @@ final class QuantityTypeTest extends TestCase
     }
 
     #[DataProvider('databaseValues')]
-    public function testRoundTripsExactly(int | float | string $value): void
+    public function testRoundTripsExactly(int | float | string $value, string $expected): void
     {
         $php = $this->type->convertToPHPValue($value, $this->platform);
         self::assertNotNull($php);
@@ -135,5 +135,9 @@ final class QuantityTypeTest extends TestCase
         self::assertNotNull($database);
 
         self::assertTrue($php->isEqualTo(BigDecimal::of($database)));
+
+        // A second trip through the column has to land on the same PHP value, so a stored
+        // quantity cannot drift a little further on every read and write.
+        self::assertSame($expected, (string) $this->type->convertToPHPValue($database, $this->platform));
     }
 }

--- a/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
+++ b/src/CoreBundle/Tests/Doctrine/Type/QuantityTypeTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Doctrine\Type;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigInteger;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+
+final class QuantityTypeTest extends TestCase
+{
+    private QuantityType $type;
+
+    private AbstractPlatform $platform;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->type = new QuantityType();
+        $this->platform = new MySQLPlatform();
+    }
+
+    /**
+     * @return iterable<string, array{AbstractPlatform, string}>
+     */
+    public static function platforms(): iterable
+    {
+        yield 'mysql' => [new MySQLPlatform(), 'NUMERIC(20, 6)'];
+        yield 'postgres' => [new PostgreSQLPlatform(), 'NUMERIC(20, 6)'];
+        yield 'sqlite' => [new SQLitePlatform(), 'NUMERIC(20, 6)'];
+    }
+
+    #[DataProvider('platforms')]
+    public function testDeclaresAFixedPrecisionAndScale(AbstractPlatform $platform, string $expected): void
+    {
+        // The precision and scale in the mapping are deliberately ignored, so the DDL can
+        // never drift from the scale convertToDatabaseValue() rounds to.
+        self::assertSame($expected, $this->type->getSQLDeclaration(['precision' => 4, 'scale' => 1], $platform));
+    }
+
+    public function testConvertsNullBothWays(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    /**
+     * @return iterable<string, array{int|float|string, string}>
+     */
+    public static function databaseValues(): iterable
+    {
+        yield 'padded decimal string' => ['2.500000', '2.5'];
+        yield 'whole number string' => ['1.000000', '1'];
+        yield 'full scale' => ['0.000001', '0.000001'];
+        yield 'largest supported value' => ['99999999999999.999999', '99999999999999.999999'];
+        yield 'negative' => ['-3.250000', '-3.25'];
+        yield 'zero' => ['0.000000', '0'];
+        // SQLite has no exact decimal storage class and hands back native types instead.
+        yield 'sqlite float' => [2.5, '2.5'];
+        yield 'sqlite float needing the full scale' => [1.234567, '1.234567'];
+        yield 'sqlite integer' => [3, '3'];
+    }
+
+    #[DataProvider('databaseValues')]
+    public function testConvertsToPhpValue(int | float | string $value, string $expected): void
+    {
+        $converted = $this->type->convertToPHPValue($value, $this->platform);
+
+        self::assertInstanceOf(BigDecimal::class, $converted);
+        // Trailing zeros are stripped so `{{ line.qty }}` renders "2.5", not "2.500000".
+        self::assertSame($expected, (string) $converted);
+    }
+
+    /**
+     * @return iterable<string, array{BigDecimal|BigInteger, string}>
+     */
+    public static function phpValues(): iterable
+    {
+        yield 'integer' => [BigInteger::of(3), '3.000000'];
+        yield 'one decimal' => [BigDecimal::of('2.5'), '2.500000'];
+        yield 'full scale' => [BigDecimal::of('0.000001'), '0.000001'];
+        yield 'beyond scale rounds half even down' => [BigDecimal::of('0.0000005'), '0.000000'];
+        yield 'beyond scale rounds half even up' => [BigDecimal::of('0.0000015'), '0.000002'];
+        yield 'negative' => [BigDecimal::of('-3.25'), '-3.250000'];
+    }
+
+    #[DataProvider('phpValues')]
+    public function testConvertsToDatabaseValue(BigDecimal | BigInteger $value, string $expected): void
+    {
+        self::assertSame($expected, $this->type->convertToDatabaseValue($value, $this->platform));
+    }
+
+    public function testRejectsNonNumbers(): void
+    {
+        $this->expectException(InvalidType::class);
+
+        $this->type->convertToDatabaseValue('2.5', $this->platform);
+    }
+
+    #[DataProvider('databaseValues')]
+    public function testRoundTripsExactly(int | float | string $value): void
+    {
+        $php = $this->type->convertToPHPValue($value, $this->platform);
+        self::assertNotNull($php);
+
+        $database = $this->type->convertToDatabaseValue($php, $this->platform);
+        self::assertNotNull($database);
+
+        self::assertTrue($php->isEqualTo(BigDecimal::of($database)));
+    }
+}

--- a/src/CoreBundle/Tests/Fixtures/LineQuantityCorpus.php
+++ b/src/CoreBundle/Tests/Fixtures/LineQuantityCorpus.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Fixtures;
+
+use function count;
+use function mt_rand;
+use function mt_srand;
+use function number_format;
+
+/**
+ * A corpus of `(price, qty)` pairs standing in for the lines of already-issued invoices,
+ * used to prove that moving `qty` from a float column to `DECIMAL(20, 6)` leaves every
+ * existing total unchanged.
+ *
+ * Quantities are expressed as the *float* the old column held, because that is what a
+ * pre-migration database contains. The value the migration lands in the new column is
+ * whatever the database rounds that double to at the column scale — {@see self::migrated()}.
+ *
+ * @see \SolidInvoice\CoreBundle\Tests\Billing\LineQuantityRegressionTest
+ * @see \SolidInvoice\CoreBundle\Tests\Functional\LineQuantityPersistenceTest
+ *
+ * @codeCoverageIgnore
+ */
+final class LineQuantityCorpus
+{
+    /**
+     * Deterministic, so a failure is always reproducible.
+     */
+    private const int SEED = 20250803;
+
+    /**
+     * Quantities seen on real invoices, plus the awkward cases around them: whole units,
+     * halves and quarters, hours billed to two and four places, metered usage, and values
+     * that a double cannot represent exactly.
+     *
+     * @return list<float>
+     */
+    public static function quantities(): array
+    {
+        $quantities = [
+            1.0, 2.0, 3.0, 5.0, 10.0, 12.0, 24.0, 100.0, 250.0, 1000.0,
+            0.5, 1.5, 2.5, 7.5, 0.25, 0.75, 3.25, 8.75,
+            // Hours as decimals: 5, 10, 20 and 45 minutes, and typical retainer blocks.
+            0.0833, 0.1667, 0.3333, 1.25, 7.25, 37.5, 160.0,
+            // No exact double representation.
+            0.1, 0.2, 0.3, 0.7, 1.1, 2.2, 4.4, 8.8, 1.005, 2.675,
+            // Metered usage, including the limits of the chosen scale.
+            0.001, 0.0001, 1234.5678, 999.999, 0.000001, 0.123456,
+        ];
+
+        // A deterministic sweep, so the corpus is not only the cases someone thought of.
+        mt_srand(self::SEED);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $quantities[] = (float) number_format(mt_rand(1, 5_000_000) / 10_000, $i % 7, '.', '');
+        }
+
+        mt_srand();
+
+        return $quantities;
+    }
+
+    /**
+     * Prices in the minor unit, spanning the range the money columns hold.
+     *
+     * @return list<int>
+     */
+    public static function prices(): array
+    {
+        return [1, 7, 99, 100, 333, 1000, 1999, 12345, 100000, 999999, 123456789];
+    }
+
+    /**
+     * @return list<array{int, float}>
+     */
+    public static function lines(): array
+    {
+        $prices = self::prices();
+        $lines = [];
+
+        foreach (self::quantities() as $index => $qty) {
+            $lines[] = [$prices[$index % count($prices)], $qty];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The value the migration lands in the `DECIMAL(20, 6)` column for a float that was
+     * previously stored: the database rounds the double to the column scale.
+     */
+    public static function migrated(float $qty): string
+    {
+        return number_format($qty, 6, '.', '');
+    }
+
+    /**
+     * How the total was computed before this change: the float cast to a string at PHP's
+     * `precision` ini setting, then multiplied into the exactly-computed price.
+     */
+    public static function legacyQtyString(float $qty): string
+    {
+        return (string) $qty;
+    }
+
+    /**
+     * Quantities at the exact limit of the chosen scale, for round-trip tests.
+     *
+     * @return list<string>
+     */
+    public static function fullScaleQuantities(): array
+    {
+        return [
+            '0.000001',
+            '0.123456',
+            '1.000001',
+            '99.999999',
+            '1234.567891',
+        ];
+    }
+}

--- a/src/CoreBundle/Tests/Form/Transformer/QuantityTransformerTest.php
+++ b/src/CoreBundle/Tests/Form/Transformer/QuantityTransformerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Form\Transformer;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigInteger;
+use Brick\Math\BigNumber;
+use Locale;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+final class QuantityTransformerTest extends TestCase
+{
+    private QuantityTransformer $transformer;
+
+    private string $locale;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->locale = Locale::getDefault();
+        Locale::setDefault('en');
+        $this->transformer = new QuantityTransformer();
+    }
+
+    protected function tearDown(): void
+    {
+        Locale::setDefault($this->locale);
+        parent::tearDown();
+    }
+
+    /**
+     * @return iterable<string, array{BigNumber, string}>
+     */
+    public static function modelValues(): iterable
+    {
+        yield 'integer' => [BigInteger::of(2), '2'];
+        yield 'one decimal' => [BigDecimal::of('2.5'), '2.5'];
+        yield 'trailing zeros are not padded' => [BigDecimal::of('2.500000'), '2.5'];
+        yield 'full scale' => [BigDecimal::of('0.000001'), '0.000001'];
+        yield 'negative' => [BigDecimal::of('-1.25'), '-1.25'];
+        yield 'zero' => [BigDecimal::zero(), '0'];
+    }
+
+    #[DataProvider('modelValues')]
+    public function testTransform(BigNumber $value, string $expected): void
+    {
+        self::assertSame($expected, $this->transformer->transform($value));
+    }
+
+    public function testTransformsNullToAnEmptyString(): void
+    {
+        self::assertSame('', $this->transformer->transform(null));
+    }
+
+    public function testTransformUsesTheLocaleDecimalSeparator(): void
+    {
+        Locale::setDefault('de');
+
+        self::assertSame('2,5', new QuantityTransformer()->transform(BigDecimal::of('2.5')));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function viewValues(): iterable
+    {
+        yield 'integer' => ['2', '2'];
+        yield 'decimal point' => ['2.5', '2.5'];
+        yield 'decimal comma' => ['2,5', '2.5'];
+        yield 'full scale' => ['0.000001', '0.000001'];
+        yield 'beyond the scale is rounded half up' => ['0.0000005', '0.000001'];
+        yield 'padded' => ['2.500000', '2.5'];
+        yield 'negative' => ['-1.25', '-1.25'];
+        yield 'surrounding whitespace' => ["  2.5\n", '2.5'];
+        yield 'non-breaking space' => ["2\xc2\xa0500.5", '2500.5'];
+    }
+
+    #[DataProvider('viewValues')]
+    public function testReverseTransform(string $value, string $expected): void
+    {
+        $result = $this->transformer->reverseTransform($value);
+
+        self::assertInstanceOf(BigDecimal::class, $result);
+        self::assertSame($expected, (string) $result);
+    }
+
+    /**
+     * @return iterable<string, array{string|null}>
+     */
+    public static function emptyViewValues(): iterable
+    {
+        yield 'null' => [null];
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['   '];
+    }
+
+    #[DataProvider('emptyViewValues')]
+    public function testReverseTransformsEmptyValuesToNull(?string $value): void
+    {
+        self::assertNull($this->transformer->reverseTransform($value));
+    }
+
+    public function testReverseTransformRejectsNonNumericInput(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+
+        $this->transformer->reverseTransform('one and a half');
+    }
+
+    public function testReverseTransformRejectsNonStrings(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+
+        $this->transformer->reverseTransform(2.5);
+    }
+
+    #[DataProvider('modelValues')]
+    public function testRoundTripsWithoutLosingDigits(BigNumber $value): void
+    {
+        $result = $this->transformer->reverseTransform($this->transformer->transform($value));
+
+        self::assertInstanceOf(BigDecimal::class, $result);
+        self::assertTrue($value->isEqualTo($result));
+    }
+}

--- a/src/CoreBundle/Tests/Form/Transformer/QuantityTransformerTest.php
+++ b/src/CoreBundle/Tests/Form/Transformer/QuantityTransformerTest.php
@@ -19,6 +19,7 @@ use Brick\Math\BigNumber;
 use Locale;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
@@ -82,8 +83,8 @@ final class QuantityTransformerTest extends TestCase
         yield 'decimal point' => ['2.5', '2.5'];
         yield 'decimal comma' => ['2,5', '2.5'];
         yield 'full scale' => ['0.000001', '0.000001'];
-        yield 'beyond the scale is rounded half up' => ['0.0000005', '0.000001'];
-        yield 'padded' => ['2.500000', '2.5'];
+        // Parsed verbatim; setQty() canonicalises, and the field re-renders from the model.
+        yield 'padded' => ['2.500000', '2.500000'];
         yield 'negative' => ['-1.25', '-1.25'];
         yield 'surrounding whitespace' => ["  2.5\n", '2.5'];
         yield 'non-breaking space' => ["2\xc2\xa0500.5", '2500.5'];
@@ -114,6 +115,19 @@ final class QuantityTransformerTest extends TestCase
         self::assertNull($this->transformer->reverseTransform($value));
     }
 
+    /**
+     * Beyond-scale input is passed through untouched: setQty() owns the rounding, so that a
+     * form and an API call resolve the same quantity identically.
+     */
+    public function testReverseTransformLeavesRoundingToTheEntity(): void
+    {
+        $result = $this->transformer->reverseTransform('0.0000005');
+
+        self::assertInstanceOf(BigDecimal::class, $result);
+        self::assertSame('0.0000005', (string) $result);
+        self::assertSame('0', (string) QuantityType::normalize($result));
+    }
+
     public function testReverseTransformRejectsNonNumericInput(): void
     {
         $this->expectException(TransformationFailedException::class);
@@ -129,11 +143,11 @@ final class QuantityTransformerTest extends TestCase
     }
 
     #[DataProvider('modelValues')]
-    public function testRoundTripsWithoutLosingDigits(BigNumber $value): void
+    public function testRoundTripsWithoutLosingDigits(BigNumber $value, string $view): void
     {
-        $result = $this->transformer->reverseTransform($this->transformer->transform($value));
+        $result = $this->transformer->reverseTransform($view);
 
         self::assertInstanceOf(BigDecimal::class, $result);
-        self::assertTrue($value->isEqualTo($result));
+        self::assertTrue($value->isEqualTo($result), sprintf('Expected %s, got %s', $value, $result));
     }
 }

--- a/src/CoreBundle/Tests/Functional/LineQuantityPersistenceTest.php
+++ b/src/CoreBundle/Tests/Functional/LineQuantityPersistenceTest.php
@@ -119,6 +119,47 @@ final class LineQuantityPersistenceTest extends KernelTestCase
     }
 
     /**
+     * The line total is computed in `PrePersist`, before DBAL converts the quantity. If the
+     * quantity were not already at the column scale by then, the stored total would be
+     * computed from digits the column drops, and recomputing after a reload would move the
+     * invoice. The price here is large enough that a difference lands in the minor unit.
+     */
+    public function testTheStoredTotalMatchesTheStoredQuantity(): void
+    {
+        $invoice = new Invoice();
+        $invoice->setClient(ClientFactory::createOne(['currencyCode' => 'USD']));
+        $invoice->setStatus(InvoiceStatus::Draft);
+
+        $line = new Line();
+        $line->setDescription('Sub-scale usage')
+            ->setPrice(100_000_000)
+            ->setQty('1.23456749')
+            ->updateTotal();
+
+        $invoice->addLine($line);
+
+        $storedTotal = (string) $line->getTotal();
+
+        $this->em->persist($invoice);
+        $this->em->flush();
+
+        $id = $line->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Line::class, $id);
+
+        self::assertInstanceOf(Line::class, $reloaded);
+        self::assertTrue(
+            $reloaded->updateTotal()->getTotal()->isEqualTo(BigDecimal::of($storedTotal)),
+            sprintf(
+                'Recomputing from the stored quantity gave %s, but %s was stored',
+                (string) $reloaded->getTotal(),
+                $storedTotal
+            )
+        );
+    }
+
+    /**
      * A quantity beyond the column scale is rounded once, on the way in, rather than
      * drifting differently on every read.
      */

--- a/src/CoreBundle/Tests/Functional/LineQuantityPersistenceTest.php
+++ b/src/CoreBundle/Tests/Functional/LineQuantityPersistenceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Functional;
+
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use SolidInvoice\CoreBundle\Tests\Fixtures\LineQuantityCorpus;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Entity\Line;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\QuoteBundle\Entity\Line as QuoteLine;
+use SolidInvoice\QuoteBundle\Entity\Quote;
+use SolidInvoice\QuoteBundle\Enum\QuoteStatus;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use function sprintf;
+
+/**
+ * Fractional quantities have to survive a round trip through the database unchanged, and
+ * the line total recomputed from a reloaded quantity has to match the one that was stored.
+ *
+ * @see QuantityType
+ */
+#[CoversClass(QuantityType::class)]
+#[Group('functional')]
+final class LineQuantityPersistenceTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function fullScaleQuantities(): iterable
+    {
+        foreach (LineQuantityCorpus::fullScaleQuantities() as $qty) {
+            yield $qty => [$qty];
+        }
+    }
+
+    #[DataProvider('fullScaleQuantities')]
+    public function testAnInvoiceLineQuantityRoundTripsExactly(string $qty): void
+    {
+        $invoice = new Invoice();
+        $invoice->setClient(ClientFactory::createOne(['currencyCode' => 'USD']));
+        $invoice->setStatus(InvoiceStatus::Draft);
+
+        $line = new Line();
+        $line->setDescription('Metered usage')
+            ->setPrice(100000)
+            ->setQty($qty)
+            ->updateTotal();
+
+        $invoice->addLine($line);
+
+        $storedTotal = (string) $line->getTotal();
+
+        $this->em->persist($invoice);
+        $this->em->flush();
+
+        $id = $line->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Line::class, $id);
+
+        self::assertInstanceOf(Line::class, $reloaded);
+        self::assertTrue(
+            BigDecimal::of($qty)->isEqualTo($reloaded->getQty()),
+            sprintf('Expected %s, got %s', $qty, (string) $reloaded->getQty())
+        );
+        self::assertTrue(
+            $reloaded->updateTotal()->getTotal()->isEqualTo(BigDecimal::of($storedTotal)),
+            'The total recomputed from the reloaded quantity does not match the stored one'
+        );
+    }
+
+    #[DataProvider('fullScaleQuantities')]
+    public function testAQuoteLineQuantityRoundTripsExactly(string $qty): void
+    {
+        $quote = new Quote();
+        $quote->setClient(ClientFactory::createOne(['currencyCode' => 'USD']));
+        $quote->setStatus(QuoteStatus::Draft);
+
+        $line = new QuoteLine();
+        $line->setDescription('Metered usage')
+            ->setPrice(100000)
+            ->setQty($qty)
+            ->updateTotal();
+
+        $quote->addLine($line);
+
+        $this->em->persist($quote);
+        $this->em->flush();
+
+        $id = $line->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(QuoteLine::class, $id);
+
+        self::assertInstanceOf(QuoteLine::class, $reloaded);
+        self::assertTrue(
+            BigDecimal::of($qty)->isEqualTo($reloaded->getQty()),
+            sprintf('Expected %s, got %s', $qty, (string) $reloaded->getQty())
+        );
+    }
+
+    /**
+     * A quantity beyond the column scale is rounded once, on the way in, rather than
+     * drifting differently on every read.
+     */
+    public function testAQuantityBeyondTheScaleIsRoundedOnce(): void
+    {
+        $invoice = new Invoice();
+        $invoice->setClient(ClientFactory::createOne(['currencyCode' => 'USD']));
+        $invoice->setStatus(InvoiceStatus::Draft);
+
+        $line = new Line();
+        $line->setDescription('Sub-scale usage')
+            ->setPrice(100)
+            ->setQty('1.23456749')
+            ->updateTotal();
+
+        $invoice->addLine($line);
+
+        $this->em->persist($invoice);
+        $this->em->flush();
+
+        $id = $line->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Line::class, $id);
+
+        self::assertInstanceOf(Line::class, $reloaded);
+        self::assertTrue(BigDecimal::of('1.234567')->isEqualTo($reloaded->getQty()));
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $reread = $this->em->find(Line::class, $id);
+
+        self::assertInstanceOf(Line::class, $reread);
+        self::assertTrue(BigDecimal::of('1.234567')->isEqualTo($reread->getQty()));
+    }
+}

--- a/src/CoreBundle/Tests/Migration/LineQuantityColumnMatchesMappingTest.php
+++ b/src/CoreBundle/Tests/Migration/LineQuantityColumnMatchesMappingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The mapping and {@see \DoctrineMigrations\Version30100_2} have to agree on the column
+ * definition, or every deployment ends up with a permanent schema diff.
+ */
+#[Group('functional')]
+final class LineQuantityColumnMatchesMappingTest extends KernelTestCase
+{
+    use EnsureApplicationInstalled;
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function tables(): iterable
+    {
+        yield 'invoice_lines' => ['invoice_lines'];
+        yield 'quote_lines' => ['quote_lines'];
+    }
+
+    #[DataProvider('tables')]
+    public function testTheInstalledColumnIsAnExactDecimal(string $table): void
+    {
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        $column = $connection->createSchemaManager()->introspectTable($table)->getColumn('qty');
+
+        self::assertSame(QuantityType::PRECISION, $column->getPrecision());
+        self::assertSame(QuantityType::SCALE, $column->getScale());
+        self::assertTrue($column->getNotnull());
+    }
+}

--- a/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use DoctrineMigrations\Version30100_2;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
+
+final class LineQuantityDecimalMigrationTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function tables(): iterable
+    {
+        yield 'invoice_lines' => ['invoice_lines'];
+        yield 'quote_lines' => ['quote_lines'];
+    }
+
+    #[DataProvider('tables')]
+    public function testUpConvertsTheFloatColumnToAnExactDecimal(string $table): void
+    {
+        $schema = $this->preMigrationSchema();
+
+        $this->migration()->up($schema);
+
+        $column = $schema->getTable($table)->getColumn('qty');
+
+        self::assertSame(Type::getType(Types::DECIMAL), $column->getType());
+        self::assertSame(QuantityType::PRECISION, $column->getPrecision());
+        self::assertSame(QuantityType::SCALE, $column->getScale());
+        self::assertTrue($column->getNotnull());
+    }
+
+    #[DataProvider('tables')]
+    public function testDownRestoresTheFloatColumn(string $table): void
+    {
+        $schema = $this->preMigrationSchema();
+        $migration = $this->migration();
+
+        $migration->up($schema);
+        $migration->down($schema);
+
+        $column = $schema->getTable($table)->getColumn('qty');
+
+        self::assertSame(Type::getType(Types::FLOAT), $column->getType());
+    }
+
+    private function preMigrationSchema(): Schema
+    {
+        $schema = new Schema();
+
+        foreach (['invoice_lines', 'quote_lines'] as $tableName) {
+            $table = $schema->createTable($tableName);
+            $table->addColumn('qty', Types::FLOAT, ['notnull' => true]);
+        }
+
+        return $schema;
+    }
+
+    private function migration(): Version30100_2
+    {
+        return new Version30100_2($this->connection(), new NullLogger());
+    }
+
+    private function connection(): Connection
+    {
+        // A server version keeps DBAL from having to connect to resolve the platform.
+        return DriverManager::getConnection([
+            'driver' => 'pdo_mysql',
+            'host' => 'localhost',
+            'dbname' => 'solidinvoice',
+            'serverVersion' => '8.0.0',
+        ]);
+    }
+}

--- a/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
@@ -26,13 +26,16 @@ use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 
 final class LineQuantityDecimalMigrationTest extends TestCase
 {
+    private const array TABLES = ['invoice_lines', 'quote_lines'];
+
     /**
      * @return iterable<string, array{string}>
      */
     public static function tables(): iterable
     {
-        yield 'invoice_lines' => ['invoice_lines'];
-        yield 'quote_lines' => ['quote_lines'];
+        foreach (self::TABLES as $table) {
+            yield $table => [$table];
+        }
     }
 
     #[DataProvider('tables')]
@@ -64,6 +67,8 @@ final class LineQuantityDecimalMigrationTest extends TestCase
         $column = $schema->getTable($table)->getColumn('qty');
 
         self::assertSame(Type::getType(Types::FLOAT), $column->getType());
+        self::assertSame(10, $column->getPrecision());
+        self::assertSame(0, $column->getScale());
     }
 
     private function preMigrationSchema(): Schema
@@ -76,7 +81,7 @@ final class LineQuantityDecimalMigrationTest extends TestCase
 
         $schema = new Schema();
 
-        foreach (['invoice_lines', 'quote_lines'] as $tableName) {
+        foreach (self::TABLES as $tableName) {
             $table = $schema->createTable($tableName);
             $table->addColumn('qty', Types::FLOAT, ['notnull' => true]);
         }

--- a/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
@@ -94,14 +94,17 @@ final class LineQuantityDecimalMigrationTest extends TestCase
         return new Version30100_2($this->connection(), new NullLogger());
     }
 
+    /**
+     * The migration only mutates a {@see Schema}, so the platform is irrelevant to what is
+     * asserted here — but AbstractMigration resolves one in its constructor. In-memory
+     * SQLite keeps that self-contained: it needs no server, and it is the only driver the
+     * suite already requires, whereas `ext-pdo_mysql` is not a declared dependency.
+     */
     private function connection(): Connection
     {
-        // A server version keeps DBAL from having to connect to resolve the platform.
         return DriverManager::getConnection([
-            'driver' => 'pdo_mysql',
-            'host' => 'localhost',
-            'dbname' => 'solidinvoice',
-            'serverVersion' => '8.0.0',
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
         ]);
     }
 }

--- a/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineQuantityDecimalMigrationTest.php
@@ -44,9 +44,11 @@ final class LineQuantityDecimalMigrationTest extends TestCase
 
         $column = $schema->getTable($table)->getColumn('qty');
 
-        self::assertSame(Type::getType(Types::DECIMAL), $column->getType());
-        self::assertSame(QuantityType::PRECISION, $column->getPrecision());
-        self::assertSame(QuantityType::SCALE, $column->getScale());
+        self::assertSame(Type::getType(QuantityType::NAME), $column->getType());
+        // Literals, not QuantityType's constants: the migration freezes the shape it
+        // produced, so this has to fail if a later change to the type silently moves it.
+        self::assertSame(20, $column->getPrecision());
+        self::assertSame(6, $column->getScale());
         self::assertTrue($column->getNotnull());
     }
 
@@ -66,6 +68,12 @@ final class LineQuantityDecimalMigrationTest extends TestCase
 
     private function preMigrationSchema(): Schema
     {
+        // The type is registered by the DBAL config in a booted kernel; this test runs
+        // without one.
+        if (! Type::hasType(QuantityType::NAME)) {
+            Type::addType(QuantityType::NAME, QuantityType::class);
+        }
+
         $schema = new Schema();
 
         foreach (['invoice_lines', 'quote_lines'] as $tableName) {

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -244,7 +244,10 @@ class Line implements LineInterface, Stringable
      */
     public function setQty(BigNumber | int | string $qty): static
     {
-        $this->qty = BigNumber::of($qty)->toBigDecimal()->strippedOfTrailingZeros();
+        // Normalized on the way in, not on the way out: updateTotal() runs before DBAL
+        // converts the quantity, so the total has to be computed from the same value the
+        // column will hold. See QuantityType::normalize().
+        $this->qty = QuantityType::normalize(BigNumber::of($qty));
 
         return $this;
     }

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -28,8 +28,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer;
 use SolidInvoice\ApiBundle\State\Processor\InvoiceLinePersistProcessor;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
@@ -39,6 +41,7 @@ use SolidInvoice\TaxBundle\Entity\LineTax;
 use Stringable;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
@@ -150,10 +153,22 @@ class Line implements LineInterface, Stringable
     )]
     protected BigNumber $price;
 
-    #[ORM\Column(name: 'qty', type: Types::FLOAT)]
+    #[ORM\Column(name: 'qty', type: QuantityType::NAME, precision: QuantityType::PRECISION, scale: QuantityType::SCALE)]
     #[Assert\NotBlank]
     #[Groups(['invoice_api:read', 'invoice_api:write', 'recurring_invoice_api:read', 'recurring_invoice_api:write'])]
-    protected ?float $qty = 1;
+    #[Context(
+        normalizationContext: [BigIntegerNormalizer::MONETARY => false],
+        denormalizationContext: [BigIntegerNormalizer::MONETARY => false],
+    )]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'number',
+        ],
+        jsonSchemaContext: [
+            'type' => 'number',
+        ]
+    )]
+    protected BigNumber $qty;
 
     #[ORM\ManyToOne(targetEntity: Invoice::class, inversedBy: 'lines')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
@@ -188,6 +203,7 @@ class Line implements LineInterface, Stringable
     {
         $this->total = BigDecimal::zero();
         $this->price = BigDecimal::zero();
+        $this->qty = BigDecimal::one();
         $this->taxes = new ArrayCollection();
     }
 
@@ -223,14 +239,17 @@ class Line implements LineInterface, Stringable
         return $this->price;
     }
 
-    public function setQty(float $qty): static
+    /**
+     * @throws MathException
+     */
+    public function setQty(BigNumber | int | string $qty): static
     {
-        $this->qty = $qty;
+        $this->qty = BigNumber::of($qty)->toBigDecimal()->strippedOfTrailingZeros();
 
         return $this;
     }
 
-    public function getQty(): ?float
+    public function getQty(): BigNumber
     {
         return $this->qty;
     }
@@ -295,7 +314,7 @@ class Line implements LineInterface, Stringable
     #[ORM\PrePersist]
     public function updateTotal(): static
     {
-        $this->total = $this->getPrice()->toBigDecimal()->multipliedBy($this->qty !== null ? (string) $this->qty : 1);
+        $this->total = $this->getPrice()->toBigDecimal()->multipliedBy($this->qty->toBigDecimal());
 
         return $this;
     }

--- a/src/InvoiceBundle/Form/Type/ItemType.php
+++ b/src/InvoiceBundle/Form/Type/ItemType.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\InvoiceBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
@@ -65,12 +66,18 @@ class ItemType extends AbstractType
             'qty',
             NumberType::class,
             [
-                'empty_data' => 1,
+                'empty_data' => '1',
                 'attr' => [
                     'class' => 'input-mini invoice-item-qty',
                 ],
             ]
         );
+
+        // NumberType's own view transformer round-trips through a float, which would undo
+        // the exact-decimal quantity the entity now holds.
+        $builder->get('qty')
+            ->resetViewTransformers()
+            ->addViewTransformer(new QuantityTransformer());
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
+++ b/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\InvoiceBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
@@ -65,12 +66,18 @@ class RecurringInvoiceLineType extends AbstractType
             'qty',
             NumberType::class,
             [
-                'empty_data' => 1,
+                'empty_data' => '1',
                 'attr' => [
                     'class' => 'input-mini invoice-item-qty',
                 ],
             ]
         );
+
+        // NumberType's own view transformer round-trips through a float, which would undo
+        // the exact-decimal quantity the entity now holds.
+        $builder->get('qty')
+            ->resetViewTransformers()
+            ->addViewTransformer(new QuantityTransformer());
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/InvoiceBundle/Tests/Cloner/InvoiceClonerTest.php
+++ b/src/InvoiceBundle/Tests/Cloner/InvoiceClonerTest.php
@@ -132,7 +132,7 @@ final class InvoiceClonerTest extends TestCase
         self::assertSame($line->getDescription(), $invoiceLine[0]->getDescription());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
-        self::assertSame($line->getQty(), $invoiceLine[0]->getQty());
+        self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
     }
 
     public function testCloneWithRecurring(): void
@@ -208,7 +208,7 @@ final class InvoiceClonerTest extends TestCase
         self::assertSame($line->getDescription(), $invoiceLine[0]->getDescription());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
-        self::assertSame($line->getQty(), $invoiceLine[0]->getQty());
+        self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
         self::assertSame($newInvoice->getDateStart(), $invoice->getDateStart());
         self::assertSame($newInvoice->getDateEnd(), $invoice->getDateEnd());
     }

--- a/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
@@ -28,7 +28,7 @@ final class ItemTypeTest extends FormTestCase
     {
         $description = $this->faker->text();
         $price = $this->faker->randomNumber(3);
-        $qty = $this->faker->randomFloat(2);
+        $qty = '12.345678';
 
         $formData = [
             'description' => $description,
@@ -50,7 +50,7 @@ final class ItemTypeTest extends FormTestCase
     {
         $description = 'Item + discount & "special" chars: 100% off';
         $price = 100;
-        $qty = 1.0;
+        $qty = '1';
 
         $formData = [
             'description' => $description,

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -48,6 +48,51 @@ final class InvoiceLineTest extends ApiTestCase
         self::assertArrayHasKey('total', $result);
     }
 
+    /**
+     * `qty` is a plain number on the wire, unlike `price` and `total`, which are scaled
+     * into the minor unit. A fractional quantity has to come back exactly as sent.
+     */
+    public function testCreateWithAFractionalQuantity(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => 'Metered usage',
+            'price' => 1000,
+            'qty' => 2.5,
+        ]);
+
+        self::assertSame(2.5, $result['qty']);
+        // price is sent in the major unit, so 1000 × 2.5 comes back as 2500.
+        self::assertEquals(2500, $result['total']);
+
+        $reloaded = $this->requestGet('/api/invoices/' . $invoiceId . '/line/' . $result['id']);
+
+        self::assertSame(2.5, $reloaded['qty']);
+    }
+
+    public function testEditAQuantityToSixDecimalPlaces(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $created = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => 'Metered usage',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        $updated = $this->requestPatch(
+            '/api/invoices/' . $invoiceId . '/line/' . $created['id'],
+            ['qty' => 0.123456]
+        );
+
+        self::assertSame(0.123456, $updated['qty']);
+    }
+
     public function testGet(): void
     {
         $invoice = InvoiceFactory::createOne();

--- a/src/InvoiceBundle/Tests/Functional/Email/TemplateEmailSnapshotTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Email/TemplateEmailSnapshotTest.php
@@ -119,7 +119,7 @@ final class TemplateEmailSnapshotTest extends KernelTestCase
                     new Line()
                         ->setDescription('Sample line item')
                         ->setPrice(75000)
-                        ->setQty(2.0)
+                        ->setQty(2)
                         ->updateTotal(),
                 ],
                 'users' => [$contact],

--- a/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -203,7 +203,7 @@ final class TemplatesRenderingTest extends KernelTestCase
                 new Line()
                     ->setDescription('Sample line item')
                     ->setPrice(BigInteger::of(75000))
-                    ->setQty(2.0)
+                    ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
             ],
             'users' => [$contact],

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -176,7 +176,7 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertSame($line->getDescription(), $invoiceLine[0]->getDescription());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
-        self::assertSame($line->getQty(), $invoiceLine[0]->getQty());
+        self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
     }
 
     public function testQuoteToInvoiceCopiesLineTaxSnapshotsAsNewRows(): void
@@ -349,6 +349,6 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertSame('Line Description 15 Monday January 2024', $invoiceLine[0]->getDescription());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
-        self::assertSame($line->getQty(), $invoiceLine[0]->getQty());
+        self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
     }
 }

--- a/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
@@ -168,7 +168,7 @@ final class CreateInvoiceTest extends LiveComponentTest
         $line = new Line()
             ->setDescription('Consulting')
             ->setPrice(10000)
-            ->setQty(1.0);
+            ->setQty(1);
 
         $invoice = new Invoice();
         $invoice->setStatus(InvoiceStatus::Pending);

--- a/src/McpBundle/Mcp/Tool/EntityNormalizer.php
+++ b/src/McpBundle/Mcp/Tool/EntityNormalizer.php
@@ -185,7 +185,7 @@ final class EntityNormalizer
                 'id' => $line->getId()->toRfc4122(),
                 'description' => $line->getDescription(),
                 'price' => $this->bigNumber($line->getPrice()),
-                'qty' => $line->getQty(),
+                'qty' => $this->bigNumber($line->getQty()),
                 'total' => $this->bigNumber($line->getTotal()),
                 'taxes' => array_values(array_map(
                     $this->lineTax(...),

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -154,7 +154,11 @@ final readonly class LineItemBuilder
                 throw new ToolCallException(sprintf('Line item #%d has an invalid "price": %s', $index, (string) $price));
             }
 
-            $line->setQty((float) $qty);
+            try {
+                $line->setQty(BigDecimal::of(\is_float($qty) ? (string) $qty : $qty));
+            } catch (Throwable) {
+                throw new ToolCallException(sprintf('Line item #%d has an invalid "qty": %s', $index, (string) $qty));
+            }
 
             $this->attachTaxes($line, $data, $index);
 

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -149,13 +149,13 @@ final readonly class LineItemBuilder
             $line->setDescription($description);
 
             try {
-                $line->setPrice(BigDecimal::of((string) $price));
+                $line->setPrice(BigDecimal::of($this->toExactString($price)));
             } catch (Throwable) {
                 throw new ToolCallException(sprintf('Line item #%d has an invalid "price": %s', $index, $this->describe($price)));
             }
 
             try {
-                $line->setQty(BigDecimal::of(\is_float($qty) ? (string) $qty : $qty));
+                $line->setQty(BigDecimal::of($this->toExactString($qty)));
             } catch (Throwable) {
                 throw new ToolCallException(sprintf('Line item #%d has an invalid "qty": %s', $index, $this->describe($qty)));
             }
@@ -166,6 +166,20 @@ final readonly class LineItemBuilder
         }
 
         return $built;
+    }
+
+    /**
+     * A JSON number reaches a tool as a float. `(string)` would serialise it at the host's
+     * `precision` ini setting, so the same tool call could resolve to different digits from
+     * one host to the next; %.14G pins that, matching
+     * {@see \SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer}.
+     *
+     * Anything that is not a number is handed to BigDecimal untouched, so that malformed
+     * input fails there and is reported as a ToolCallException.
+     */
+    private function toExactString(mixed $value): mixed
+    {
+        return \is_float($value) ? sprintf('%.14G', $value) : $value;
     }
 
     /**

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -151,13 +151,13 @@ final readonly class LineItemBuilder
             try {
                 $line->setPrice(BigDecimal::of((string) $price));
             } catch (Throwable) {
-                throw new ToolCallException(sprintf('Line item #%d has an invalid "price": %s', $index, (string) $price));
+                throw new ToolCallException(sprintf('Line item #%d has an invalid "price": %s', $index, $this->describe($price)));
             }
 
             try {
                 $line->setQty(BigDecimal::of(\is_float($qty) ? (string) $qty : $qty));
             } catch (Throwable) {
-                throw new ToolCallException(sprintf('Line item #%d has an invalid "qty": %s', $index, (string) $qty));
+                throw new ToolCallException(sprintf('Line item #%d has an invalid "qty": %s', $index, $this->describe($qty)));
             }
 
             $this->attachTaxes($line, $data, $index);
@@ -166,6 +166,15 @@ final readonly class LineItemBuilder
         }
 
         return $built;
+    }
+
+    /**
+     * Tools are handed raw JSON, so a value that failed to parse can be an array or an
+     * object; casting those to string for the error message would emit a warning of its own.
+     */
+    private function describe(mixed $value): string
+    {
+        return \is_scalar($value) ? (string) $value : \get_debug_type($value);
     }
 
     /**

--- a/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
+++ b/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
@@ -76,7 +76,7 @@ class CapturePaymentAction implements ActionInterface, GatewayAwareInterface
             /** @var Line $item */
             $details['L_PAYMENTREQUEST_0_NAME' . $counter] = $item->getDescription();
             $details['L_PAYMENTREQUEST_0_AMT' . $counter] = number_format(MoneyFormatter::toFloat($item->getPrice()), 2);
-            $details['L_PAYMENTREQUEST_0_QTY' . $counter] = $item->getQty();
+            $details['L_PAYMENTREQUEST_0_QTY' . $counter] = (string) $item->getQty();
 
             ++$counter;
         }

--- a/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
+++ b/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
@@ -74,9 +74,20 @@ class CapturePaymentAction implements ActionInterface, GatewayAwareInterface
         $counter = 0;
         foreach ($invoice->getLines() as $item) {
             /** @var Line $item */
+            $qty = $item->getQty()->toBigDecimal();
+
+            // PayPal's NVP API only accepts a positive integer for an item quantity, but a
+            // SolidInvoice line can be billed in fractions of a unit (hours, weights, metered
+            // usage). Such a line is sent as a single unit priced at the line total, which
+            // keeps the item amounts summing to ITEMAMT — what PayPal actually validates.
+            $isWholeUnits = $qty->getFractionalPart()->isZero();
+
             $details['L_PAYMENTREQUEST_0_NAME' . $counter] = $item->getDescription();
-            $details['L_PAYMENTREQUEST_0_AMT' . $counter] = number_format(MoneyFormatter::toFloat($item->getPrice()), 2);
-            $details['L_PAYMENTREQUEST_0_QTY' . $counter] = (string) $item->getQty();
+            $details['L_PAYMENTREQUEST_0_AMT' . $counter] = number_format(
+                MoneyFormatter::toFloat($isWholeUnits ? $item->getPrice() : $item->getTotal()),
+                2
+            );
+            $details['L_PAYMENTREQUEST_0_QTY' . $counter] = $isWholeUnits ? (string) $qty->toBigInteger() : '1';
 
             ++$counter;
         }

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -239,7 +239,10 @@ class Line implements LineInterface, Stringable
      */
     public function setQty(BigNumber | int | string $qty): static
     {
-        $this->qty = BigNumber::of($qty)->toBigDecimal()->strippedOfTrailingZeros();
+        // Normalized on the way in, not on the way out: updateTotal() runs before DBAL
+        // converts the quantity, so the total has to be computed from the same value the
+        // column will hold. See QuantityType::normalize().
+        $this->qty = QuantityType::normalize(BigNumber::of($qty));
 
         return $this;
     }

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -29,8 +29,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer;
 use SolidInvoice\ApiBundle\State\Processor\QuoteLinePersistProcessor;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
+use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
@@ -39,6 +41,7 @@ use SolidInvoice\TaxBundle\Entity\LineTax;
 use Stringable;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
@@ -146,10 +149,22 @@ class Line implements LineInterface, Stringable
     )]
     private BigNumber $price;
 
-    #[ORM\Column(name: 'qty', type: Types::FLOAT)]
+    #[ORM\Column(name: 'qty', type: QuantityType::NAME, precision: QuantityType::PRECISION, scale: QuantityType::SCALE)]
     #[Assert\NotBlank]
     #[Groups(['quote_api:read', 'quote_api:write'])]
-    private ?float $qty = 1;
+    #[Context(
+        normalizationContext: [BigIntegerNormalizer::MONETARY => false],
+        denormalizationContext: [BigIntegerNormalizer::MONETARY => false],
+    )]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'number',
+        ],
+        jsonSchemaContext: [
+            'type' => 'number',
+        ]
+    )]
+    private BigNumber $qty;
 
     #[ORM\ManyToOne(targetEntity: Quote::class, inversedBy: 'lines')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
@@ -183,6 +198,7 @@ class Line implements LineInterface, Stringable
     {
         $this->total = BigDecimal::zero();
         $this->price = BigDecimal::zero();
+        $this->qty = BigDecimal::one();
         $this->taxes = new ArrayCollection();
     }
 
@@ -218,14 +234,17 @@ class Line implements LineInterface, Stringable
         return $this->price;
     }
 
-    public function setQty(float $qty): static
+    /**
+     * @throws MathException
+     */
+    public function setQty(BigNumber | int | string $qty): static
     {
-        $this->qty = $qty;
+        $this->qty = BigNumber::of($qty)->toBigDecimal()->strippedOfTrailingZeros();
 
         return $this;
     }
 
-    public function getQty(): ?float
+    public function getQty(): BigNumber
     {
         return $this->qty;
     }
@@ -293,7 +312,7 @@ class Line implements LineInterface, Stringable
     {
         $this->total = $this->getPrice()
             ->toBigDecimal()
-            ->multipliedBy($this->qty !== null ? (string) $this->qty : 1);
+            ->multipliedBy($this->qty->toBigDecimal());
 
         return $this;
     }

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\QuoteBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
@@ -65,12 +66,18 @@ class ItemType extends AbstractType
             'qty',
             NumberType::class,
             [
-                'empty_data' => 1,
+                'empty_data' => '1',
                 'attr' => [
                     'class' => 'input-mini quote-item-qty',
                 ],
             ]
         );
+
+        // NumberType's own view transformer round-trips through a float, which would undo
+        // the exact-decimal quantity the entity now holds.
+        $builder->get('qty')
+            ->resetViewTransformers()
+            ->addViewTransformer(new QuantityTransformer());
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/QuoteBundle/Tests/Cloner/QuoteClonerTest.php
+++ b/src/QuoteBundle/Tests/Cloner/QuoteClonerTest.php
@@ -133,6 +133,6 @@ final class QuoteClonerTest extends TestCase
         self::assertSame($item->getDescription(), $quoteItem[0]->getDescription());
         self::assertInstanceOf(DateTimeImmutable::class, $quoteItem[0]->getCreated());
         self::assertEquals($item->getPrice(), $quoteItem[0]->getPrice());
-        self::assertSame($item->getQty(), $quoteItem[0]->getQty());
+        self::assertTrue($item->getQty()->isEqualTo($quoteItem[0]->getQty()));
     }
 }

--- a/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
@@ -32,7 +32,7 @@ final class ItemTypeTest extends FormTestCase
     {
         $description = $this->faker->text();
         $price = $this->faker->randomNumber(3);
-        $qty = $this->faker->randomFloat(2);
+        $qty = '12.345678';
 
         $formData = [
             'description' => $description,
@@ -57,7 +57,7 @@ final class ItemTypeTest extends FormTestCase
     {
         $description = 'Item + discount & "special" chars: 100% off';
         $price = 100;
-        $qty = 1.0;
+        $qty = '1';
 
         $formData = [
             'description' => $description,

--- a/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -205,7 +205,7 @@ final class TemplatesRenderingTest extends KernelTestCase
                 new Line()
                     ->setDescription('Sample line item')
                     ->setPrice(BigInteger::of(75000))
-                    ->setQty(2.0)
+                    ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
             ],
             'users' => [$contact],

--- a/src/SaasBundle/Templates/PreviewInvoiceFactory.php
+++ b/src/SaasBundle/Templates/PreviewInvoiceFactory.php
@@ -73,9 +73,9 @@ final readonly class PreviewInvoiceFactory
         $invoice->setDiscount(new Discount()->setType(null));
 
         foreach ([
-            ['Brand identity design', 120000, 1.0],
-            ['Landing page implementation', 85000, 1.0],
-            ['Consulting & support', 15000, 3.0],
+            ['Brand identity design', 120000, 1],
+            ['Landing page implementation', 85000, 1],
+            ['Consulting & support', 15000, 3],
         ] as [$description, $price, $qty]) {
             $line = new Line();
             $line->setDescription($description);

--- a/src/SaasBundle/Tests/Functional/PdfBaseCustomBrandingGateTest.php
+++ b/src/SaasBundle/Tests/Functional/PdfBaseCustomBrandingGateTest.php
@@ -217,7 +217,7 @@ final class PdfBaseCustomBrandingGateTest extends KernelTestCase
                 new Line()
                     ->setDescription('Sample line item')
                     ->setPrice(BigInteger::of(75000))
-                    ->setQty(2.0)
+                    ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
             ],
             'users' => [$contact],

--- a/src/TaxBundle/Tests/Calculator/LineTaxCalculatorTest.php
+++ b/src/TaxBundle/Tests/Calculator/LineTaxCalculatorTest.php
@@ -216,7 +216,7 @@ final class LineTaxCalculatorTest extends TestCase
         self::assertFalse($row->compound);
     }
 
-    private function makeLine(int $price, float $qty): Line
+    private function makeLine(int $price, int | string $qty): Line
     {
         $line = new Line();
         $line->setPrice($price);


### PR DESCRIPTION
Closes #2708.

## Why

Money in SolidInvoice is handled exactly — `BigIntegerType`, `brick/math`, `BigNumber` throughout. Quantity was the one input to the line total that was not:

```php
#[ORM\Column(name: 'qty', type: Types::FLOAT)]
protected ?float $qty = 1;

$this->total = $this->getPrice()->toBigDecimal()->multipliedBy($this->qty !== null ? (string) $this->qty : 1);
```

An exactly-computed price was multiplied by a value that made a round trip through IEEE-754 and back out through `(string)`, which serialises at PHP's `precision` ini setting. For typical quantities that is fine; for quantities with many significant digits — metered usage, weights, fractional hours billed to four places — the float column can round the stored value, and the string cast can surface or hide that rounding depending on host configuration.

## What changed

**Storage.** New `QuantityType` (`src/CoreBundle/Doctrine/Type/QuantityType.php`) mapping `DECIMAL(20, 6)` ↔ `BigNumber`, registered in `config/packages/doctrine.php`. `migrations/Version30100_2.php` converts `invoice_lines.qty` and `quote_lines.qty` from float.

**Entities.** `InvoiceBundle\Entity\Line` and `QuoteBundle\Entity\Line` hold `BigNumber $qty` (defaulting to `BigDecimal::one()`); `LineInterface` is now `setQty(BigNumber|int|string)` / `getQty(): BigNumber`, matching `setPrice()`/`getPrice()`. `updateTotal()` multiplies two `BigDecimal`s directly, with no string round trip. `RecurringInvoiceLine` inherits it. `LineTaxCalculator` needed no change — it consumes `getTotal()`, which was already exact.

Both `setQty()` and the Doctrine type canonicalise via `strippedOfTrailingZeros()`, so `{{ line.qty }}` still renders `2.5` rather than `2.500000` — PDF and template output is byte-identical.

**API.** `BigIntegerNormalizer` gained a `MONETARY` context flag; `qty` opts out via `#[Context]`, so it is not scaled by 100 the way monetary `BigNumber`s are. OpenAPI and JSON Schema still declare `type: number` across all 36 generated line schemas, and the same JSON payloads are accepted.

**Forms.** `NumberType`'s stock view transformer round-trips through a float, which would undo the exactness at the edit boundary. The three line form types now use a `QuantityTransformer` that converts string ↔ `BigNumber` directly, preserving locale decimal separators and without padding trailing zeros into the input.

**Other consumers.** `LineItemBuilder` and `EntityNormalizer` (MCP), PayPal `CapturePaymentAction`, `PreviewInvoiceFactory`.

## Chosen precision and scale

**Scale 6.** Covers fractional hours to four places (`0.0833` = 5 minutes — the case that motivated the issue), metered usage priced per unit, and metric weights and volumes (a milligram is `0.000001` kg). It is also comfortably above what e-invoicing formats need of a quantity: Peppol BIS Billing 3.0 and Factur-X/ZUGFeRD both cap `InvoicedQuantity` at four decimals, so a SolidInvoice line is always representable in those formats without rounding. Relevant to #2659, which this unblocks.

**Precision 20.** Leaves 14 digits for the integral part — a hundred trillion units — which no realistic line item approaches, while staying well inside the limits of every supported platform (MySQL caps `DECIMAL` at 65 digits). 20 is also the number of digits in a 64-bit integer, matching the `BIGINT` columns the monetary amounts use, so both halves of `price × qty` have symmetric headroom.

**SQLite caveat.** SQLite has no exact decimal storage class: a `NUMERIC(20, 6)` column falls back to `REAL` for fractional values, so quantities are only exact there up to a double's ~15 significant digits — far beyond anything enterable, but not the full 20 the column advertises. MySQL, MariaDB and PostgreSQL store the full precision. Documented on the type.

## Tests

- `LineQuantityRegressionTest` — a corpus of ~240 `(price, float qty)` pairs standing in for the lines of already-issued invoices: quantities seen in practice, values with no exact double representation, the limits of the scale, plus a deterministic seeded sweep so the corpus is not only the cases someone thought of. Asserts both the stored minor-unit total and the unrounded total are unchanged, reporting *every* line that moved rather than failing on the first. Also checks `price × qty` against `BigRational` as an exact reference.
- `LineQuantityPersistenceTest` — quantities at the scale limit round-trip exactly through save and reload for both invoice and quote lines; a sub-scale quantity is rounded once on the way in rather than drifting on every read.
- `QuantityTypeTest`, `QuantityTransformerTest`, `LineQuantityDecimalMigrationTest` (migration `up()`/`down()`), `LineQuantityColumnMatchesMappingTest` (the installed column matches the mapping, so deployments do not carry a permanent schema diff).
- Two new API tests covering a fractional `qty` and a six-decimal-place edit over JSON.

`bin/phpunit` 2413 passing, `bin/ecs` clean, `bin/phpstan` clean apart from two pre-existing errors in `SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php` that this branch does not touch.

## Two things worth a look in review

**A latent GraphQL bug, fixed here.** Typing `qty` as `BigNumber` would have changed its GraphQL type from `Float!` to `Int!`, because `BigNumber` is not an API Platform resource and the converter falls back to `Int`. That fallback was *already* wrong for `price` and `total`: `BigIntegerNormalizer` returns a float (a de-scaled money amount), so GraphQL was advertising `Int` for values like `10.5`. `BigNumberTypeConverter` decorates `api_platform.graphql.type_converter` to map `BigNumber` → `Float`; `qty`, `price` and `total` are now all `Float!`. Verified against the exported schema.

**`composer.json` gained `autoload-dev.classmap: ["migrations/"]`** so the migration test can instantiate `Version30100_2`. Migrations were not autoloaded before.