### PR TITLE
fix: atomic credit deduction to prevent lost-update race condition

### DIFF
--- a/src/ClientBundle/Exception/InsufficientCreditException.php
+++ b/src/ClientBundle/Exception/InsufficientCreditException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Exception;
+
+use RuntimeException;
+
+final class InsufficientCreditException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Insufficient credit to complete this transaction.');
+    }
+}

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -13,15 +13,16 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ClientBundle\Repository;
 
-use Brick\Math\BigDecimal;
-use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
-use function assert;
+use Symfony\Bridge\Doctrine\Types\UlidType;
 
 /**
  * @extends EntityRepository<Credit>
@@ -38,31 +39,49 @@ class CreditRepository extends EntityRepository
      */
     public function addCredit(Client $client, BigNumber | float | int | string $amount): Credit
     {
+        $amountInt = (int) BigNumber::of($amount)->toScale(0, RoundingMode::HalfEven)->toInt();
+
+        $this->getEntityManager()
+            ->createQueryBuilder()
+            ->update(Credit::class, 'c')
+            ->set('c.value', 'c.value + :amount')
+            ->where('c.client = :client')
+            ->setParameter('amount', $amountInt, Types::INTEGER)
+            ->setParameter('client', $client->getId(), UlidType::NAME)
+            ->getQuery()
+            ->execute();
+
         $credit = $client->getCredit();
-
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
-
-        $credit->setValue($value->plus($amount));
-
-        $this->save($credit);
+        $this->getEntityManager()->refresh($credit);
 
         return $credit;
     }
 
     /**
      * @throws MathException
+     * @throws InsufficientCreditException
      */
     public function deductCredit(Client $client, BigNumber | float | int | string $amount): Credit
     {
+        $amountInt = (int) BigNumber::of($amount)->toScale(0, RoundingMode::HalfEven)->toInt();
+
+        $updated = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->update(Credit::class, 'c')
+            ->set('c.value', 'c.value - :amount')
+            ->where('c.client = :client')
+            ->andWhere('c.value >= :amount')
+            ->setParameter('amount', $amountInt, Types::INTEGER)
+            ->setParameter('client', $client->getId(), UlidType::NAME)
+            ->getQuery()
+            ->execute();
+
+        if ($updated === 0) {
+            throw new InsufficientCreditException();
+        }
+
         $credit = $client->getCredit();
-
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
-
-        $credit->setValue($value->minus($amount));
-
-        $this->save($credit);
+        $this->getEntityManager()->refresh($credit);
 
         return $credit;
     }

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -26,6 +26,7 @@ use Symfony\Bridge\Doctrine\Types\UlidType;
 
 /**
  * @extends EntityRepository<Credit>
+ * @see \SolidInvoice\ClientBundle\Tests\Repository\CreditRepositoryTest
  */
 class CreditRepository extends EntityRepository
 {

--- a/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
+++ b/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
@@ -34,7 +34,7 @@ final class CreditRepositoryTest extends KernelTestCase
     {
         parent::setUp();
         $creditRepository = $this->em->getRepository(Credit::class);
-        assert($creditRepository instanceof CreditRepository);
+        self::assertInstanceOf(CreditRepository::class, $creditRepository);
         $this->creditRepository = $creditRepository;
     }
 
@@ -46,6 +46,7 @@ final class CreditRepositoryTest extends KernelTestCase
         $client = ClientFactory::createOne(['company' => $this->company]);
         $credit = $client->getCredit();
         $credit->setValue(50000);
+
         $this->em->flush();
 
         $returned = $this->creditRepository->addCredit($client, 20000);
@@ -64,6 +65,7 @@ final class CreditRepositoryTest extends KernelTestCase
         $client = ClientFactory::createOne(['company' => $this->company]);
         $credit = $client->getCredit();
         $credit->setValue(50000);
+
         $this->em->flush();
 
         $returned = $this->creditRepository->deductCredit($client, 20000);
@@ -82,6 +84,7 @@ final class CreditRepositoryTest extends KernelTestCase
         $client = ClientFactory::createOne(['company' => $this->company]);
         $credit = $client->getCredit();
         $credit->setValue(50000);
+
         $this->em->flush();
 
         $returned = $this->creditRepository->deductCredit($client, 50000);
@@ -97,6 +100,7 @@ final class CreditRepositoryTest extends KernelTestCase
         $client = ClientFactory::createOne(['company' => $this->company]);
         $credit = $client->getCredit();
         $credit->setValue(50000);
+
         $this->em->flush();
 
         $this->expectException(InsufficientCreditException::class);
@@ -124,6 +128,7 @@ final class CreditRepositoryTest extends KernelTestCase
         $client = ClientFactory::createOne(['company' => $this->company]);
         $credit = $client->getCredit();
         $credit->setValue(50000);
+
         $this->em->flush();
 
         $this->creditRepository->deductCredit($client, 50000);

--- a/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
+++ b/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Repository;
+
+use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
+use SolidInvoice\ClientBundle\Repository\CreditRepository;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(CreditRepository::class)]
+final class CreditRepositoryTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+
+    private CreditRepository $creditRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $creditRepository = $this->em->getRepository(Credit::class);
+        assert($creditRepository instanceof CreditRepository);
+        $this->creditRepository = $creditRepository;
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testAddCreditIncreasesBalance(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $credit = $client->getCredit();
+        $credit->setValue(50000);
+        $this->em->flush();
+
+        $returned = $this->creditRepository->addCredit($client, 20000);
+
+        self::assertTrue(BigInteger::of(70000)->isEqualTo($returned->getValue()));
+
+        $this->em->refresh($credit);
+        self::assertTrue(BigInteger::of(70000)->isEqualTo($credit->getValue()));
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testDeductCreditDecreasesBalance(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $credit = $client->getCredit();
+        $credit->setValue(50000);
+        $this->em->flush();
+
+        $returned = $this->creditRepository->deductCredit($client, 20000);
+
+        self::assertTrue(BigInteger::of(30000)->isEqualTo($returned->getValue()));
+
+        $this->em->refresh($credit);
+        self::assertTrue(BigInteger::of(30000)->isEqualTo($credit->getValue()));
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testDeductCreditExactAmountSucceeds(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $credit = $client->getCredit();
+        $credit->setValue(50000);
+        $this->em->flush();
+
+        $returned = $this->creditRepository->deductCredit($client, 50000);
+
+        self::assertTrue(BigInteger::of(0)->isEqualTo($returned->getValue()));
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testDeductCreditThrowsWhenInsufficientBalance(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $credit = $client->getCredit();
+        $credit->setValue(50000);
+        $this->em->flush();
+
+        $this->expectException(InsufficientCreditException::class);
+
+        $this->creditRepository->deductCredit($client, 50001);
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testDeductCreditThrowsWhenBalanceIsZero(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+
+        $this->expectException(InsufficientCreditException::class);
+
+        $this->creditRepository->deductCredit($client, 1);
+    }
+
+    /**
+     * @throws MathException
+     */
+    public function testConcurrentDeductionsDoNotAllowOverdraft(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $credit = $client->getCredit();
+        $credit->setValue(50000);
+        $this->em->flush();
+
+        $this->creditRepository->deductCredit($client, 50000);
+
+        $this->expectException(InsufficientCreditException::class);
+
+        $this->creditRepository->deductCredit($client, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2717 — client credit deduction is not atomic.

- Replaces the read-modify-write pattern in `CreditRepository` with atomic DQL `UPDATE … SET value = value ± :amount WHERE … AND value >= :amount` statements
- Introduces `InsufficientCreditException` thrown when the sufficiency guard rejects the update (0 rows affected)
- Adds `CreditRepositoryTest` with six integration tests: add credit, deduct credit, exact-amount deduction, insufficient balance, zero-balance, and sequential-deduction (overdraft prevention)

## Root cause

The old implementation read the balance, checked it in PHP, then wrote back—leaving a TOCTOU window where two concurrent requests could both read a sufficient balance and both deduct, driving the balance negative (classic lost update).

## Fix

The atomic `UPDATE` uses the database engine as the arbiter:

```sql
UPDATE client_credit
SET    value_amount = value_amount - :amount
WHERE  client_id = :client
  AND  value_amount >= :amount
```

If 0 rows are affected the balance was insufficient (or already depleted by a concurrent request), and `InsufficientCreditException` is raised.  The entity manager identity map is refreshed after each successful update so callers see the new balance immediately.

## Implementation note

Doctrine ORM SQL filters (including `CompanyFilter`) are applied to DQL UPDATE queries. The `client_id` parameter must be bound with `UlidType::NAME` rather than passing the entity object directly, because DQL UPDATE does not auto-resolve entity parameters to their identifiers the same way SELECT queries do.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Aq64nVJ2EMaW2QRVTtSQ)_