### PR TITLE
Fix race condition in credit deduction with atomic SQL UPDATE

### DIFF
--- a/src/ClientBundle/Exception/InsufficientCreditException.php
+++ b/src/ClientBundle/Exception/InsufficientCreditException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Exception;
+
+use RuntimeException;
+
+final class InsufficientCreditException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Insufficient credit to complete this transaction.');
+    }
+}

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -24,6 +24,7 @@ use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 
 /**
  * @extends EntityRepository<Credit>
+ * @see \SolidInvoice\ClientBundle\Tests\Repository\CreditRepositoryTest
  */
 class CreditRepository extends EntityRepository
 {

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ClientBundle\Repository;
 
-use Brick\Math\BigDecimal;
-use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
-use function assert;
 
 /**
  * @extends EntityRepository<Credit>
@@ -38,14 +37,51 @@ class CreditRepository extends EntityRepository
      */
     public function addCredit(Client $client, BigNumber | float | int | string $amount): Credit
     {
+        $intAmount = $this->toIntAmount($amount);
+
+        $this->getEntityManager()
+            ->createQueryBuilder()
+            ->update(Credit::class, 'c')
+            ->set('c.value', 'c.value + :amount')
+            ->where('c.client = :client')
+            ->setParameter('amount', $intAmount)
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->execute();
+
         $credit = $client->getCredit();
+        $this->getEntityManager()->refresh($credit);
 
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
+        return $credit;
+    }
 
-        $credit->setValue($value->plus($amount));
+    /**
+     * @throws MathException
+     * @throws InsufficientCreditException
+     */
+    public function deductCredit(Client $client, BigNumber | float | int | string $amount): Credit
+    {
+        $intAmount = $this->toIntAmount($amount);
 
-        $this->save($credit);
+        // Single atomic UPDATE: checks balance and deducts in one statement.
+        // If the WHERE clause fails (insufficient credit), zero rows are affected.
+        $affected = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->update(Credit::class, 'c')
+            ->set('c.value', 'c.value - :amount')
+            ->where('c.client = :client')
+            ->andWhere('c.value >= :amount')
+            ->setParameter('amount', $intAmount)
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->execute();
+
+        if ($affected === 0) {
+            throw new InsufficientCreditException();
+        }
+
+        $credit = $client->getCredit();
+        $this->getEntityManager()->refresh($credit);
 
         return $credit;
     }
@@ -53,17 +89,12 @@ class CreditRepository extends EntityRepository
     /**
      * @throws MathException
      */
-    public function deductCredit(Client $client, BigNumber | float | int | string $amount): Credit
+    private function toIntAmount(BigNumber | float | int | string $amount): int
     {
-        $credit = $client->getCredit();
+        if (is_float($amount)) {
+            $amount = (string) $amount;
+        }
 
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
-
-        $credit->setValue($value->minus($amount));
-
-        $this->save($credit);
-
-        return $credit;
+        return BigNumber::of($amount)->toScale(0, RoundingMode::HalfEven)->toInt();
     }
 }

--- a/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
+++ b/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Repository;
+
+use Brick\Math\BigInteger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
+use SolidInvoice\ClientBundle\Repository\CreditRepository;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Ulid;
+
+#[CoversClass(CreditRepository::class)]
+final class CreditRepositoryTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+
+    private CreditRepository $creditRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $repository = $this->em->getRepository(Credit::class);
+        self::assertInstanceOf(CreditRepository::class, $repository);
+        $this->creditRepository = $repository;
+    }
+
+    public function testAddCreditIncreasesBalance(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $client->getCredit()->setValue(BigInteger::of(500));
+        $this->em->flush();
+
+        $this->creditRepository->addCredit($client, 300);
+
+        $this->em->clear();
+        $clientId = $client->getId();
+        self::assertInstanceOf(Ulid::class, $clientId);
+        $refreshed = $this->em->find(Client::class, $clientId);
+        self::assertNotNull($refreshed);
+        self::assertTrue(
+            BigInteger::of(800)->isEqualTo($refreshed->getCredit()->getValue()),
+            'addCredit should atomically increase the balance'
+        );
+    }
+
+    public function testDeductCreditDecreasesBalance(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $client->getCredit()->setValue(BigInteger::of(1000));
+        $this->em->flush();
+
+        $this->creditRepository->deductCredit($client, 400);
+
+        $this->em->clear();
+        $clientId = $client->getId();
+        self::assertInstanceOf(Ulid::class, $clientId);
+        $refreshed = $this->em->find(Client::class, $clientId);
+        self::assertNotNull($refreshed);
+        self::assertTrue(
+            BigInteger::of(600)->isEqualTo($refreshed->getCredit()->getValue()),
+            'deductCredit should atomically decrease the balance'
+        );
+    }
+
+    public function testDeductCreditThrowsWhenInsufficientFunds(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $client->getCredit()->setValue(BigInteger::of(200));
+        $this->em->flush();
+
+        $this->expectException(InsufficientCreditException::class);
+
+        $this->creditRepository->deductCredit($client, 500);
+    }
+
+    public function testDeductCreditExactBalanceSucceeds(): void
+    {
+        $client = ClientFactory::createOne(['company' => $this->company]);
+        $client->getCredit()->setValue(BigInteger::of(500));
+        $this->em->flush();
+
+        $credit = $this->creditRepository->deductCredit($client, 500);
+
+        self::assertTrue(
+            BigInteger::of(0)->isEqualTo($credit->getValue()),
+            'Deducting the exact available balance should succeed'
+        );
+    }
+}

--- a/src/PaymentBundle/Listener/PaymentCompleteListener.php
+++ b/src/PaymentBundle/Listener/PaymentCompleteListener.php
@@ -17,6 +17,7 @@ use Brick\Math\Exception\MathException;
 use Doctrine\Persistence\ManagerRegistry;
 use Generator;
 use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
 use SolidInvoice\CoreBundle\Response\FlashResponse;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Model\Graph;
@@ -58,10 +59,35 @@ class PaymentCompleteListener implements EventSubscriberInterface
 
         if ('credit' === $payment->getMethod()?->getGatewayName()) {
             $creditRepository = $this->registry->getRepository(Credit::class);
-            $creditRepository->deductCredit(
-                $payment->getClient(),
-                $payment->getTotalAmount(),
-            );
+
+            try {
+                $creditRepository->deductCredit(
+                    $payment->getClient(),
+                    $payment->getTotalAmount(),
+                );
+            } catch (InsufficientCreditException) {
+                // The atomic deduction guard fired — another concurrent payment
+                // already consumed the credit between Prepare's check and now.
+                // Mark this payment as failed so the invoice stays unpaid.
+                $payment->setStatus(PaymentStatus::Failed);
+                $this->registry->getManager()->flush();
+
+                $invoice = $event->getPayment()->getInvoice();
+                $redirectUrl = $invoice instanceof Invoice
+                    ? $this->router->generate('_view_invoice_external', ['uuid' => $invoice->getUuid()])
+                    : $this->router->generate('_payments_index');
+
+                $event->setResponse(
+                    new class($redirectUrl) extends RedirectResponse implements FlashResponse {
+                        public function getFlash(): Generator
+                        {
+                            yield FlashResponse::FLASH_DANGER => 'payment.create.exception.not_enough_credit';
+                        }
+                    }
+                );
+
+                return;
+            }
         }
 
         if (($invoice = $event->getPayment()->getInvoice()) instanceof Invoice) {


### PR DESCRIPTION
## Root cause

`CreditRepository::deductCredit()` and `addCredit()` used a non-atomic read-modify-write pattern:

1. Read current balance from DB into a PHP `BigInteger`
2. Compute the new value in PHP
3. Write the new value back with an unconditional `UPDATE`

Two concurrent credit-payment requests could both read the same balance, both pass the sufficiency check in `Prepare`, and both write back the same computed result — silently losing one deduction (the **lost-update** race condition / TOCTOU gap).

## Fix

Replace the non-atomic pattern with a single DQL `UPDATE` statement that performs the arithmetic and enforces the guard condition at the database level in one round-trip:

```sql
-- deductCredit
UPDATE credit c SET c.value = c.value - :amount
WHERE c.client = :client AND c.value >= :amount

-- addCredit  
UPDATE credit c SET c.value = c.value + :amount
WHERE c.client = :client
```

If the `WHERE` clause matches 0 rows (insufficient credit at commit time), a new `InsufficientCreditException` is thrown.

`PaymentCompleteListener` now catches `InsufficientCreditException`, marks the payment as `Failed`, and returns a user-facing flash error, preventing the invoice from being incorrectly marked as paid.

## Changes

- **`src/ClientBundle/Exception/InsufficientCreditException.php`** — new `RuntimeException` thrown by `deductCredit` when the atomic guard fires
- **`src/ClientBundle/Repository/CreditRepository.php`** — atomic DQL `UPDATE` for both `addCredit` and `deductCredit`; calls `refresh()` after update to clear stale ORM identity-map data
- **`src/PaymentBundle/Listener/PaymentCompleteListener.php`** — try/catch around `deductCredit`, marks payment `Failed` and sets flash error on `InsufficientCreditException`
- **`src/ClientBundle/Tests/Repository/CreditRepositoryTest.php`** — 4 functional tests: add increases balance, deduct decreases balance, deduct with insufficient funds throws, deduct of exact balance succeeds

## Test approach

Functional tests boot the kernel and use a real SQLite/MySQL database (via `DoctrineTestTrait`). Each test creates a client with a known credit balance using `ClientFactory`, calls the repository method, clears the ORM identity map, and re-fetches from the database to verify the persisted value.

Closes #2717

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH5r21DQWp2gk4V48WiPU3)_