### PR TITLE
fix: make credit add/deduct atomic to prevent race conditions (fixes #2717)

### DIFF
--- a/src/ClientBundle/Exception/InsufficientCreditException.php
+++ b/src/ClientBundle/Exception/InsufficientCreditException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Exception;
+
+use RuntimeException;
+use SolidInvoice\ClientBundle\Entity\Client;
+
+final class InsufficientCreditException extends RuntimeException
+{
+    public function __construct(Client $client)
+    {
+        parent::__construct(
+            sprintf('Client "%s" does not have sufficient credit to complete this operation.', (string) $client->getName())
+        );
+    }
+}

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 
 namespace SolidInvoice\ClientBundle\Repository;
 
-use Brick\Math\BigDecimal;
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException;
 use Doctrine\Persistence\ManagerRegistry;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
-use function assert;
 
 /**
  * @extends EntityRepository<Credit>
@@ -34,35 +33,62 @@ class CreditRepository extends EntityRepository
     }
 
     /**
+     * Atomically add credit for a client.
+     *
+     * Uses a single UPDATE statement so concurrent calls cannot interleave.
+     *
      * @throws MathException
      */
     public function addCredit(Client $client, BigNumber | float | int | string $amount): Credit
     {
+        $amount = BigInteger::of(BigNumber::of($amount));
+
+        $this->createQueryBuilder('c')
+            ->update()
+            ->set('c.value', 'c.value + :amount')
+            ->where('c.client = :client')
+            ->setParameter('amount', $amount, 'BigInteger')
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->execute();
+
         $credit = $client->getCredit();
-
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
-
-        $credit->setValue($value->plus($amount));
-
-        $this->save($credit);
+        $this->getEntityManager()->refresh($credit);
 
         return $credit;
     }
 
     /**
+     * Atomically deduct credit for a client, guarding against over-deduction.
+     *
+     * The WHERE condition `value_amount >= :amount` folds the sufficiency check
+     * into the same write, making concurrent deductions safe: the second deduction
+     * that would push the balance negative simply matches zero rows and throws
+     * InsufficientCreditException rather than silently corrupting the balance.
+     *
      * @throws MathException
+     * @throws InsufficientCreditException when the client does not have enough credit
      */
     public function deductCredit(Client $client, BigNumber | float | int | string $amount): Credit
     {
+        $amount = BigInteger::of(BigNumber::of($amount));
+
+        $rows = $this->createQueryBuilder('c')
+            ->update()
+            ->set('c.value', 'c.value - :amount')
+            ->where('c.client = :client')
+            ->andWhere('c.value >= :amount')
+            ->setParameter('amount', $amount, 'BigInteger')
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->execute();
+
+        if (0 === $rows) {
+            throw new InsufficientCreditException($client);
+        }
+
         $credit = $client->getCredit();
-
-        $value = $credit->getValue();
-        assert($value instanceof BigInteger || $value instanceof BigDecimal);
-
-        $credit->setValue($value->minus($amount));
-
-        $this->save($credit);
+        $this->getEntityManager()->refresh($credit);
 
         return $credit;
     }

--- a/src/ClientBundle/Repository/CreditRepository.php
+++ b/src/ClientBundle/Repository/CreditRepository.php
@@ -24,6 +24,7 @@ use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 
 /**
  * @extends EntityRepository<Credit>
+ * @see \SolidInvoice\ClientBundle\Tests\Repository\CreditRepositoryTest
  */
 class CreditRepository extends EntityRepository
 {

--- a/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
+++ b/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\ClientBundle\Tests\Repository;
+
+use Brick\Math\BigInteger;
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\ClientBundle\Entity\Credit;
+use SolidInvoice\ClientBundle\Exception\InsufficientCreditException;
+use SolidInvoice\ClientBundle\Repository\CreditRepository;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[Group('functional')]
+final class CreditRepositoryTest extends KernelTestCase
+{
+    use DoctrineTestTrait;
+
+    private CreditRepository $creditRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->creditRepository = $this->em->getRepository(Credit::class);
+    }
+
+    public function testAddCreditIsAtomic(): void
+    {
+        $client = ClientFactory::createOne(['currencyCode' => 'USD']);
+
+        $credit = $this->creditRepository->addCredit($client, 50000);
+
+        self::assertSame('50000', (string) $credit->getValue());
+
+        // Reload from DB to confirm the value was actually persisted
+        $this->em->clear();
+        $reloaded = $this->em->find(Client::class, $client->getId());
+        self::assertInstanceOf(Client::class, $reloaded);
+        self::assertSame('50000', (string) $reloaded->getCredit()->getValue());
+    }
+
+    public function testDeductCreditIsAtomicAndUpdatesBalance(): void
+    {
+        $client = ClientFactory::createOne(['currencyCode' => 'USD']);
+
+        // Start at 50000 (e.g. $500.00)
+        $credit = $client->getCredit();
+        $credit->setValue(BigInteger::of(50000));
+        $this->em->persist($credit);
+        $this->em->flush();
+
+        $result = $this->creditRepository->deductCredit($client, 20000);
+
+        self::assertSame('30000', (string) $result->getValue());
+
+        // Confirm the DB was updated
+        $this->em->clear();
+        $reloaded = $this->em->find(Client::class, $client->getId());
+        self::assertInstanceOf(Client::class, $reloaded);
+        self::assertSame('30000', (string) $reloaded->getCredit()->getValue());
+    }
+
+    public function testDeductCreditExactBalanceSucceeds(): void
+    {
+        $client = ClientFactory::createOne(['currencyCode' => 'USD']);
+
+        $credit = $client->getCredit();
+        $credit->setValue(BigInteger::of(50000));
+        $this->em->persist($credit);
+        $this->em->flush();
+
+        $result = $this->creditRepository->deductCredit($client, 50000);
+
+        self::assertSame('0', (string) $result->getValue());
+    }
+
+    public function testDeductCreditThrowsWhenBalanceIsZero(): void
+    {
+        $client = ClientFactory::createOne(['currencyCode' => 'USD']);
+
+        $this->expectException(InsufficientCreditException::class);
+
+        // Balance starts at 0; deduction of any positive amount must be rejected
+        $this->creditRepository->deductCredit($client, 1);
+    }
+
+    public function testDeductCreditThrowsWhenAmountExceedsBalance(): void
+    {
+        $client = ClientFactory::createOne(['currencyCode' => 'USD']);
+
+        $credit = $client->getCredit();
+        $credit->setValue(BigInteger::of(10000));
+        $this->em->persist($credit);
+        $this->em->flush();
+
+        $this->expectException(InsufficientCreditException::class);
+
+        $this->creditRepository->deductCredit($client, 50000);
+    }
+}

--- a/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
+++ b/src/ClientBundle/Tests/Repository/CreditRepositoryTest.php
@@ -58,6 +58,7 @@ final class CreditRepositoryTest extends KernelTestCase
         // Start at 50000 (e.g. $500.00)
         $credit = $client->getCredit();
         $credit->setValue(BigInteger::of(50000));
+
         $this->em->persist($credit);
         $this->em->flush();
 
@@ -78,6 +79,7 @@ final class CreditRepositoryTest extends KernelTestCase
 
         $credit = $client->getCredit();
         $credit->setValue(BigInteger::of(50000));
+
         $this->em->persist($credit);
         $this->em->flush();
 
@@ -102,6 +104,7 @@ final class CreditRepositoryTest extends KernelTestCase
 
         $credit = $client->getCredit();
         $credit->setValue(BigInteger::of(10000));
+
         $this->em->persist($credit);
         $this->em->flush();
 


### PR DESCRIPTION
## Summary

The `addCredit()` and `deductCredit()` methods in `CreditRepository` used a non-atomic PHP read-modify-write pattern: read the entity, compute a new value in PHP, then persist it. Two concurrent requests could both read the same stale balance and each write back a value computed from it, silently losing one of the operations (a classic lost-update / TOCTOU race condition).

## Root cause

`CreditRepository::addCredit()` and `deductCredit()` read the `Credit` entity, performed arithmetic in PHP, and called `save()`. Under concurrent load, a second request reading before the first request's `save()` committed would compute its delta from the same stale balance, and the second write would silently overwrite the correct result of the first.

`deductCredit()` additionally had no guard preventing the balance from going negative.

## Changes

- `src/ClientBundle/Repository/CreditRepository.php` — Replace both methods with single atomic DQL `UPDATE` statements (`c.value + :amount` / `c.value - :amount`). `deductCredit()` adds a `WHERE c.value >= :amount` guard so the UPDATE is self-checking: zero affected rows means insufficient balance, and `InsufficientCreditException` is thrown. Both methods call `$em->refresh($credit)` after the statement to keep the Doctrine identity map consistent with the DB.
- `src/ClientBundle/Exception/InsufficientCreditException.php` — New exception thrown when a deduction is rejected because the balance is too low.
- `src/ClientBundle/Tests/Repository/CreditRepositoryTest.php` — Functional tests covering: atomic add persisted to DB, atomic deduct persisted to DB, exact-balance deduct succeeds (result is 0), deduct on zero balance throws, deduct exceeding balance throws.

## Testing

- [ ] New functional test `CreditRepositoryTest` covers all branches (add, deduct, insufficient credit)
- [ ] Existing callers (`PaymentCompleteListener`) remain compatible — `deductCredit()` signature is unchanged; callers must now handle `InsufficientCreditException` (previously any over-deduction was silent data corruption)

> **Note:** The pre-check in `Prepare.php` and the deduction in `PaymentCompleteListener` are not wrapped in a shared transaction, so a narrow TOCTOU window between them remains. That is a separate, larger concern and is out of scope for this fix.

Closes #2717

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDm7DzJNR3Z73d1P3L4Bp3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDm7DzJNR3Z73d1P3L4Bp3)_