### PR TITLE
test(invoice): cover InvoiceManager::create() invalid transition case

### DIFF
--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -30,9 +30,11 @@ use SolidInvoice\CoreBundle\Generator\BillingIdGenerator\IdGeneratorInterface;
 use SolidInvoice\CoreBundle\Repository\CustomFieldRepository;
 use SolidInvoice\CoreBundle\Repository\CustomFieldValueRepository;
 use SolidInvoice\CoreBundle\Service\CustomField\CustomFieldValueCopier;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\Line as InvoiceLine;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoice;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
+use SolidInvoice\InvoiceBundle\Exception\InvalidTransitionException;
 use SolidInvoice\InvoiceBundle\Listener\WorkFlowSubscriber;
 use SolidInvoice\InvoiceBundle\Manager\InvoiceManager;
 use SolidInvoice\NotificationBundle\Notification\NotificationManager;
@@ -61,6 +63,14 @@ final class InvoiceManagerTest extends KernelTestCase
 
     protected function setUp(): void
     {
+        $this->manager = $this->buildManager([new Transition('new', 'new', 'draft')]);
+    }
+
+    /**
+     * @param list<Transition> $transitions
+     */
+    private function buildManager(array $transitions): InvoiceManager
+    {
         $entityManager = M::mock(EntityManagerInterface::class);
         $doctrine = M::mock(ManagerRegistry::class, ['getManager' => $entityManager]);
         $notification = M::mock(NotificationManager::class);
@@ -68,16 +78,13 @@ final class InvoiceManagerTest extends KernelTestCase
         $notification->shouldReceive('sendNotification')
             ->andReturn(null);
 
-        $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new WorkFlowSubscriber($doctrine, M::mock(NotificationManager::class)));
+        $workflowDispatcher = new EventDispatcher();
+        $workflowDispatcher->addSubscriber(new WorkFlowSubscriber($doctrine, M::mock(NotificationManager::class)));
 
         $stateMachine = new StateMachine(
-            new Definition(
-                ['new', 'draft'],
-                [new Transition('new', 'new', 'draft')]
-            ),
+            new Definition(['new', 'draft'], $transitions),
             new MethodMarkingStore(true, 'status'),
-            $dispatcher,
+            $workflowDispatcher,
             'invoice'
         );
 
@@ -89,7 +96,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $clock->method('now')
             ->willReturn(CarbonImmutable::parse('2024-01-15 10:30:00'));
 
-        $this->manager = new InvoiceManager(
+        $manager = new InvoiceManager(
             $doctrine,
             new EventDispatcher(),
             $stateMachine,
@@ -109,6 +116,8 @@ final class InvoiceManagerTest extends KernelTestCase
         $entityManager
             ->shouldReceive('persist', 'flush')
             ->zeroOrMoreTimes();
+
+        return $manager;
     }
 
     public function testCreateFromQuote(): void
@@ -350,5 +359,24 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
+    }
+
+    public function testCreateThrowsInvalidTransitionExceptionWhenTransitionNotAllowed(): void
+    {
+        // No transitions defined on the workflow, so the "new" transition can never be applied.
+        $manager = $this->buildManager([]);
+
+        $client = new Client();
+        $client->setName('Test Client');
+
+        $invoice = new Invoice();
+        $invoice->setBaseTotal(100);
+        $invoice->setTotal(100);
+        $invoice->setClient($client);
+        $invoice->setCompany(new Company());
+
+        $this->expectException(InvalidTransitionException::class);
+
+        $manager->create($invoice);
     }
 }

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -79,7 +79,7 @@ final class InvoiceManagerTest extends KernelTestCase
             ->andReturn(null);
 
         $workflowDispatcher = new EventDispatcher();
-        $workflowDispatcher->addSubscriber(new WorkFlowSubscriber($doctrine, M::mock(NotificationManager::class)));
+        $workflowDispatcher->addSubscriber(new WorkFlowSubscriber($doctrine, $notification));
 
         $stateMachine = new StateMachine(
             new Definition(['new', 'draft'], $transitions),


### PR DESCRIPTION
## Summary
- `InvoiceManager::create()` was never exercised by `InvoiceManagerTest` - only `createFromQuote()`/`createFromRecurring()` were tested - so the `InvalidTransitionException` guard in `applyTransition()` had zero coverage.
- Refactored `setUp()` mock wiring into a `buildManager(array $transitions)` helper (behavior-preserving) so tests can build an `InvoiceManager` against different workflow definitions.
- Added `testCreateThrowsInvalidTransitionExceptionWhenTransitionNotAllowed`, using a workflow with no transitions to force `can()` to return `false` and assert `create()` throws.

## Test plan
- [x] `bin/phpunit --filter InvoiceManagerTest` - 5/5 pass
- [x] `bin/phpunit src/InvoiceBundle/Tests` - 312/312 pass
- [x] `bin/phpstan analyse` on changed file - clean
- [x] `bin/ecs check` on changed file - clean