### PR TITLE
Give invoice, recurring invoice and quote lines a name

### DIFF
--- a/assets/scss/components/_billing-form.scss
+++ b/assets/scss/components/_billing-form.scss
@@ -439,6 +439,7 @@
     // The description is secondary to the name, and most lines never get one. A closed
     // `<details>` keeps the common case to the single input it was before the name existed,
     // and costs a click — not a trip elsewhere — when a line does need detail.
+
     .line-description {
         margin-top: 0.25rem;
 

--- a/assets/scss/components/_billing-form.scss
+++ b/assets/scss/components/_billing-form.scss
@@ -436,6 +436,42 @@
         }
     }
 
+    // The description is secondary to the name, and most lines never get one. A closed
+    // `<details>` keeps the common case to the single input it was before the name existed,
+    // and costs a click — not a trip elsewhere — when a line does need detail.
+    .line-description {
+        margin-top: 0.25rem;
+
+        > summary {
+            color: var(--tblr-secondary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            list-style: none;
+            width: fit-content;
+
+            &::-webkit-details-marker {
+                display: none;
+            }
+
+            &::before {
+                content: '+';
+                margin-right: 0.25rem;
+            }
+
+            &:hover {
+                color: var(--tblr-primary);
+            }
+        }
+
+        &[open] > summary {
+            margin-bottom: 0.25rem;
+
+            &::before {
+                content: '−';
+            }
+        }
+    }
+
     .column-price,
     .column-qty,
     .column-tax {

--- a/migrations/Version30100_6.php
+++ b/migrations/Version30100_6.php
@@ -187,12 +187,23 @@ final class Version30100_6 extends AbstractMigration
 
     private function nameFor(string $description): string
     {
-        $firstLine = trim(explode("\n", str_replace("\r\n", "\n", $description), 2)[0]);
+        // Lone CR as well as CRLF: a description stored by an older client can use either,
+        // and one that arrives as a single `\r`-separated run would otherwise be read as one
+        // very long line and truncated in the middle of it.
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $description)) as $line) {
+            $line = trim($line);
 
-        if (mb_strlen($firstLine) <= self::NAME_MAX_LENGTH) {
-            return $firstLine;
+            if ($line === '') {
+                continue;
+            }
+
+            if (mb_strlen($line) <= self::NAME_MAX_LENGTH) {
+                return $line;
+            }
+
+            return rtrim(mb_substr($line, 0, self::NAME_MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
         }
 
-        return rtrim(mb_substr($firstLine, 0, self::NAME_MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
+        return '';
     }
 }

--- a/migrations/Version30100_6.php
+++ b/migrations/Version30100_6.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use function explode;
+use function mb_strlen;
+use function mb_substr;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function trim;
+
+final class Version30100_6 extends AbstractMigration
+{
+    private const array LINE_TABLES = ['invoice_lines', 'quote_lines'];
+
+    private const int NAME_MAX_LENGTH = 255;
+
+    private const string ELLIPSIS = '…';
+
+    private const int PAGE_SIZE = 500;
+
+    public function getDescription(): string
+    {
+        return 'Give invoice, recurring invoice and quote lines a name, backfilled from their description';
+    }
+
+    public function isTransactional(): bool
+    {
+        // MySQL and MariaDB commit implicitly on DDL. AbstractMySQLPlatform, because
+        // MariaDBPlatform is a sibling of MySQLPlatform rather than a subclass.
+        return ! $this->platform instanceof AbstractMySQLPlatform && ! $this->platform instanceof OraclePlatform;
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::LINE_TABLES as $tableName) {
+            $table = $schema->getTable($tableName);
+
+            if (! $table->hasColumn('name')) {
+                $table->addColumn('name', Types::STRING, [
+                    'length' => self::NAME_MAX_LENGTH,
+                    'notnull' => true,
+                    'default' => '',
+                ]);
+            }
+
+            // A line that is only a name no longer needs a description, and the backfill
+            // below is what turns most existing lines into exactly that.
+            $table->getColumn('description')->setNotnull(false);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function postUp(Schema $schema): void
+    {
+        foreach (self::LINE_TABLES as $table) {
+            $this->backfillNames($table);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function preDown(Schema $schema): void
+    {
+        // A description the backfill moved wholesale into the name has to come back before
+        // the column is `NOT NULL` again, or down() fails on the first line it moved.
+        foreach (self::LINE_TABLES as $table) {
+            $this->connection->executeStatement(
+                sprintf(
+                    'UPDATE %s SET description = %s WHERE description IS NULL',
+                    $table,
+                    $this->platform->quoteSingleIdentifier('name'),
+                )
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::LINE_TABLES as $tableName) {
+            $table = $schema->getTable($tableName);
+
+            if ($table->hasColumn('name')) {
+                $table->dropColumn('name');
+            }
+
+            $table->getColumn('description')->setNotnull(true);
+        }
+    }
+
+    /**
+     * Names every existing line after the first line of its description.
+     *
+     * The rule is spelled out here rather than called out of
+     * {@see \SolidInvoice\CoreBundle\Billing\LineName}, because a migration has to keep
+     * producing the result it produced the day it was written. If the runtime rule changes,
+     * the lines this pass already named must not change with it.
+     *
+     * Runs in PHP rather than as one UPDATE: finding the first line of a string is spelled
+     * three different ways across the four supported platforms. Rows are read a page at a
+     * time, and the page that needs no truncation — which is nearly all of them, since a
+     * short one-line description becomes the whole name — collapses into a single statement.
+     *
+     * @throws Exception
+     */
+    private function backfillNames(string $table): void
+    {
+        $nameColumn = $this->platform->quoteSingleIdentifier('name');
+        $lastId = null;
+
+        while (true) {
+            $rows = $this->connection->fetchAllAssociative(
+                sprintf(
+                    'SELECT id, description FROM %s WHERE %s = \'\'%s ORDER BY id ASC LIMIT %d',
+                    $table,
+                    $nameColumn,
+                    $lastId === null ? '' : ' AND id > ?',
+                    self::PAGE_SIZE,
+                ),
+                $lastId === null ? [] : [$lastId],
+            );
+
+            if ($rows === []) {
+                return;
+            }
+
+            /** @var list<string> $wholeDescriptions */
+            $wholeDescriptions = [];
+
+            foreach ($rows as $row) {
+                // Ids bind as strings on every platform: BINARY(16) bytes on MySQL and
+                // SQLite, RFC 4122 text in a UUID column on Postgres.
+                $lastId = (string) $row['id'];
+                $description = (string) ($row['description'] ?? '');
+                $name = $this->nameFor($description);
+
+                if ($name === '') {
+                    // Nothing to name the line after. `description` was NOT NULL and
+                    // validated as non-blank until now, so this is a row that predates
+                    // that or was written around it.
+                    continue;
+                }
+
+                if ($description === $name) {
+                    $wholeDescriptions[] = $lastId;
+
+                    continue;
+                }
+
+                $this->connection->executeStatement(
+                    sprintf('UPDATE %s SET %s = ? WHERE id = ?', $table, $nameColumn),
+                    [$name, $lastId],
+                );
+            }
+
+            if ($wholeDescriptions !== []) {
+                $this->connection->executeStatement(
+                    sprintf('UPDATE %s SET %s = description, description = NULL WHERE id IN (?)', $table, $nameColumn),
+                    [$wholeDescriptions],
+                    [ArrayParameterType::STRING],
+                );
+            }
+        }
+    }
+
+    private function nameFor(string $description): string
+    {
+        $firstLine = trim(explode("\n", str_replace("\r\n", "\n", $description), 2)[0]);
+
+        if (mb_strlen($firstLine) <= self::NAME_MAX_LENGTH) {
+            return $firstLine;
+        }
+
+        return rtrim(mb_substr($firstLine, 0, self::NAME_MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -565,12 +565,6 @@ parameters:
 			path: src/InvoiceBundle/Entity/Line.php
 
 		-
-			message: '#^Property SolidInvoice\\InvoiceBundle\\Entity\\Line\:\:\$description type mapping mismatch\: property can contain string\|null but database expects string\.$#'
-			identifier: doctrine.columnType
-			count: 1
-			path: src/InvoiceBundle/Entity/Line.php
-
-		-
 			message: '#^Property SolidInvoice\\InvoiceBundle\\Entity\\Line\:\:\$updated type mapping mismatch\: property can contain DateTimeImmutable\|null but database expects DateTimeImmutable\.$#'
 			identifier: doctrine.columnType
 			count: 1
@@ -617,12 +611,6 @@ parameters:
 			identifier: doctrine.columnType
 			count: 1
 			path: src/InvoiceBundle/Entity/RecurringInvoice.php
-
-		-
-			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, array\<int, int\|string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/InvoiceBundle/Manager/InvoiceManager.php
 
 		-
 			message: '#^Using nullsafe property access "\?\-\>value" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
@@ -914,12 +902,6 @@ parameters:
 
 		-
 			message: '#^Property SolidInvoice\\QuoteBundle\\Entity\\Line\:\:\$created type mapping mismatch\: property can contain DateTimeImmutable\|null but database expects DateTimeImmutable\.$#'
-			identifier: doctrine.columnType
-			count: 1
-			path: src/QuoteBundle/Entity/Line.php
-
-		-
-			message: '#^Property SolidInvoice\\QuoteBundle\\Entity\\Line\:\:\$description type mapping mismatch\: property can contain string\|null but database expects string\.$#'
 			identifier: doctrine.columnType
 			count: 1
 			path: src/QuoteBundle/Entity/Line.php

--- a/src/CoreBundle/Billing/LineName.php
+++ b/src/CoreBundle/Billing/LineName.php
@@ -38,20 +38,43 @@ final class LineName
     private const string ELLIPSIS = '…';
 
     /**
-     * The first line of the description, trimmed, and cut to fit the column.
+     * The first line of the description that has anything on it, trimmed, and cut to fit the
+     * column.
      *
      * The first line rather than the first sentence: a description someone wrote as a
      * heading with detail under it already says where the name ends, and a description
      * written as prose has no line break to find, so it falls back to the truncation.
+     *
+     * The first line *with something on it*, because a description that opens with a blank
+     * line is still a description — taking the empty string would leave the line with a name
+     * that fails its own `NotBlank`, on a path like onboarding that persists without
+     * validating.
      */
     public static function fromDescription(string $description): string
     {
-        $firstLine = trim(explode("\n", str_replace("\r\n", "\n", $description), 2)[0]);
+        // Lone CR as well as CRLF: a textarea or an older client can still send one, and a
+        // description that arrives as a single `\r`-separated run would otherwise be read as
+        // one very long line.
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $description)) as $line) {
+            $line = trim($line);
 
-        if (mb_strlen($firstLine) <= self::MAX_LENGTH) {
-            return $firstLine;
+            if ($line !== '') {
+                return self::truncate($line);
+            }
         }
 
-        return rtrim(mb_substr($firstLine, 0, self::MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
+        return '';
+    }
+
+    /**
+     * Cuts a name to fit the column, marking where it was cut.
+     */
+    public static function truncate(string $name): string
+    {
+        if (mb_strlen($name) <= self::MAX_LENGTH) {
+            return $name;
+        }
+
+        return rtrim(mb_substr($name, 0, self::MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
     }
 }

--- a/src/CoreBundle/Billing/LineName.php
+++ b/src/CoreBundle/Billing/LineName.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Billing;
+
+use function explode;
+use function mb_strlen;
+use function mb_substr;
+use function rtrim;
+use function str_replace;
+use function trim;
+
+/**
+ * How a line's name is derived when only a description was supplied.
+ *
+ * A caller that predates the name — an API client, an MCP tool, a quote being converted —
+ * still sends one field, and a line has to end up with a name either way.
+ *
+ * @see \SolidInvoice\CoreBundle\Tests\Billing\LineNameTest
+ */
+final class LineName
+{
+    /**
+     * Matches the `name` column on both line tables.
+     */
+    public const int MAX_LENGTH = 255;
+
+    private const string ELLIPSIS = '…';
+
+    /**
+     * The first line of the description, trimmed, and cut to fit the column.
+     *
+     * The first line rather than the first sentence: a description someone wrote as a
+     * heading with detail under it already says where the name ends, and a description
+     * written as prose has no line break to find, so it falls back to the truncation.
+     */
+    public static function fromDescription(string $description): string
+    {
+        $firstLine = trim(explode("\n", str_replace("\r\n", "\n", $description), 2)[0]);
+
+        if (mb_strlen($firstLine) <= self::MAX_LENGTH) {
+            return $firstLine;
+        }
+
+        return rtrim(mb_substr($firstLine, 0, self::MAX_LENGTH - mb_strlen(self::ELLIPSIS))) . self::ELLIPSIS;
+    }
+}

--- a/src/CoreBundle/Entity/LineInterface.php
+++ b/src/CoreBundle/Entity/LineInterface.php
@@ -32,6 +32,16 @@ interface LineInterface
 
     public function getId(): Ulid;
 
+    public function setName(string $name): self;
+
+    public function getName(): string;
+
+    /**
+     * Setting a description on a line that has no name yet derives one from it, so a caller
+     * that only knows about the description still produces a valid line.
+     *
+     * @see \SolidInvoice\CoreBundle\Billing\LineName
+     */
     public function setDescription(?string $description): self;
 
     public function getDescription(): ?string;

--- a/src/CoreBundle/Tests/Billing/LineNameTest.php
+++ b/src/CoreBundle/Tests/Billing/LineNameTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Billing;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Billing\LineName;
+use function mb_strlen;
+use function str_repeat;
+
+final class LineNameTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function descriptions(): iterable
+    {
+        yield 'short single line' => ['Website design', 'Website design'];
+        yield 'surrounding whitespace' => ["  Website design \n", 'Website design'];
+        yield 'multi line keeps the first line' => ["Website design\nIncluding two rounds of revisions.", 'Website design'];
+        yield 'windows line endings' => ["Website design\r\nWith revisions.", 'Website design'];
+        yield 'blank' => ['   ', ''];
+        yield 'empty' => ['', ''];
+    }
+
+    #[DataProvider('descriptions')]
+    public function testItNamesALineAfterTheFirstLineOfItsDescription(string $description, string $expected): void
+    {
+        self::assertSame($expected, LineName::fromDescription($description));
+    }
+
+    public function testItTruncatesALineTooLongForTheColumn(): void
+    {
+        $name = LineName::fromDescription(str_repeat('a', LineName::MAX_LENGTH + 50));
+
+        self::assertSame(LineName::MAX_LENGTH, mb_strlen($name));
+        self::assertStringEndsWith('…', $name);
+    }
+
+    public function testItLeavesALineExactlyTheColumnWidthAlone(): void
+    {
+        $description = str_repeat('a', LineName::MAX_LENGTH);
+
+        self::assertSame($description, LineName::fromDescription($description));
+    }
+
+    /**
+     * Counted in characters, not bytes, or a multi-byte description would truncate to more
+     * than the column holds.
+     */
+    public function testItCountsCharactersRatherThanBytes(): void
+    {
+        $name = LineName::fromDescription(str_repeat('é', LineName::MAX_LENGTH));
+
+        self::assertSame(str_repeat('é', LineName::MAX_LENGTH), $name);
+    }
+}

--- a/src/CoreBundle/Tests/Billing/LineNameTest.php
+++ b/src/CoreBundle/Tests/Billing/LineNameTest.php
@@ -30,6 +30,8 @@ final class LineNameTest extends TestCase
         yield 'surrounding whitespace' => ["  Website design \n", 'Website design'];
         yield 'multi line keeps the first line' => ["Website design\nIncluding two rounds of revisions.", 'Website design'];
         yield 'windows line endings' => ["Website design\r\nWith revisions.", 'Website design'];
+        yield 'lone carriage returns' => ["Website design\rWith revisions.", 'Website design'];
+        yield 'leading blank lines are skipped' => ["\n \nWebsite design\nWith revisions.", 'Website design'];
         yield 'blank' => ['   ', ''];
         yield 'empty' => ['', ''];
     }
@@ -38,6 +40,15 @@ final class LineNameTest extends TestCase
     public function testItNamesALineAfterTheFirstLineOfItsDescription(string $description, string $expected): void
     {
         self::assertSame($expected, LineName::fromDescription($description));
+    }
+
+    /**
+     * A description that opens with a blank line still has to name its line: `name` is
+     * `NotBlank`, and onboarding persists the invoice it builds without ever validating it.
+     */
+    public function testALeadingBlankLineDoesNotLeaveTheLineUnnamed(): void
+    {
+        self::assertSame('Website design', LineName::fromDescription("\nWebsite design"));
     }
 
     public function testItTruncatesALineTooLongForTheColumn(): void

--- a/src/CoreBundle/Tests/Migration/LineNameMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineNameMigrationTest.php
@@ -110,6 +110,18 @@ final class LineNameMigrationTest extends TestCase
             "Website design\n",
         ];
 
+        yield 'lone carriage returns separate lines too' => [
+            "Website design\rIncluding two rounds of revisions.",
+            'Website design',
+            "Website design\rIncluding two rounds of revisions.",
+        ];
+
+        yield 'a leading blank line does not leave the line unnamed' => [
+            "\n \nWebsite design\nIncluding two rounds of revisions.",
+            'Website design',
+            "\n \nWebsite design\nIncluding two rounds of revisions.",
+        ];
+
         yield 'blank description names nothing' => [
             '   ',
             '',

--- a/src/CoreBundle/Tests/Migration/LineNameMigrationTest.php
+++ b/src/CoreBundle/Tests/Migration/LineNameMigrationTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use DoctrineMigrations\Version30100_6;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use function mb_strlen;
+use function sprintf;
+use function str_repeat;
+
+final class LineNameMigrationTest extends TestCase
+{
+    private const array TABLES = ['invoice_lines', 'quote_lines'];
+
+    private const int NAME_MAX_LENGTH = 255;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function tables(): iterable
+    {
+        foreach (self::TABLES as $table) {
+            yield $table => [$table];
+        }
+    }
+
+    #[DataProvider('tables')]
+    public function testUpAddsTheNameColumnAndRelaxesTheDescription(string $table): void
+    {
+        $schema = $this->preMigrationSchema();
+
+        $this->migration()->up($schema);
+
+        $columns = $schema->getTable($table);
+
+        self::assertTrue($columns->getColumn('name')->getNotnull());
+        self::assertSame(self::NAME_MAX_LENGTH, $columns->getColumn('name')->getLength());
+        self::assertFalse($columns->getColumn('description')->getNotnull());
+    }
+
+    #[DataProvider('tables')]
+    public function testDownDropsTheNameColumnAndRequiresTheDescriptionAgain(string $table): void
+    {
+        $schema = $this->preMigrationSchema();
+        $migration = $this->migration();
+
+        $migration->up($schema);
+        $migration->down($schema);
+
+        self::assertFalse($schema->getTable($table)->hasColumn('name'));
+        self::assertTrue($schema->getTable($table)->getColumn('description')->getNotnull());
+    }
+
+    /**
+     * The corpus the acceptance criteria ask for: short, long, multi-line and blank. Nothing
+     * a user wrote may be lost, so every case asserts what happened to `description` too.
+     *
+     * @return iterable<string, array{string, string, ?string}>
+     */
+    public static function corpus(): iterable
+    {
+        yield 'short single line moves into the name' => [
+            'Website design',
+            'Website design',
+            null,
+        ];
+
+        yield 'multi line keeps the detail' => [
+            "Website design\nIncluding two rounds of revisions.",
+            'Website design',
+            "Website design\nIncluding two rounds of revisions.",
+        ];
+
+        yield 'long prose is truncated and kept in full' => [
+            str_repeat('a', 400),
+            str_repeat('a', self::NAME_MAX_LENGTH - 1) . '…',
+            str_repeat('a', 400),
+        ];
+
+        yield 'trailing whitespace is not data' => [
+            "Website design\n",
+            'Website design',
+            "Website design\n",
+        ];
+
+        yield 'blank description names nothing' => [
+            '   ',
+            '',
+            '   ',
+        ];
+    }
+
+    #[DataProvider('corpus')]
+    public function testPostUpBackfillsNamesWithoutLosingAnything(
+        string $description,
+        string $expectedName,
+        ?string $expectedDescription
+    ): void {
+        foreach (self::TABLES as $table) {
+            $this->createTable($table);
+            $this->connection->insert($table, ['id' => 'line-1', 'description' => $description, 'name' => '']);
+        }
+
+        $this->migration()->postUp(new Schema());
+
+        foreach (self::TABLES as $table) {
+            $row = $this->connection->fetchAssociative(sprintf('SELECT name, description FROM %s', $table));
+
+            self::assertIsArray($row);
+            self::assertSame($expectedName, $row['name'], $table);
+            self::assertSame($expectedDescription, $row['description'], $table);
+            self::assertLessThanOrEqual(self::NAME_MAX_LENGTH, mb_strlen((string) $row['name']), $table);
+        }
+    }
+
+    /**
+     * The backfill pages through the table, and a page is 500 rows. A corpus larger than one
+     * page is what proves the cursor advances rather than re-reading the first page forever —
+     * including over the rows it deliberately skips.
+     */
+    public function testPostUpBackfillsEveryPage(): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->createTable($table);
+        }
+
+        for ($i = 0; $i < 1200; ++$i) {
+            $this->connection->insert('invoice_lines', [
+                // A blank description is one of the rows the pass skips, so the cursor has
+                // to move past it on its own.
+                'id' => sprintf('line-%04d', $i),
+                'description' => $i % 100 === 0 ? '' : sprintf('Line %d', $i),
+                'name' => '',
+            ]);
+        }
+
+        $this->migration()->postUp(new Schema());
+
+        self::assertSame(
+            12,
+            (int) $this->connection->fetchOne("SELECT COUNT(*) FROM invoice_lines WHERE name = ''")
+        );
+        self::assertSame(
+            'Line 1199',
+            $this->connection->fetchOne('SELECT name FROM invoice_lines WHERE id = ?', ['line-1199'])
+        );
+    }
+
+    public function testPreDownPutsAMovedDescriptionBack(): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->createTable($table);
+            $this->connection->insert($table, ['id' => 'line-1', 'description' => 'Website design', 'name' => '']);
+        }
+
+        $migration = $this->migration();
+        $migration->postUp(new Schema());
+        $migration->preDown(new Schema());
+
+        foreach (self::TABLES as $table) {
+            self::assertSame(
+                'Website design',
+                $this->connection->fetchOne(sprintf('SELECT description FROM %s', $table)),
+                $table
+            );
+        }
+    }
+
+    private function createTable(string $table): void
+    {
+        $this->connection->executeStatement(
+            sprintf('CREATE TABLE %s (id VARCHAR(32) NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, description TEXT NULL)', $table)
+        );
+    }
+
+    private function preMigrationSchema(): Schema
+    {
+        $schema = new Schema();
+
+        foreach (self::TABLES as $tableName) {
+            $table = $schema->createTable($tableName);
+            $table->addColumn('description', Types::TEXT, ['notnull' => true]);
+        }
+
+        return $schema;
+    }
+
+    private function migration(): Version30100_6
+    {
+        return new Version30100_6($this->connection, new NullLogger());
+    }
+}

--- a/src/InvoiceBundle/Cloner/InvoiceCloner.php
+++ b/src/InvoiceBundle/Cloner/InvoiceCloner.php
@@ -122,6 +122,7 @@ final readonly class InvoiceCloner
 
             $invoiceLine->setCreated($now);
             $invoiceLine->setTotal($line->getTotal());
+            $invoiceLine->setName($line->getName());
             $invoiceLine->setDescription($line->getDescription());
             $invoiceLine->setPrice($line->getPrice());
             $invoiceLine->setQty($line->getQty());

--- a/src/InvoiceBundle/DummyData/InvoiceDummyDataLoader.php
+++ b/src/InvoiceBundle/DummyData/InvoiceDummyDataLoader.php
@@ -117,7 +117,7 @@ final readonly class InvoiceDummyDataLoader implements DummyDataLoaderInterface
                     $qty = random_int(1, 10);
 
                     $line = new Line();
-                    $line->setDescription($this->faker->sentence(5))
+                    $line->setName($this->faker->sentence(5))
                         ->setPrice($price)
                         ->setQty($qty)
                         ->setCompany($company);

--- a/src/InvoiceBundle/Entity/Invoice.php
+++ b/src/InvoiceBundle/Entity/Invoice.php
@@ -487,12 +487,14 @@ class Invoice extends BaseInvoice implements Stringable
     #[Groups(['searchable'])]
     public function getLineDescriptions(): array
     {
-        return array_values(
-            $this->lines
-                ->map(static fn (Line $line) => $line->getDescription())
-                ->filter(static fn (?string $d) => $d !== null && $d !== '')
-                ->toArray()
-        );
+        $text = [];
+
+        foreach ($this->lines as $line) {
+            $text[] = $line->getName();
+            $text[] = (string) $line->getDescription();
+        }
+
+        return array_values(array_filter($text, static fn (string $value) => $value !== ''));
     }
 
     public function __toString(): string

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -47,7 +47,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
-use function trim;
 
 #[ORM\Table(name: Line::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: LineRepository::class)]
@@ -252,6 +251,12 @@ class Line implements LineInterface, Stringable
      * Deriving the name here, rather than in a lifecycle callback, is what keeps a caller
      * that only sends a description valid: `name` is `NotBlank`, so it has to hold a value
      * by the time the object is validated, which is long before it is persisted.
+     *
+     * The description itself is stored exactly as given, never cleared. The serializer
+     * calls setters in payload key order, so anything this setter does to another field
+     * would make `{"description": …, "name": …}` and `{"name": …, "description": …}`
+     * persist differently. Not printing the same text twice is the `line_description`
+     * macro's job, where it costs no data.
      */
     public function setDescription(?string $description): static
     {
@@ -263,14 +268,9 @@ class Line implements LineInterface, Stringable
 
         $derived = LineName::fromDescription($description);
 
-        if ($derived === '') {
-            return $this;
+        if ($derived !== '') {
+            $this->name = $derived;
         }
-
-        $this->name = $derived;
-        // The description is dropped only when the name is all of it — whitespace aside.
-        // Anything longer stays, so nothing the caller wrote is lost.
-        $this->description = trim($description) === $derived ? null : $description;
 
         return $this;
     }

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -235,8 +235,22 @@ class Line implements LineInterface, Stringable
         return $this->id;
     }
 
+    /**
+     * An empty name with a description already set derives from it, the same way
+     * {@see self::setDescription()} does when the name is the field that is missing.
+     *
+     * Without that, `{"description": …, "name": ""}` and `{"name": "", "description": …}`
+     * would not mean the same thing: the serializer calls setters in payload key order, so
+     * the first would land on an empty name and be rejected while the second derived one.
+     * A name can never legitimately be cleared — it is `NotBlank` — so there is nothing lost
+     * in reading an empty one as "work it out from the description".
+     */
     public function setName(string $name): static
     {
+        if ($name === '' && ($this->description ?? '') !== '') {
+            $name = LineName::fromDescription($this->description);
+        }
+
         $this->name = $name;
 
         return $this;

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -30,6 +30,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer;
 use SolidInvoice\ApiBundle\State\Processor\InvoiceLinePersistProcessor;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
 use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
@@ -46,6 +47,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
+use function trim;
 
 #[ORM\Table(name: Line::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: LineRepository::class)]
@@ -138,8 +140,13 @@ class Line implements LineInterface, Stringable
     #[Groups(['invoice_api:read', 'recurring_invoice_api:read'])]
     protected ?Ulid $id = null;
 
-    #[ORM\Column(name: 'description', type: Types::TEXT)]
+    #[ORM\Column(name: 'name', type: Types::STRING, length: LineName::MAX_LENGTH, options: ['default' => ''])]
     #[Assert\NotBlank]
+    #[Assert\Length(max: LineName::MAX_LENGTH)]
+    #[Groups(['invoice_api:read', 'invoice_api:write', 'recurring_invoice_api:read', 'recurring_invoice_api:write'])]
+    protected string $name = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
     #[Groups(['invoice_api:read', 'invoice_api:write', 'recurring_invoice_api:read', 'recurring_invoice_api:write'])]
     protected ?string $description = null;
 
@@ -229,9 +236,41 @@ class Line implements LineInterface, Stringable
         return $this->id;
     }
 
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Deriving the name here, rather than in a lifecycle callback, is what keeps a caller
+     * that only sends a description valid: `name` is `NotBlank`, so it has to hold a value
+     * by the time the object is validated, which is long before it is persisted.
+     */
     public function setDescription(?string $description): static
     {
         $this->description = $description;
+
+        if ($this->name !== '' || ($description ?? '') === '') {
+            return $this;
+        }
+
+        $derived = LineName::fromDescription($description);
+
+        if ($derived === '') {
+            return $this;
+        }
+
+        $this->name = $derived;
+        // The description is dropped only when the name is all of it — whitespace aside.
+        // Anything longer stays, so nothing the caller wrote is lost.
+        $this->description = trim($description) === $derived ? null : $description;
 
         return $this;
     }
@@ -381,6 +420,6 @@ class Line implements LineInterface, Stringable
 
     public function __toString(): string
     {
-        return (string) $this->description;
+        return $this->name;
     }
 }

--- a/src/InvoiceBundle/Entity/RecurringInvoice.php
+++ b/src/InvoiceBundle/Entity/RecurringInvoice.php
@@ -374,12 +374,14 @@ class RecurringInvoice extends BaseInvoice
     #[Serialize\Groups(['searchable'])]
     public function getLineDescriptions(): array
     {
-        return array_values(
-            $this->lines
-                ->map(static fn (RecurringInvoiceLine $line) => $line->getDescription())
-                ->filter(static fn (?string $d) => $d !== null && $d !== '')
-                ->toArray()
-        );
+        $text = [];
+
+        foreach ($this->lines as $line) {
+            $text[] = $line->getName();
+            $text[] = (string) $line->getDescription();
+        }
+
+        return array_values(array_filter($text, static fn (string $value) => $value !== ''));
     }
 
     /**

--- a/src/InvoiceBundle/Form/Type/ItemType.php
+++ b/src/InvoiceBundle/Form/Type/ItemType.php
@@ -49,6 +49,10 @@ class ItemType extends AbstractType
             TextType::class,
             [
                 'empty_data' => '',
+                // Not required in the browser, so that a line with only a description still
+                // submits and derives its name from it, the same way the API does. The
+                // entity's NotBlank is what rejects a line with neither.
+                'required' => false,
                 'attr' => [
                     'class' => 'input-medium invoice-item-name',
                 ],

--- a/src/InvoiceBundle/Form/Type/ItemType.php
+++ b/src/InvoiceBundle/Form/Type/ItemType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -41,12 +42,26 @@ class ItemType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        // Before `description`, so that a line submitted with only a description still gets
+        // a name out of it. See Line::setDescription().
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'empty_data' => '',
+                'attr' => [
+                    'class' => 'input-medium invoice-item-name',
+                ],
+            ]
+        );
+
         $builder->add(
             'description',
             TextareaType::class,
             [
+                'required' => false,
                 'attr' => [
-                    'class' => 'input-medium invoice-item-name',
+                    'class' => 'input-medium invoice-item-description',
                 ],
             ]
         );

--- a/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
+++ b/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
@@ -49,6 +49,10 @@ class RecurringInvoiceLineType extends AbstractType
             TextType::class,
             [
                 'empty_data' => '',
+                // Not required in the browser, so that a line with only a description still
+                // submits and derives its name from it, the same way the API does. The
+                // entity's NotBlank is what rejects a line with neither.
+                'required' => false,
                 'attr' => [
                     'class' => 'input-medium invoice-item-name',
                 ],

--- a/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
+++ b/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -41,12 +42,26 @@ class RecurringInvoiceLineType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        // Before `description`, so that a line submitted with only a description still gets
+        // a name out of it. See Line::setDescription().
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'empty_data' => '',
+                'attr' => [
+                    'class' => 'input-medium invoice-item-name',
+                ],
+            ]
+        );
+
         $builder->add(
             'description',
             TextareaType::class,
             [
+                'required' => false,
                 'attr' => [
-                    'class' => 'input-medium invoice-item-name',
+                    'class' => 'input-medium invoice-item-description',
                 ],
             ]
         );

--- a/src/InvoiceBundle/Manager/InvoiceManager.php
+++ b/src/InvoiceBundle/Manager/InvoiceManager.php
@@ -19,6 +19,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerExceptionInterface;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Enum\CustomFieldTarget;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator;
 use SolidInvoice\CoreBundle\Service\CustomField\CustomFieldValueCopier;
@@ -96,7 +97,12 @@ class InvoiceManager
         foreach ($invoice->getLines() as $item) {
             // The name carries the date tokens as readily as the description does — a
             // recurring line called "Hosting — {month}" is the ordinary case.
-            $item->setName(str_replace($tokens, $values, $item->getName()));
+            //
+            // Cut to fit, because expanding a token makes the name longer: `{month}` is seven
+            // characters and September is nine, so a name that fit its column can stop
+            // fitting it. Nothing validates this invoice — the scheduler generates it — so an
+            // over-long name would go straight at the column and fail the flush.
+            $item->setName(LineName::truncate(str_replace($tokens, $values, $item->getName())));
 
             if (($description = $item->getDescription()) !== null) {
                 $item->setDescription(str_replace($tokens, $values, $description));

--- a/src/InvoiceBundle/Manager/InvoiceManager.php
+++ b/src/InvoiceBundle/Manager/InvoiceManager.php
@@ -78,27 +78,29 @@ class InvoiceManager
 
         $now = CarbonImmutable::instance($this->clock->now());
 
+        $tokens = [
+            '{day}',
+            '{day_name}',
+            '{month}',
+            '{year}',
+        ];
+
+        $values = [
+            (string) $now->day,
+            $now->format('l'),
+            $now->format('F'),
+            (string) $now->year,
+        ];
+
         /** @var Line $item */
         foreach ($invoice->getLines() as $item) {
-            $description = $item->getDescription();
+            // The name carries the date tokens as readily as the description does — a
+            // recurring line called "Hosting — {month}" is the ordinary case.
+            $item->setName(str_replace($tokens, $values, $item->getName()));
 
-            $description = str_replace(
-                [
-                    '{day}',
-                    '{day_name}',
-                    '{month}',
-                    '{year}',
-                ],
-                [
-                    $now->day,
-                    $now->format('l'),
-                    $now->format('F'),
-                    $now->year,
-                ],
-                $description
-            );
-
-            $item->setDescription($description);
+            if (($description = $item->getDescription()) !== null) {
+                $item->setDescription(str_replace($tokens, $values, $description));
+            }
         }
 
         return $invoice;
@@ -138,6 +140,7 @@ class InvoiceManager
             $invoiceItem = new Line();
             $invoiceItem->setCreated($now);
             $invoiceItem->setTotal($item->getTotal());
+            $invoiceItem->setName($item->getName());
             $invoiceItem->setDescription($item->getDescription());
             $invoiceItem->setPrice($item->getPrice());
             $invoiceItem->setQty($item->getQty());

--- a/src/InvoiceBundle/Mcp/InvoiceWriteTools.php
+++ b/src/InvoiceBundle/Mcp/InvoiceWriteTools.php
@@ -76,7 +76,7 @@ final readonly class InvoiceWriteTools
      * `apply_invoice_transition` to move it through the workflow.
      *
      * @param string                          $client_id      Client ULID (must belong to the active company)
-     * @param list<array<string, mixed>>      $lines          Line items: [{description, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
+     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
      *                                                        Price is in the minor unit (e.g. cents). Provide `taxes[]` for multi-tax lines
      *                                                        (India GST split, Quebec GST+QST compound); `tax_id` is the legacy single-tax shorthand.
      * @param string|null                     $invoice_date   ISO-8601 date (defaults to today)

--- a/src/InvoiceBundle/Mcp/RecurringInvoiceWriteTools.php
+++ b/src/InvoiceBundle/Mcp/RecurringInvoiceWriteTools.php
@@ -58,7 +58,7 @@ final readonly class RecurringInvoiceWriteTools
      * use `apply_recurring_transition` to activate it.
      *
      * @param string                          $client_id   Client ULID
-     * @param list<array<string, mixed>>      $lines       Line items: [{description, price, qty, tax_id?}, ...]
+     * @param list<array<string, mixed>>      $lines       Line items: [{name, description?, price, qty, tax_id?}, ...]
      * @param string                          $date_start  ISO-8601 date the first invoice should be generated
      * @param array<string, mixed>            $schedule    {"type": "daily"|"weekly"|"monthly"|"yearly",
      *                                                     "end_type": "never"|"on"|"after" (default "never"),

--- a/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
@@ -169,8 +169,13 @@
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">{{ 'invoice.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
-                                        {{ form_errors(item.description) }}
+                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans}}) }}
+                                        {{ form_errors(item.name) }}
+                                        <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
+                                            <summary class="line-description-toggle">{{ 'invoice.item.description.add'|trans }}</summary>
+                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_errors(item.description) }}
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">{{ 'invoice.item.heading.price'|trans }}</span>

--- a/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
@@ -155,7 +155,7 @@
                         <div class="billing-items-list" {{ stimulus_controller('line-reorder') }}
                              {{ stimulus_action('line-reorder', 'keydown', 'keydown') }}>
                             <div class="billing-items-header-row">
-                                <div class="column-description">{{ 'invoice.item.heading.description'|trans }}</div>
+                                <div class="column-description">{{ 'invoice.item.heading.name'|trans }}</div>
                                 <div class="column-price">{{ 'invoice.item.heading.price'|trans }}</div>
                                 <div class="column-qty">{{ 'invoice.item.heading.qty'|trans }}</div>
                                 {% if hasTax %}
@@ -168,12 +168,12 @@
                             {% for index, item in form.lines %}
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">{{ 'invoice.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans}}) }}
+                                        <span class="mobile-label">{{ 'invoice.item.heading.name'|trans }}</span>
+                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans, 'aria-label': 'invoice.item.name.label'|trans}}) }}
                                         {{ form_errors(item.name) }}
                                         <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
                                             <summary class="line-description-toggle">{{ 'invoice.item.description.add'|trans }}</summary>
-                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2, 'aria-label': 'invoice.item.description.label'|trans}}) }}
                                             {{ form_errors(item.description) }}
                                         </details>
                                     </div>

--- a/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
@@ -80,7 +80,7 @@
                         <div class="billing-items-list" {{ stimulus_controller('line-reorder') }}
                              {{ stimulus_action('line-reorder', 'keydown', 'keydown') }}>
                             <div class="billing-items-header-row">
-                                <div class="column-description">{{ 'invoice.item.heading.description'|trans }}</div>
+                                <div class="column-description">{{ 'invoice.item.heading.name'|trans }}</div>
                                 <div class="column-price">{{ 'invoice.item.heading.price'|trans }}</div>
                                 <div class="column-qty">{{ 'invoice.item.heading.qty'|trans }}</div>
                                 {% if hasTax %}
@@ -93,12 +93,12 @@
                             {% for index, item in form.lines %}
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">{{ 'invoice.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans}}) }}
+                                        <span class="mobile-label">{{ 'invoice.item.heading.name'|trans }}</span>
+                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans, 'aria-label': 'invoice.item.name.label'|trans}}) }}
                                         {{ form_errors(item.name) }}
                                         <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
                                             <summary class="line-description-toggle">{{ 'invoice.item.description.add'|trans }}</summary>
-                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2, 'aria-label': 'invoice.item.description.label'|trans}}) }}
                                             {{ form_errors(item.description) }}
                                         </details>
                                     </div>

--- a/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
@@ -94,8 +94,13 @@
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">{{ 'invoice.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
-                                        {{ form_errors(item.description) }}
+                                        {{ form_widget(item.name, {attr: {placeholder: 'invoice.item.name.placeholder'|trans}}) }}
+                                        {{ form_errors(item.name) }}
+                                        <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
+                                            <summary class="line-description-toggle">{{ 'invoice.item.description.add'|trans }}</summary>
+                                            {{ form_widget(item.description, {attr: {placeholder: 'invoice.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_errors(item.description) }}
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">{{ 'invoice.item.heading.price'|trans }}</span>

--- a/src/InvoiceBundle/Resources/views/Default/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view.html.twig
@@ -292,7 +292,7 @@
                         <tbody>
                             {% for item in invoice.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item) }}</td>
+                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if invoice.tax.positive %}

--- a/src/InvoiceBundle/Resources/views/Default/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view.html.twig
@@ -6,7 +6,6 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
-
 {% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
 
 {% block page_title %}
@@ -14,6 +13,7 @@
 {% endblock page_title %}
 
 {% block content %}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
 {% set currency = invoice.client.currency %}
 <div class="doc-view-page">
     <div class="doc-view-header no-print">
@@ -292,7 +292,7 @@
                         <tbody>
                             {% for item in invoice.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.description|nl2br }}</td>
+                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if invoice.tax.positive %}

--- a/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
@@ -222,7 +222,7 @@
                         <tbody>
                             {% for item in invoice.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item) }}</td>
+                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if invoice.tax.positive %}

--- a/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
@@ -6,7 +6,6 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
-
 {% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
 
 {% block page_title %}
@@ -14,6 +13,7 @@
 {% endblock page_title %}
 
 {% block content %}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
 {% set currency = invoice.client.currency %}
 <div class="doc-view-page">
     {# ═══════════════════════════════════════════════════════════════════════
@@ -222,7 +222,7 @@
                         <tbody>
                             {% for item in invoice.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.description|nl2br }}</td>
+                                    <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if invoice.tax.positive %}

--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -6,6 +6,7 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
 
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice.payments|length > 0 and not invoice.balance.zero %}
@@ -240,7 +241,7 @@
         {% for line in invoice.lines %}
             <tr{% if loop.index is even %} style="background-color: #fafbfc;"{% endif %}>
                 <td class="col-description" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; vertical-align: top;">
-                    {{ line.description|nl2br }}
+                    {{ line.name }}{{ inv.line_description(line) }}
                 </td>
                 <td class="col-price" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">
                     {{ line.price|formatCurrency(currency) }}

--- a/src/InvoiceBundle/Resources/views/Templates/_macros.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/_macros.html.twig
@@ -6,8 +6,9 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #
- # Shared macros for invoice templates. Used by every template under
- # `Templates/{slug}/{pdf,email,preview}.html.twig` to keep markup consistent.
+ # Shared macros for the views that render an invoice or a quote — every template
+ # under `Templates/{slug}/{pdf,email,preview}.html.twig`, plus the in-app and
+ # external views — to keep markup consistent.
  #}
 
 {% macro bill_to_block(invoice, label='invoice.to') %}
@@ -236,3 +237,11 @@
         </table>
     {% endif %}
 {% endmacro %}
+
+{#
+ # line_description
+ #
+ # A line's description, under its name. A description is optional now that a line has a
+ # name, so every view that renders a line needs the same "omit it when absent" rule.
+ #}
+{% macro line_description(line) %}{% if line.description is not empty %}<div class="line-item-description" style="font-size: 0.85em; color: #64748b; margin-top: 3px;">{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}

--- a/src/InvoiceBundle/Resources/views/Templates/_macros.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/_macros.html.twig
@@ -242,6 +242,10 @@
  # line_description
  #
  # A line's description, under its name. A description is optional now that a line has a
- # name, so every view that renders a line needs the same "omit it when absent" rule.
+ # name, and a description that is only the name over again would print the same text
+ # twice, so every view that renders a line needs the same "omit it" rule.
+ #
+ # `inline` for the PDF and email templates, which have no stylesheet to reach; the in-app
+ # views pass false and take the Tabler utilities instead, so the text follows the theme.
  #}
-{% macro line_description(line) %}{% if line.description is not empty %}<div class="line-item-description" style="font-size: 0.85em; color: #64748b; margin-top: 3px;">{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}
+{% macro line_description(line, inline = true) %}{% if line.description is not empty and line.description|trim != line.name %}<div class="line-item-description{% if not inline %} text-secondary small{% endif %}"{% if inline %} style="font-size: 0.85em; color: #64748b; margin-top: 3px;"{% endif %}>{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}

--- a/src/InvoiceBundle/Resources/views/Templates/classic/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/classic/pdf.html.twig
@@ -54,7 +54,7 @@
     <tbody>
         {% for line in invoice.lines %}
             <tr>
-                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/classic/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/classic/preview.html.twig
@@ -1,4 +1,6 @@
 {# Classic Professional preview — Bootstrap 5.3 / Tabler #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 
@@ -40,7 +42,7 @@
                 <tbody>
                     {% for line in invoice.lines %}
                         <tr>
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="text-end font-monospace">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end">{{ line.qty }}</td>
                             <td class="text-end font-monospace fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/compact/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/compact/pdf.html.twig
@@ -58,7 +58,7 @@
         {% for line in invoice.lines %}
             <tr{% if loop.index0 is divisible by(2) %} style="background-color: #f8fafc;"{% endif %}>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: center; color: #64748b;">{{ loop.index }}</td>
-                <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.description|nl2br }}</td>
+                <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.name }}{{ inv.line_description(line) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/compact/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/compact/preview.html.twig
@@ -1,4 +1,6 @@
 {# Compact Dense preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 
@@ -50,7 +52,7 @@
                         {% for line in invoice.lines %}
                             <tr>
                                 <td class="text-muted small">{{ loop.index }}</td>
-                                <td class="small">{{ line.description|nl2br }}</td>
+                                <td class="small">{{ line.name }}{{ inv.line_description(line) }}</td>
                                 <td class="text-end font-monospace small">{{ line.qty }}</td>
                                 <td class="text-end font-monospace small">{{ line.price|formatCurrency(currency) }}</td>
                                 <td class="text-end font-monospace small fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/editorial/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/editorial/pdf.html.twig
@@ -43,7 +43,7 @@
     {% for line in invoice.lines %}
         <tr>
             <td style="padding: 14px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; vertical-align: top;">
-                <em>{{ line.description|nl2br }}</em>
+                <em>{{ line.name }}</em>{{ inv.line_description(line) }}
                 <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
             </td>
             <td style="padding: 14px 0; font-size: 13pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; text-align: right; vertical-align: top; width: 25%;">

--- a/src/InvoiceBundle/Resources/views/Templates/editorial/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/editorial/preview.html.twig
@@ -1,4 +1,6 @@
 {# Editorial preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400;1,600&display=swap">
@@ -35,7 +37,7 @@
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #e8dcc4;">
                             <td>
-                                <em>{{ line.description|nl2br }}</em>
+                                <em>{{ line.name }}</em>{{ inv.line_description(line) }}
                                 <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-5">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/friendly/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/friendly/pdf.html.twig
@@ -74,7 +74,7 @@
         <tbody>
             {% for line in invoice.lines %}
                 <tr>
-                    <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.description|nl2br }}</td>
+                    <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.name }}{{ inv.line_description(line) }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ line.qty }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
                 </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/friendly/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/friendly/preview.html.twig
@@ -1,4 +1,6 @@
 {# Freelancer Friendly preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 {% set primary = invoice_primary_contact(invoice) %}
@@ -62,7 +64,7 @@
                 <tbody>
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #f1eada;">
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="text-end text-muted">{{ line.qty }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/modern/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/modern/pdf.html.twig
@@ -52,7 +52,7 @@
     <tbody>
         {% for line in invoice.lines %}
             <tr>
-                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/modern/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/modern/preview.html.twig
@@ -1,4 +1,6 @@
 {# Modern Minimal preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 
@@ -47,7 +49,7 @@
                 <tbody>
                     {% for line in invoice.lines %}
                         <tr class="border-bottom">
-                            <td class="py-3">{{ line.description|nl2br }}</td>
+                            <td class="py-3">{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="py-3 text-end">{{ line.qty }}</td>
                             <td class="py-3 text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="py-3 text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/monochrome/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/monochrome/pdf.html.twig
@@ -104,7 +104,7 @@
                             <tbody>
                                 {% for line in invoice.lines %}
                                     <tr>
-                                        <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.description|nl2br }}</td>
+                                        <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.name }}{{ inv.line_description(line) }}</td>
                                         <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
                                         <td style="padding: 12px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif; font-weight: bold;">{{ line.total|formatCurrency(currency) }}</td>
                                     </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/monochrome/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/monochrome/preview.html.twig
@@ -1,4 +1,6 @@
 {# Monochrome Luxury preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 
@@ -47,7 +49,7 @@
                 <tbody>
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #e0d8c8;">
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="text-muted text-end">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/photographer/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/photographer/pdf.html.twig
@@ -50,7 +50,7 @@
                 {% for line in invoice.lines %}
                     <tr>
                         <td style="padding: 12px 0; font-size: 10pt; color: #2a2418; border-bottom: 1px solid #e8d7b8; vertical-align: top;">
-                            <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.description|nl2br }}</div>
+                            <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.name }}</div>{{ inv.line_description(line) }}
                             <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                         </td>
                         <td style="padding: 12px 0; font-size: 12pt; color: #a2492b; border-bottom: 1px solid #e8d7b8; text-align: right; font-family: Georgia, serif; font-weight: bold; width: 28%;">

--- a/src/InvoiceBundle/Resources/views/Templates/photographer/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/photographer/preview.html.twig
@@ -1,4 +1,6 @@
 {# Photographer preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap">
@@ -39,7 +41,7 @@
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #e8d7b8;">
                             <td>
-                                <div class="fs-5">{{ line.description|nl2br }}</div>
+                                <div class="fs-5">{{ line.name }}</div>{{ inv.line_description(line) }}
                                 <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-4 fw-bold" style="color: #a2492b;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/studio/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/studio/pdf.html.twig
@@ -52,7 +52,7 @@
     <tbody>
         {% for line in invoice.lines %}
             <tr>
-                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/Templates/studio/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/studio/preview.html.twig
@@ -1,4 +1,6 @@
 {# Studio / Agency preview #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
+
 {% set currency = invoice.client.currency %}
 {% set hasOutstandingBalance = invoice_has_outstanding_balance(invoice) %}
 
@@ -45,7 +47,7 @@
                 <tbody>
                     {% for line in invoice.lines %}
                         <tr>
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="text-end">{{ line.qty }}</td>
                             <td class="text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
+++ b/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
@@ -6,6 +6,7 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
 
 {% set currency = invoice.client.currency %}
 
@@ -175,7 +176,7 @@
                             <tbody>
                                 {% for item in invoice.lines %}
                                     <tr>
-                                        <td class="item-description">{{ item.description|nl2br }}</td>
+                                        <td class="item-description">{{ item.name }}{{ inv.line_description(item) }}</td>
                                         <td class="text-end item-amount">{{ item.price|formatCurrency(currency) }}</td>
                                         <td class="text-center">{{ item.qty }}</td>
                                         {% if invoice.tax.positive %}

--- a/src/InvoiceBundle/Resources/views/invoice_template.html.twig
+++ b/src/InvoiceBundle/Resources/views/invoice_template.html.twig
@@ -6,6 +6,7 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
+{% import '@SolidInvoiceInvoice/Templates/_macros.html.twig' as inv %}
 
 {% set footerSpan = invoice.tax.positive ? 4 : 3 %}
 
@@ -126,7 +127,7 @@
                             {% for item in invoice.lines %}
                                 <tr>
                                     <td class="column-description">
-                                        {{ item.description|nl2br }}
+                                        {{ item.name }}{{ inv.line_description(item) }}
                                     </td>
                                     <td class="column-price">
                                         {{ item.price|formatCurrency(invoice.client.currency) }}

--- a/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
@@ -26,11 +26,13 @@ final class ItemTypeTest extends FormTestCase
 {
     public function testSubmit(): void
     {
+        $name = $this->faker->sentence(3);
         $description = $this->faker->text();
         $price = $this->faker->randomNumber(3);
         $qty = '12.345678';
 
         $formData = [
+            'name' => $name,
             'description' => $description,
             'price' => $price,
             'qty' => $qty,
@@ -39,6 +41,7 @@ final class ItemTypeTest extends FormTestCase
         $currency = new Currency('USD');
 
         $object = new Line();
+        $object->setName($name);
         $object->setDescription($description);
         $object->setQty($qty);
         $object->setPrice(BigDecimal::of($price * 100));
@@ -48,12 +51,12 @@ final class ItemTypeTest extends FormTestCase
 
     public function testSubmitPreservesSpecialCharacters(): void
     {
-        $description = 'Item + discount & "special" chars: 100% off';
+        $name = 'Item + discount & "special" chars: 100% off';
         $price = 100;
         $qty = '1';
 
         $formData = [
-            'description' => $description,
+            'name' => $name,
             'price' => $price,
             'qty' => $qty,
         ];
@@ -61,11 +64,39 @@ final class ItemTypeTest extends FormTestCase
         $currency = new Currency('USD');
 
         $object = new Line();
-        $object->setDescription($description);
+        $object->setName($name);
         $object->setQty($qty);
         $object->setPrice(BigDecimal::of($price * 100));
 
         $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    /**
+     * The name field comes first so that a line submitted with only a description still
+     * derives one. Nothing in the UI submits this shape today, but the form has to survive
+     * a stale browser tab that does.
+     */
+    public function testSubmitWithOnlyADescriptionDerivesTheName(): void
+    {
+        $formData = [
+            'name' => '',
+            'description' => "Website design\nIncluding two rounds of revisions.",
+            'price' => 100,
+            'qty' => '1',
+        ];
+
+        $object = new Line();
+        $object->setDescription("Website design\nIncluding two rounds of revisions.");
+        $object->setQty('1');
+        $object->setPrice(BigDecimal::of(10000));
+
+        self::assertSame('Website design', $object->getName());
+
+        $this->assertFormData(
+            $this->factory->create(ItemType::class, null, ['currency' => new Currency('USD')]),
+            $formData,
+            $object
+        );
     }
 
     /**

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -42,7 +42,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item 1',
+            'name' => 'Item 1',
             'price' => 1000,
             'qty' => 2.0,
         ];
@@ -51,7 +51,7 @@ final class InvoiceLineTest extends ApiTestCase
 
         self::assertArrayHasKey('id', $result);
         self::assertTrue(Ulid::isValid($result['id'], Ulid::FORMAT_BASE_32));
-        self::assertSame('Item 1', $result['description']);
+        self::assertSame('Item 1', $result['name']);
         self::assertEquals(2.0, $result['qty']);
         self::assertArrayHasKey('total', $result);
     }
@@ -67,7 +67,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $result = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
-            'description' => 'Metered usage',
+            'name' => 'Metered usage',
             'price' => 1000,
             'qty' => 2.5,
         ]);
@@ -88,7 +88,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $created = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
-            'description' => 'Metered usage',
+            'name' => 'Metered usage',
             'price' => 1000,
             'qty' => 1,
         ]);
@@ -108,7 +108,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Test Item',
+            'name' => 'Test Item',
             'price' => 500,
             'qty' => 1.0,
         ];
@@ -118,7 +118,7 @@ final class InvoiceLineTest extends ApiTestCase
 
         $data = $this->requestGet('/api/invoices/' . $invoiceId . '/line/' . $lineId);
 
-        self::assertSame('Test Item', $data['description']);
+        self::assertSame('Test Item', $data['name']);
         self::assertSame($lineId, $data['id']);
         self::assertEquals(1.0, $data['qty']);
     }
@@ -130,7 +130,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Original Item',
+            'name' => 'Original Item',
             'price' => 300,
             'qty' => 1.0,
         ];
@@ -140,10 +140,10 @@ final class InvoiceLineTest extends ApiTestCase
 
         $data = $this->requestPatch(
             '/api/invoices/' . $invoiceId . '/line/' . $lineId,
-            ['description' => 'Updated Item']
+            ['name' => 'Updated Item']
         );
 
-        self::assertSame('Updated Item', $data['description']);
+        self::assertSame('Updated Item', $data['name']);
         self::assertSame($lineId, $data['id']);
     }
 
@@ -154,7 +154,7 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item To Delete',
+            'name' => 'Item To Delete',
             'price' => 100,
             'qty' => 1.0,
         ];
@@ -238,13 +238,13 @@ final class InvoiceLineTest extends ApiTestCase
             ->toString();
 
         $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
-            'description' => 'Collection Item 1',
+            'name' => 'Collection Item 1',
             'price' => 100,
             'qty' => 1.0,
         ]);
 
         $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
-            'description' => 'Collection Item 2',
+            'name' => 'Collection Item 2',
             'price' => 200,
             'qty' => 2.0,
         ]);
@@ -287,5 +287,45 @@ final class InvoiceLineTest extends ApiTestCase
         );
 
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * A client written before lines had a name sends only a description. It has to keep
+     * working, and the line it creates has to end up with a name all the same.
+     */
+    public function testCreateWithOnlyADescriptionDerivesTheName(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => "Website design\nIncluding two rounds of revisions.",
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertSame("Website design\nIncluding two rounds of revisions.", $result['description']);
+    }
+
+    /**
+     * A one-line description is the whole name, so keeping it would print the same text
+     * twice on the invoice.
+     */
+    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => 'Website design',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertNull($result['description']);
     }
 }

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -359,4 +359,33 @@ final class InvoiceLineTest extends ApiTestCase
         self::assertSame($nameFirst['name'], $descriptionFirst['name']);
         self::assertSame($nameFirst['description'], $descriptionFirst['description']);
     }
+
+    /**
+     * The same, for a client that sends the name as an empty string rather than leaving the
+     * key out — which is what a form-ish serialiser does. Whichever way round the two keys
+     * arrive, the name has to come from the description.
+     */
+    public function testAnEmptyNameIsDerivedInEitherKeyOrder(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $descriptionFirst = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => 'Website design',
+            'name' => '',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        $nameFirst = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'name' => '',
+            'description' => 'Website design',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $descriptionFirst['name']);
+        self::assertSame($nameFirst['name'], $descriptionFirst['name']);
+    }
 }

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -310,10 +310,11 @@ final class InvoiceLineTest extends ApiTestCase
     }
 
     /**
-     * A one-line description is the whole name, so keeping it would print the same text
-     * twice on the invoice.
+     * A one-line description becomes the name in full, and is still stored. Not printing
+     * the same text twice is the `line_description` macro's job; the API keeps what it
+     * was sent.
      */
-    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    public function testASingleLineDescriptionBecomesTheNameAndIsKept(): void
     {
         $invoice = InvoiceFactory::createOne();
         $invoiceId = $invoice->getId()
@@ -326,6 +327,36 @@ final class InvoiceLineTest extends ApiTestCase
         ]);
 
         self::assertSame('Website design', $result['name']);
-        self::assertNull($result['description']);
+        self::assertSame('Website design', $result['description']);
+    }
+
+    /**
+     * The serializer calls setters in payload key order, so a client that happens to
+     * serialise `description` first must not get a different line from one that does not.
+     */
+    public function testBothFieldsSurviveEitherKeyOrder(): void
+    {
+        $invoice = InvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $descriptionFirst = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'description' => 'Consulting',
+            'name' => 'Widget',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        $nameFirst = $this->requestPost('/api/invoices/' . $invoiceId . '/lines', [
+            'name' => 'Widget',
+            'description' => 'Consulting',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Widget', $descriptionFirst['name']);
+        self::assertSame('Consulting', $descriptionFirst['description']);
+        self::assertSame($nameFirst['name'], $descriptionFirst['name']);
+        self::assertSame($nameFirst['description'], $descriptionFirst['description']);
     }
 }

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -258,11 +258,13 @@ final class InvoiceLineTest extends ApiTestCase
         // Both posts have to survive. Asserting only the collection's type let the second
         // post silently overwrite the first, because the response looked the same either way.
         self::assertSame(2, $data['totalItems']);
-        // Canonicalizing: the lines association carries no OrderBy, so collection order
-        // is unspecified. What matters here is that neither post replaced the other.
-        self::assertEqualsCanonicalizing(
+        // In the posted order, not canonicalized: the lines association carries an OrderBy
+        // on `position` now, so a posted line lands after the ones already there and the
+        // collection comes back in a specified order rather than whatever the database
+        // happened to return. Asserted on `name`, which is what these posts set.
+        self::assertSame(
             ['Collection Item 1', 'Collection Item 2'],
-            array_column($data['member'], 'description')
+            array_column($data['member'], 'name')
         );
     }
 

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
@@ -110,7 +110,7 @@ final class InvoiceTest extends ApiTestCase
                 [
                     'price' => 100,
                     'qty' => 1,
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                 ],
             ],
         ];
@@ -131,10 +131,11 @@ final class InvoiceTest extends ApiTestCase
             'paidDate' => null,
             'lines' => [
                 [
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                     'price' => 100,
                     'qty' => 1,
                     'total' => 100,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -182,7 +183,7 @@ final class InvoiceTest extends ApiTestCase
                 ->setValue(0),
             'lines' => [
                 new Line()
-                    ->setDescription('Test Item')
+                    ->setName('Test Item')
                     ->setQty(1)
                     ->setPrice(10000),
             ],
@@ -214,10 +215,11 @@ final class InvoiceTest extends ApiTestCase
                         ->first()
                         ->getId()
                         ->toString(),
-                    'description' => 'Test Item',
+                    'name' => 'Test Item',
                     'price' => 100,
                     'qty' => 1,
                     'total' => 100,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -254,11 +256,11 @@ final class InvoiceTest extends ApiTestCase
             'users' => $contacts,
             'lines' => [
                 new Line()
-                    ->setDescription('Test Item')
+                    ->setName('Test Item')
                     ->setQty(1)
                     ->setPrice(10000),
                 new Line()
-                    ->setDescription('Test Item Too')
+                    ->setName('Test Item Too')
                     ->setQty(1)
                     ->setPrice(10000),
             ],
@@ -275,7 +277,7 @@ final class InvoiceTest extends ApiTestCase
                     [
                         'price' => 10000,
                         'qty' => 1,
-                        'description' => 'Foo Item',
+                        'name' => 'Foo Item',
                     ],
                 ],
             ]
@@ -305,10 +307,11 @@ final class InvoiceTest extends ApiTestCase
                         ->first()
                         ->getId()
                         ->toString(),
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                     'price' => 10000,
                     'qty' => 1,
                     'total' => 10000,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
@@ -46,7 +46,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item 1',
+            'name' => 'Item 1',
             'price' => 1000,
             'qty' => 2.0,
         ];
@@ -55,7 +55,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
 
         self::assertArrayHasKey('id', $result);
         self::assertTrue(Ulid::isValid($result['id'], Ulid::FORMAT_BASE_32));
-        self::assertSame('Item 1', $result['description']);
+        self::assertSame('Item 1', $result['name']);
         self::assertEquals(2.0, $result['qty']);
         self::assertArrayHasKey('total', $result);
     }
@@ -67,7 +67,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Test Item',
+            'name' => 'Test Item',
             'price' => 500,
             'qty' => 1.0,
         ];
@@ -77,7 +77,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
 
         $data = $this->requestGet('/api/recurring-invoices/' . $invoiceId . '/line/' . $lineId);
 
-        self::assertSame('Test Item', $data['description']);
+        self::assertSame('Test Item', $data['name']);
         self::assertSame($lineId, $data['id']);
         self::assertEquals(1.0, $data['qty']);
     }
@@ -89,7 +89,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Original Item',
+            'name' => 'Original Item',
             'price' => 300,
             'qty' => 1.0,
         ];
@@ -99,10 +99,10 @@ final class RecurringInvoiceLineTest extends ApiTestCase
 
         $data = $this->requestPatch(
             '/api/recurring-invoices/' . $invoiceId . '/line/' . $lineId,
-            ['description' => 'Updated Item']
+            ['name' => 'Updated Item']
         );
 
-        self::assertSame('Updated Item', $data['description']);
+        self::assertSame('Updated Item', $data['name']);
         self::assertSame($lineId, $data['id']);
     }
 
@@ -113,7 +113,7 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item To Delete',
+            'name' => 'Item To Delete',
             'price' => 100,
             'qty' => 1.0,
         ];
@@ -131,13 +131,13 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             ->toString();
 
         $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
-            'description' => 'Collection Item 1',
+            'name' => 'Collection Item 1',
             'price' => 100,
             'qty' => 1.0,
         ]);
 
         $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
-            'description' => 'Collection Item 2',
+            'name' => 'Collection Item 2',
             'price' => 200,
             'qty' => 2.0,
         ]);
@@ -180,6 +180,46 @@ final class RecurringInvoiceLineTest extends ApiTestCase
         );
 
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * A client written before lines had a name sends only a description. It has to keep
+     * working, and the line it creates has to end up with a name all the same.
+     */
+    public function testCreateWithOnlyADescriptionDerivesTheName(): void
+    {
+        $invoice = RecurringInvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
+            'description' => "Website design\nIncluding two rounds of revisions.",
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertSame("Website design\nIncluding two rounds of revisions.", $result['description']);
+    }
+
+    /**
+     * A one-line description is the whole name, so keeping it would print the same text
+     * twice on the invoice.
+     */
+    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    {
+        $invoice = RecurringInvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
+            'description' => 'Website design',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertNull($result['description']);
     }
 
     /**

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
@@ -203,10 +203,11 @@ final class RecurringInvoiceLineTest extends ApiTestCase
     }
 
     /**
-     * A one-line description is the whole name, so keeping it would print the same text
-     * twice on the invoice.
+     * A one-line description becomes the name in full, and is still stored. Not printing
+     * the same text twice is the `line_description` macro's job; the API keeps what it
+     * was sent.
      */
-    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    public function testASingleLineDescriptionBecomesTheNameAndIsKept(): void
     {
         $invoice = RecurringInvoiceFactory::createOne();
         $invoiceId = $invoice->getId()
@@ -219,7 +220,37 @@ final class RecurringInvoiceLineTest extends ApiTestCase
         ]);
 
         self::assertSame('Website design', $result['name']);
-        self::assertNull($result['description']);
+        self::assertSame('Website design', $result['description']);
+    }
+
+    /**
+     * The serializer calls setters in payload key order, so a client that happens to
+     * serialise `description` first must not get a different line from one that does not.
+     */
+    public function testBothFieldsSurviveEitherKeyOrder(): void
+    {
+        $invoice = RecurringInvoiceFactory::createOne();
+        $invoiceId = $invoice->getId()
+            ->toString();
+
+        $descriptionFirst = $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
+            'description' => 'Consulting',
+            'name' => 'Widget',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        $nameFirst = $this->requestPost('/api/recurring-invoices/' . $invoiceId . '/lines', [
+            'name' => 'Widget',
+            'description' => 'Consulting',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Widget', $descriptionFirst['name']);
+        self::assertSame('Consulting', $descriptionFirst['description']);
+        self::assertSame($nameFirst['name'], $descriptionFirst['name']);
+        self::assertSame($nameFirst['description'], $descriptionFirst['description']);
     }
 
     /**

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
@@ -151,11 +151,13 @@ final class RecurringInvoiceLineTest extends ApiTestCase
         // Both posts have to survive. Asserting only the collection's type let the second
         // post silently overwrite the first, because the response looked the same either way.
         self::assertSame(2, $data['totalItems']);
-        // Canonicalizing: the lines association carries no OrderBy, so collection order
-        // is unspecified. What matters here is that neither post replaced the other.
-        self::assertEqualsCanonicalizing(
+        // In the posted order, not canonicalized: the lines association carries an OrderBy
+        // on `position` now, so a posted line lands after the ones already there and the
+        // collection comes back in a specified order rather than whatever the database
+        // happened to return. Asserted on `name`, which is what these posts set.
+        self::assertSame(
             ['Collection Item 1', 'Collection Item 2'],
-            array_column($data['member'], 'description')
+            array_column($data['member'], 'name')
         );
     }
 

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -103,7 +103,7 @@ final class RecurringInvoiceTest extends ApiTestCase
                 [
                     'price' => 100.1,
                     'qty' => 1.0,
-                    'description' => 'Foo Line',
+                    'name' => 'Foo Line',
                 ],
             ],
         ];
@@ -126,10 +126,11 @@ final class RecurringInvoiceTest extends ApiTestCase
             'lines' => [
                 [
                     '@type' => 'RecurringInvoiceLine',
-                    'description' => 'Foo Line',
+                    'name' => 'Foo Line',
                     'price' => 100.1,
                     'qty' => 1,
                     'total' => 100.1,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -181,7 +182,7 @@ final class RecurringInvoiceTest extends ApiTestCase
             'users' => $contacts,
             'lines' => [
                 new RecurringInvoiceLine()
-                    ->setDescription('Test Line')
+                    ->setName('Test Line')
                     ->setPrice(100)
                     ->setQty(1)
             ],
@@ -221,10 +222,11 @@ final class RecurringInvoiceTest extends ApiTestCase
                         ->first()
                         ->getId()
                         ->toString(),
-                    'description' => 'Test Line',
+                    'name' => 'Test Line',
                     'price' => 1,
                     'qty' => 1,
                     'total' => 1,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -261,7 +263,7 @@ final class RecurringInvoiceTest extends ApiTestCase
             'users' => $contacts,
             'lines' => [
                 new RecurringInvoiceLine()
-                    ->setDescription('Test Line')
+                    ->setName('Test Line')
                     ->setPrice(100)
                     ->setQty(1)
             ],
@@ -282,7 +284,7 @@ final class RecurringInvoiceTest extends ApiTestCase
                     [
                         'price' => 100.0,
                         'qty' => 1.0,
-                        'description' => 'Foo Line',
+                        'name' => 'Foo Line',
                     ],
                 ],
             ]
@@ -315,10 +317,11 @@ final class RecurringInvoiceTest extends ApiTestCase
                         ->first()
                         ->getId()
                         ->toString(),
-                    'description' => 'Foo Line',
+                    'name' => 'Foo Line',
                     'price' => 100,
                     'qty' => 1,
                     'total' => 100,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],

--- a/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -165,7 +165,7 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureInvoice(bool $withDescription = true): Invoice
+    private function createFixtureInvoice(?string $description = 'Two rounds of revisions included.'): Invoice
     {
         $this->seedCompanyLogo();
 
@@ -202,7 +202,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             'lines' => [
                 new Line()
                     ->setName('Sample line item')
-                    ->setDescription($withDescription ? 'Two rounds of revisions included.' : null)
+                    ->setDescription($description)
                     ->setPrice(BigInteger::of(75000))
                     ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
@@ -218,7 +218,28 @@ final class TemplatesRenderingTest extends KernelTestCase
     #[DataProvider('lineChannelProvider')]
     public function testTemplateOmitsAnEmptyDescription(string $slug, string $channel): void
     {
-        $invoice = $this->createFixtureInvoice(withDescription: false);
+        $invoice = $this->createFixtureInvoice(null);
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $output = $twig->render(
+            sprintf('@SolidInvoiceInvoice/Templates/%s/%s.html.twig', $slug, $channel),
+            ['invoice' => $invoice]
+        );
+
+        self::assertStringContainsString('Sample line item', $output);
+        self::assertStringNotContainsString('line-item-description', $output);
+    }
+
+    /**
+     * A line whose description is the name over again — what a client that only knows about
+     * `description` produces — must print the text once, not twice.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testTemplateOmitsADescriptionThatRepeatsTheName(string $slug, string $channel): void
+    {
+        $invoice = $this->createFixtureInvoice('Sample line item');
 
         $twig = self::getContainer()->get('twig');
         self::assertInstanceOf(Environment::class, $twig);

--- a/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -97,8 +97,8 @@ final class TemplatesRenderingTest extends KernelTestCase
             // PDF and preview render every line item and the company logo —
             // assert both surface so a regression that drops
             // `{% for line in invoice.lines %}` or the logo block is caught.
-            'pdf' => $this->assertChannelContains($output, ['</html>', 'Sample line item', 'data:image/png;base64']),
-            'preview' => $this->assertChannelContains($output, ['Sample line item', 'data:image/png;base64']),
+            'pdf' => $this->assertChannelContains($output, ['</html>', 'Sample line item', 'Two rounds of revisions included.', 'data:image/png;base64']),
+            'preview' => $this->assertChannelContains($output, ['Sample line item', 'Two rounds of revisions included.', 'data:image/png;base64']),
             // Email is a summary (totals only, no per-line breakdown), so we
             // verify the schema.org payload + the displayed total instead.
             'email' => $this->assertChannelContains($output, ['schema.org', '$1,500.00']),
@@ -165,7 +165,7 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureInvoice(): Invoice
+    private function createFixtureInvoice(bool $withDescription = true): Invoice
     {
         $this->seedCompanyLogo();
 
@@ -201,12 +201,47 @@ final class TemplatesRenderingTest extends KernelTestCase
                 ->setType(null),
             'lines' => [
                 new Line()
-                    ->setDescription('Sample line item')
+                    ->setName('Sample line item')
+                    ->setDescription($withDescription ? 'Two rounds of revisions included.' : null)
                     ->setPrice(BigInteger::of(75000))
                     ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
             ],
             'users' => [$contact],
         ]);
+    }
+
+    /**
+     * The description is optional, so the block that renders it has to disappear entirely
+     * for a line that has only a name — not leave an empty div under every item.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testTemplateOmitsAnEmptyDescription(string $slug, string $channel): void
+    {
+        $invoice = $this->createFixtureInvoice(withDescription: false);
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $output = $twig->render(
+            sprintf('@SolidInvoiceInvoice/Templates/%s/%s.html.twig', $slug, $channel),
+            ['invoice' => $invoice]
+        );
+
+        self::assertStringContainsString('Sample line item', $output);
+        self::assertStringNotContainsString('line-item-description', $output);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function lineChannelProvider(): iterable
+    {
+        // Only the channels that render a line breakdown; email is a totals summary.
+        foreach (self::slugs() as $slug) {
+            foreach (['pdf', 'preview'] as $channel) {
+                yield sprintf('%s/%s', $slug, $channel) => [$slug, $channel];
+            }
+        }
     }
 }

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -139,7 +139,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $lineTax->snapshotFrom($tax);
 
         $line->addTax($lineTax);
-        $line->setDescription('Line Description');
+        $line->setName('Line Description');
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
@@ -182,7 +182,7 @@ final class InvoiceManagerTest extends KernelTestCase
 
         self::assertCount(1, $invoiceLine[0]->getTaxes());
         self::assertSame('VAT', $invoiceLine[0]->getTaxes()->first()->getNameSnapshot());
-        self::assertSame($line->getDescription(), $invoiceLine[0]->getDescription());
+        self::assertSame($line->getName(), $invoiceLine[0]->getName());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
@@ -202,7 +202,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $sourceLineTax->setSequence(1);
 
         $line = new Line();
-        $line->setDescription('Service');
+        $line->setName('Service');
         $line->setPrice(120);
         $line->setQty(1);
         $line->setTotal(120);
@@ -259,7 +259,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $sourceLineTax->setTypeSnapshot(TaxType::Exclusive);
 
         $line = new RecurringInvoiceLine();
-        $line->setDescription('Recurring Service');
+        $line->setName('Recurring Service');
         $line->setPrice(1000);
         $line->setQty(1);
         $line->setTotal(1000);
@@ -313,7 +313,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $lineTax->snapshotFrom($tax);
 
         $line->addTax($lineTax);
-        $line->setDescription('Line Description {day} {day_name} {month} {year}');
+        $line->setName('Line Description {day} {day_name} {month} {year}');
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
@@ -355,7 +355,7 @@ final class InvoiceManagerTest extends KernelTestCase
 
         self::assertCount(1, $invoiceLine[0]->getTaxes());
         self::assertSame('VAT', $invoiceLine[0]->getTaxes()->first()->getNameSnapshot());
-        self::assertSame('Line Description 15 Monday January 2024', $invoiceLine[0]->getDescription());
+        self::assertSame('Line Description 15 Monday January 2024', $invoiceLine[0]->getName());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidInvoice\InvoiceBundle\Tests\Manager;
 
+use Brick\Math\Exception\MathException;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use DateTimeImmutable;
@@ -23,6 +24,7 @@ use Mockery as M;
 use Money\Currency;
 use Psr\Clock\ClockInterface;
 use SolidInvoice\ClientBundle\Entity\Client;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Entity\Discount;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator;
@@ -54,6 +56,8 @@ use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Component\Workflow\Transition;
+use function mb_strlen;
+use function str_repeat;
 
 final class InvoiceManagerTest extends KernelTestCase
 {
@@ -69,7 +73,7 @@ final class InvoiceManagerTest extends KernelTestCase
     /**
      * @param list<Transition> $transitions
      */
-    private function buildManager(array $transitions): InvoiceManager
+    private function buildManager(array $transitions, string $now = '2024-01-15 10:30:00'): InvoiceManager
     {
         $entityManager = M::mock(EntityManagerInterface::class);
         $doctrine = M::mock(ManagerRegistry::class, ['getManager' => $entityManager]);
@@ -94,7 +98,7 @@ final class InvoiceManagerTest extends KernelTestCase
 
         $clock = $this->createStub(ClockInterface::class);
         $clock->method('now')
-            ->willReturn(CarbonImmutable::parse('2024-01-15 10:30:00'));
+            ->willReturn(CarbonImmutable::parse($now));
 
         $manager = new InvoiceManager(
             $doctrine,
@@ -359,6 +363,43 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
+    }
+
+    /**
+     * Expanding a token makes the name longer — `{month}` is seven characters and September
+     * is nine — so a name that fitted VARCHAR(255) can stop fitting it. Nothing validates a
+     * generated invoice, so an over-long name would reach the column and fail the flush; on
+     * MySQL in production, not on the SQLite the suite runs against.
+     *
+     * @throws MathException
+     */
+    public function testAGeneratedNameIsCutToFitItsColumn(): void
+    {
+        // September, because that is when `{month}` expands to more than it replaces.
+        $manager = $this->buildManager([new Transition('new', 'new', 'draft')], '2024-09-15 10:30:00');
+
+        $client = new Client();
+        $client->setName('Test Client');
+        $client->setCurrencyCode('USD');
+
+        $line = new RecurringInvoiceLine();
+        // Exactly the column width before expansion, and two characters over it after.
+        $line->setName(str_repeat('a', LineName::MAX_LENGTH - mb_strlen('{month}')) . '{month}');
+        $line->setPrice(100);
+        $line->setQty(1);
+        $line->setTotal(100);
+
+        $recurringInvoice = new RecurringInvoice();
+        $recurringInvoice->setClient($client);
+        $recurringInvoice->setCompany(new Company());
+        $recurringInvoice->addLine($line);
+
+        $generated = $manager->createFromRecurring($recurringInvoice)->getLines()->first();
+
+        self::assertInstanceOf(InvoiceLine::class, $generated);
+        self::assertSame(LineName::MAX_LENGTH, mb_strlen($generated->getName()));
+        self::assertStringEndsWith('…', $generated->getName());
+        self::assertStringStartsWith(str_repeat('a', 100), $generated->getName());
     }
 
     public function testCreateThrowsInvalidTransitionExceptionWhenTransitionNotAllowed(): void

--- a/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Twig/Components/CreateInvoiceTest.php
@@ -166,7 +166,7 @@ final class CreateInvoiceTest extends LiveComponentTest
 
         // Build a persisted Pending invoice (accept transition already applied).
         $line = new Line()
-            ->setDescription('Consulting')
+            ->setName('Consulting')
             ->setPrice(10000)
             ->setQty(1);
 
@@ -284,8 +284,8 @@ final class CreateInvoiceTest extends LiveComponentTest
         $invoice->setInvoiceDate(CarbonImmutable::parse('2024-01-15'));
         $invoice->addUser($contact);
 
-        foreach (['First', 'Second', 'Third'] as $description) {
-            $invoice->addLine(new Line()->setDescription($description)->setPrice(10000)->setQty(1));
+        foreach (['First', 'Second', 'Third'] as $name) {
+            $invoice->addLine(new Line()->setName($name)->setPrice(10000)->setQty(1));
         }
 
         $em->persist($invoice);
@@ -315,7 +315,7 @@ final class CreateInvoiceTest extends LiveComponentTest
         self::assertSame(
             ['Third', 'First', 'Second'],
             $refreshed->getLines()
-                ->map(static fn (Line $line): ?string => $line->getDescription())
+                ->map(static fn (Line $line): string => $line->getName())
                 ->toArray(),
         );
         self::assertSame([0, 1, 2], $refreshed->getLines()->map(static fn (Line $line): int => $line->getPosition())->toArray());

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
@@ -103,7 +103,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                 <div class="column-total">Total</div>
@@ -112,12 +112,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>
@@ -146,12 +146,12 @@
                                 </div>
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="invoice_lines_1_name" name="invoice[lines][1][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="invoice_lines_1_name" name="invoice[lines][1][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="invoice_lines_1_description" name="invoice[lines][1][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="invoice_lines_1_description" name="invoice[lines][1][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1"},{"description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"},{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -113,8 +113,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>
@@ -142,8 +147,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="invoice_lines_1_description" name="invoice[lines][1][description]" class="input-medium invoice-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="invoice_lines_1_name" name="invoice[lines][1][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="invoice_lines_1_description" name="invoice[lines][1][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
@@ -144,7 +144,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                 <div class="column-total">Total</div>
@@ -153,12 +153,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -154,8 +154,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -114,8 +114,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
@@ -103,7 +103,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                     <div class="column-tax">Tax</div>
@@ -113,12 +113,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="invoice_lines_0_name" name="invoice[lines][0][name]" class="input-medium invoice-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="invoice_lines_0_description" name="invoice[lines][0][description]" class="input-medium invoice-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/McpBundle/Mcp/Tool/EntityNormalizer.php
+++ b/src/McpBundle/Mcp/Tool/EntityNormalizer.php
@@ -183,6 +183,7 @@ final class EntityNormalizer
         foreach ($lines as $line) {
             $result[] = [
                 'id' => $line->getId()->toRfc4122(),
+                'name' => $line->getName(),
                 'description' => $line->getDescription(),
                 'price' => $this->bigNumber($line->getPrice()),
                 'qty' => $this->bigNumber($line->getQty()),

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\McpBundle\Mcp\Tool;
 use Brick\Math\BigDecimal;
 use Doctrine\ORM\EntityManagerInterface;
 use Mcp\Exception\ToolCallException;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Entity\Discount;
 use SolidInvoice\InvoiceBundle\Entity\Line as InvoiceLine;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
@@ -152,6 +153,19 @@ final readonly class LineItemBuilder
             }
 
             $line = $factory();
+
+            // A tool call is never validated, so an over-long name would reach VARCHAR(255)
+            // intact and blow up on flush. Anything that long is a description wearing the
+            // wrong label, so keep it as one and cut the name the way every other caller's
+            // name is cut.
+            if ($hasName && mb_strlen($name) > LineName::MAX_LENGTH) {
+                if (! $hasDescription) {
+                    $description = $name;
+                    $hasDescription = true;
+                }
+
+                $name = LineName::fromDescription($name);
+            }
 
             if ($hasName) {
                 $line->setName($name);

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -129,12 +129,18 @@ final readonly class LineItemBuilder
                 throw new ToolCallException(sprintf('Line item #%d must be an object.', $index));
             }
 
+            $name = $data['name'] ?? null;
             $description = $data['description'] ?? null;
             $price = $data['price'] ?? null;
             $qty = $data['qty'] ?? ($data['quantity'] ?? null);
 
-            if (! \is_string($description) || $description === '') {
-                throw new ToolCallException(sprintf('Line item #%d requires a non-empty "description".', $index));
+            $hasName = \is_string($name) && $name !== '';
+            $hasDescription = \is_string($description) && $description !== '';
+
+            // Either will do: a caller that predates the name still sends a description,
+            // and the line derives its name from it.
+            if (! $hasName && ! $hasDescription) {
+                throw new ToolCallException(sprintf('Line item #%d requires a non-empty "name".', $index));
             }
 
             if ($price === null) {
@@ -146,7 +152,14 @@ final readonly class LineItemBuilder
             }
 
             $line = $factory();
-            $line->setDescription($description);
+
+            if ($hasName) {
+                $line->setName($name);
+            }
+
+            if ($hasDescription) {
+                $line->setDescription($description);
+            }
 
             try {
                 $line->setPrice(BigDecimal::of($this->toExactString($price)));

--- a/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
+++ b/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
@@ -97,7 +97,7 @@ final class InvoiceCreateTest extends KernelTestCase
         self::assertInstanceOf(InvoiceWriteTools::class, $tool);
 
         $this->expectException(ToolCallException::class);
-        $this->expectExceptionMessageIsOrContains('description');
+        $this->expectExceptionMessageIsOrContains('name');
 
         $tool->createInvoice(
             $client->getId()

--- a/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
+++ b/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
@@ -104,6 +104,9 @@ final class InvoiceCreateTest extends KernelTestCase
         $line = $invoice->getLines()
             ->first();
 
+        // The exact value, not just a bounded one: a builder that cut the name its own way
+        // would still fit the column while disagreeing with every other caller.
+        self::assertSame(LineName::fromDescription($name), $line->getName());
         self::assertLessThanOrEqual(LineName::MAX_LENGTH, mb_strlen($line->getName()));
         self::assertSame($name, $line->getDescription());
     }

--- a/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
+++ b/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\McpBundle\Tests\Functional;
 use Mcp\Exception\ToolCallException;
 use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
@@ -70,6 +71,41 @@ final class InvoiceCreateTest extends KernelTestCase
         self::assertInstanceOf(Invoice::class, $invoice);
         self::assertSame($this->company->getId()->toRfc4122(), $invoice->getCompany()->getId()->toRfc4122());
         self::assertCount(2, $invoice->getLines());
+    }
+
+    /**
+     * A tool call goes to the database without passing a validator, so a name longer than
+     * the line's VARCHAR(255) would fail on flush. It is kept, as the description, and the
+     * name is cut to fit. SQLite ignores the column width, hence the explicit length check.
+     */
+    public function testAnOverLongLineNameIsKeptAsTheDescription(): void
+    {
+        $this->activateScopes([McpScope::Write->value]);
+
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $tool = self::getContainer()->get(InvoiceWriteTools::class);
+        self::assertInstanceOf(InvoiceWriteTools::class, $tool);
+
+        $name = str_repeat('An unreasonably verbose line item name. ', 10);
+
+        $result = $tool->createInvoice(
+            $client->getId()
+                ->toRfc4122(),
+            [['name' => $name, 'price' => 1000, 'qty' => 1]],
+        );
+
+        $invoice = self::getContainer()->get('doctrine')->getRepository(Invoice::class)->find(Ulid::fromString($result['id']));
+        self::assertInstanceOf(Invoice::class, $invoice);
+
+        $line = $invoice->getLines()
+            ->first();
+
+        self::assertLessThanOrEqual(LineName::MAX_LENGTH, mb_strlen($line->getName()));
+        self::assertSame($name, $line->getDescription());
     }
 
     public function testCreateInvoiceRequiresAtLeastOneLine(): void

--- a/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
+++ b/src/PaymentBundle/PaymentAction/PaypalExpress/CapturePaymentAction.php
@@ -82,7 +82,7 @@ class CapturePaymentAction implements ActionInterface, GatewayAwareInterface
             // keeps the item amounts summing to ITEMAMT — what PayPal actually validates.
             $isWholeUnits = $qty->getFractionalPart()->isZero();
 
-            $details['L_PAYMENTREQUEST_0_NAME' . $counter] = $item->getDescription();
+            $details['L_PAYMENTREQUEST_0_NAME' . $counter] = $item->getName();
             $details['L_PAYMENTREQUEST_0_AMT' . $counter] = number_format(
                 MoneyFormatter::toFloat($isWholeUnits ? $item->getPrice() : $item->getTotal()),
                 2

--- a/src/PaymentBundle/Resources/views/Payment/create.html.twig
+++ b/src/PaymentBundle/Resources/views/Payment/create.html.twig
@@ -113,7 +113,7 @@
                                 <div class="line-items-preview">
                                     {% for item in invoice.lines %}
                                         <div class="line-item-row">
-                                            <span class="line-item-desc">{{ item.description|striptags|u.truncate(40, '...') }}</span>
+                                            <span class="line-item-desc">{{ item.name|u.truncate(40, '...') }}</span>
                                             <span class="line-item-amount">{{ item.total|formatCurrency(invoice.client.currency) }}</span>
                                         </div>
                                     {% endfor %}

--- a/src/QuoteBundle/Cloner/QuoteCloner.php
+++ b/src/QuoteBundle/Cloner/QuoteCloner.php
@@ -84,6 +84,7 @@ final readonly class QuoteCloner
             $quoteLine = new Line();
             $quoteLine->setCreated($now);
             $quoteLine->setTotal($line->getTotal());
+            $quoteLine->setName($line->getName());
             $quoteLine->setDescription($line->getDescription());
             $quoteLine->setPrice($line->getPrice());
             $quoteLine->setQty($line->getQty());

--- a/src/QuoteBundle/DummyData/QuoteDummyDataLoader.php
+++ b/src/QuoteBundle/DummyData/QuoteDummyDataLoader.php
@@ -109,7 +109,7 @@ final readonly class QuoteDummyDataLoader implements DummyDataLoaderInterface
                     $qty = random_int(1, 10);
 
                     $line = new Line();
-                    $line->setDescription($this->faker->sentence(5))
+                    $line->setName($this->faker->sentence(5))
                         ->setPrice($price)
                         ->setQty($qty)
                         ->setCompany($company);

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -231,8 +231,22 @@ class Line implements LineInterface, Stringable
         return $this->id;
     }
 
+    /**
+     * An empty name with a description already set derives from it, the same way
+     * {@see self::setDescription()} does when the name is the field that is missing.
+     *
+     * Without that, `{"description": …, "name": ""}` and `{"name": "", "description": …}`
+     * would not mean the same thing: the serializer calls setters in payload key order, so
+     * the first would land on an empty name and be rejected while the second derived one.
+     * A name can never legitimately be cleared — it is `NotBlank` — so there is nothing lost
+     * in reading an empty one as "work it out from the description".
+     */
     public function setName(string $name): static
     {
+        if ($name === '' && ($this->description ?? '') !== '') {
+            $name = LineName::fromDescription($this->description);
+        }
+
         $this->name = $name;
 
         return $this;

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -31,6 +31,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use SolidInvoice\ApiBundle\Serializer\Normalizer\BigIntegerNormalizer;
 use SolidInvoice\ApiBundle\State\Processor\QuoteLinePersistProcessor;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
 use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
@@ -46,6 +47,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
+use function trim;
 
 #[ORM\Table(name: Line::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: LineRepository::class)]
@@ -135,8 +137,13 @@ class Line implements LineInterface, Stringable
     #[Groups(['quote_api:read'])]
     private ?Ulid $id = null;
 
-    #[ORM\Column(name: 'description', type: Types::TEXT)]
+    #[ORM\Column(name: 'name', type: Types::STRING, length: LineName::MAX_LENGTH, options: ['default' => ''])]
     #[Assert\NotBlank]
+    #[Assert\Length(max: LineName::MAX_LENGTH)]
+    #[Groups(['quote_api:read', 'quote_api:write'])]
+    private string $name = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
     #[Groups(['quote_api:read', 'quote_api:write'])]
     private ?string $description = null;
 
@@ -225,9 +232,41 @@ class Line implements LineInterface, Stringable
         return $this->id;
     }
 
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Deriving the name here, rather than in a lifecycle callback, is what keeps a caller
+     * that only sends a description valid: `name` is `NotBlank`, so it has to hold a value
+     * by the time the object is validated, which is long before it is persisted.
+     */
     public function setDescription(?string $description): static
     {
         $this->description = $description;
+
+        if ($this->name !== '' || ($description ?? '') === '') {
+            return $this;
+        }
+
+        $derived = LineName::fromDescription($description);
+
+        if ($derived === '') {
+            return $this;
+        }
+
+        $this->name = $derived;
+        // The description is dropped only when the name is all of it — whitespace aside.
+        // Anything longer stays, so nothing the caller wrote is lost.
+        $this->description = trim($description) === $derived ? null : $description;
 
         return $this;
     }
@@ -380,6 +419,6 @@ class Line implements LineInterface, Stringable
 
     public function __toString(): string
     {
-        return (string) $this->description;
+        return $this->name;
     }
 }

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -47,7 +47,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
-use function trim;
 
 #[ORM\Table(name: Line::TABLE_NAME)]
 #[ORM\Entity(repositoryClass: LineRepository::class)]
@@ -248,6 +247,12 @@ class Line implements LineInterface, Stringable
      * Deriving the name here, rather than in a lifecycle callback, is what keeps a caller
      * that only sends a description valid: `name` is `NotBlank`, so it has to hold a value
      * by the time the object is validated, which is long before it is persisted.
+     *
+     * The description itself is stored exactly as given, never cleared. The serializer
+     * calls setters in payload key order, so anything this setter does to another field
+     * would make `{"description": …, "name": …}` and `{"name": …, "description": …}`
+     * persist differently. Not printing the same text twice is the `line_description`
+     * macro's job, where it costs no data.
      */
     public function setDescription(?string $description): static
     {
@@ -259,14 +264,9 @@ class Line implements LineInterface, Stringable
 
         $derived = LineName::fromDescription($description);
 
-        if ($derived === '') {
-            return $this;
+        if ($derived !== '') {
+            $this->name = $derived;
         }
-
-        $this->name = $derived;
-        // The description is dropped only when the name is all of it — whitespace aside.
-        // Anything longer stays, so nothing the caller wrote is lost.
-        $this->description = trim($description) === $derived ? null : $description;
 
         return $this;
     }

--- a/src/QuoteBundle/Entity/Quote.php
+++ b/src/QuoteBundle/Entity/Quote.php
@@ -550,12 +550,14 @@ class Quote
     #[Groups(['searchable'])]
     public function getLineDescriptions(): array
     {
-        return array_values(
-            $this->lines
-                ->map(static fn (Line $line) => $line->getDescription())
-                ->filter(static fn (?string $d) => $d !== null && $d !== '')
-                ->toArray()
-        );
+        $text = [];
+
+        foreach ($this->lines as $line) {
+            $text[] = $line->getName();
+            $text[] = (string) $line->getDescription();
+        }
+
+        return array_values(array_filter($text, static fn (string $value) => $value !== ''));
     }
 
     public function setInvoice(Invoice $invoice): self

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -49,6 +49,10 @@ class ItemType extends AbstractType
             TextType::class,
             [
                 'empty_data' => '',
+                // Not required in the browser, so that a line with only a description still
+                // submits and derives its name from it, the same way the API does. The
+                // entity's NotBlank is what rejects a line with neither.
+                'required' => false,
                 'attr' => [
                     'class' => 'input-medium quote-item-name',
                 ],

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -41,12 +42,26 @@ class ItemType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        // Before `description`, so that a line submitted with only a description still gets
+        // a name out of it. See Line::setDescription().
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'empty_data' => '',
+                'attr' => [
+                    'class' => 'input-medium quote-item-name',
+                ],
+            ]
+        );
+
         $builder->add(
             'description',
             TextareaType::class,
             [
+                'required' => false,
                 'attr' => [
-                    'class' => 'input-medium quote-item-name',
+                    'class' => 'input-medium quote-item-description',
                 ],
             ]
         );

--- a/src/QuoteBundle/Mcp/QuoteWriteTools.php
+++ b/src/QuoteBundle/Mcp/QuoteWriteTools.php
@@ -66,7 +66,7 @@ final readonly class QuoteWriteTools
      * as a draft — use `apply_quote_transition` to send/accept/etc.
      *
      * @param string                          $client_id      Client ULID (must belong to the active company)
-     * @param list<array<string, mixed>>      $lines          Line items: [{description, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
+     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
      *                                                        Provide `taxes[]` for multi-tax lines (India GST, Quebec compound, etc.);
      *                                                        `tax_id` is the legacy single-tax shorthand.
      * @param string|null                     $due            ISO-8601 due date (optional)

--- a/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
+++ b/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
@@ -165,8 +165,13 @@
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">{{ 'quote.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.description, {attr: {placeholder: 'quote.item.description.placeholder'|trans, rows: 2}}) }}
-                                        {{ form_errors(item.description) }}
+                                        {{ form_widget(item.name, {attr: {placeholder: 'quote.item.name.placeholder'|trans}}) }}
+                                        {{ form_errors(item.name) }}
+                                        <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
+                                            <summary class="line-description-toggle">{{ 'quote.item.description.add'|trans }}</summary>
+                                            {{ form_widget(item.description, {attr: {placeholder: 'quote.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_errors(item.description) }}
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">{{ 'quote.item.heading.price'|trans }}</span>

--- a/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
+++ b/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
@@ -151,7 +151,7 @@
                         <div class="billing-items-list" {{ stimulus_controller('line-reorder') }}
                              {{ stimulus_action('line-reorder', 'keydown', 'keydown') }}>
                             <div class="billing-items-header-row">
-                                <div class="column-description">{{ 'quote.item.heading.description'|trans }}</div>
+                                <div class="column-description">{{ 'quote.item.heading.name'|trans }}</div>
                                 <div class="column-price">{{ 'quote.item.heading.price'|trans }}</div>
                                 <div class="column-qty">{{ 'quote.item.heading.qty'|trans }}</div>
                                 {% if this.hasTax %}
@@ -164,12 +164,12 @@
                             {% for index, item in form.lines %}
                                 <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">{{ 'quote.item.heading.description'|trans }}</span>
-                                        {{ form_widget(item.name, {attr: {placeholder: 'quote.item.name.placeholder'|trans}}) }}
+                                        <span class="mobile-label">{{ 'quote.item.heading.name'|trans }}</span>
+                                        {{ form_widget(item.name, {attr: {placeholder: 'quote.item.name.placeholder'|trans, 'aria-label': 'quote.item.name.label'|trans}}) }}
                                         {{ form_errors(item.name) }}
                                         <details class="line-description"{{ item.description.vars.value is not empty ? ' open' }}>
                                             <summary class="line-description-toggle">{{ 'quote.item.description.add'|trans }}</summary>
-                                            {{ form_widget(item.description, {attr: {placeholder: 'quote.item.description.placeholder'|trans, rows: 2}}) }}
+                                            {{ form_widget(item.description, {attr: {placeholder: 'quote.item.description.placeholder'|trans, rows: 2, 'aria-label': 'quote.item.description.label'|trans}}) }}
                                             {{ form_errors(item.description) }}
                                         </details>
                                     </div>

--- a/src/QuoteBundle/Resources/views/Default/view.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/view.html.twig
@@ -274,7 +274,7 @@
                         <tbody>
                             {% for item in quote.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'quote.item.heading.description'|trans }}">{{ item.name }}{{ q.line_description(item) }}</td>
+                                    <td class="column-description" data-label="{{ 'quote.item.heading.description'|trans }}">{{ item.name }}{{ q.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'quote.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'quote.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if quote.tax.positive %}

--- a/src/QuoteBundle/Resources/views/Default/view.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/view.html.twig
@@ -6,7 +6,6 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
-
 {% extends "@SolidInvoiceCore/Layout/default.html.twig" %}
 
 {% block page_title %}
@@ -14,6 +13,7 @@
 {% endblock page_title %}
 
 {% block content %}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
 {% set currency = quote.client.currency %}
 <div class="doc-view-page">
     {# ═══════════════════════════════════════════════════════════════════════
@@ -274,7 +274,7 @@
                         <tbody>
                             {% for item in quote.lines %}
                                 <tr>
-                                    <td class="column-description" data-label="{{ 'quote.item.heading.description'|trans }}">{{ item.description|nl2br }}</td>
+                                    <td class="column-description" data-label="{{ 'quote.item.heading.description'|trans }}">{{ item.name }}{{ q.line_description(item) }}</td>
                                     <td class="column-price" data-label="{{ 'quote.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
                                     <td class="column-qty" data-label="{{ 'quote.item.heading.qty'|trans }}">{{ item.qty }}</td>
                                     {% if quote.tax.positive %}

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -6,6 +6,7 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
 
 {% set currency = quote.client.currency %}
 
@@ -231,7 +232,7 @@
         {% for line in quote.lines %}
             <tr{% if loop.index is even %} style="background-color: #fafbfc;"{% endif %}>
                 <td class="col-description" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; vertical-align: top;">
-                    {{ line.description|nl2br }}
+                    {{ line.name }}{{ q.line_description(line) }}
                 </td>
                 <td class="col-price" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">
                     {{ line.price|formatCurrency(currency) }}

--- a/src/QuoteBundle/Resources/views/Templates/_macros.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/_macros.html.twig
@@ -236,6 +236,10 @@
  # line_description
  #
  # A line's description, under its name. A description is optional now that a line has a
- # name, so every view that renders a line needs the same "omit it when absent" rule.
+ # name, and a description that is only the name over again would print the same text
+ # twice, so every view that renders a line needs the same "omit it" rule.
+ #
+ # `inline` for the PDF and email templates, which have no stylesheet to reach; the in-app
+ # views pass false and take the Tabler utilities instead, so the text follows the theme.
  #}
-{% macro line_description(line) %}{% if line.description is not empty %}<div class="line-item-description" style="font-size: 0.85em; color: #64748b; margin-top: 3px;">{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}
+{% macro line_description(line, inline = true) %}{% if line.description is not empty and line.description|trim != line.name %}<div class="line-item-description{% if not inline %} text-secondary small{% endif %}"{% if inline %} style="font-size: 0.85em; color: #64748b; margin-top: 3px;"{% endif %}>{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}

--- a/src/QuoteBundle/Resources/views/Templates/_macros.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/_macros.html.twig
@@ -6,8 +6,9 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #
- # Shared macros for quote templates. Used by every template under
- # `Templates/{slug}/{pdf,email,preview}.html.twig` to keep markup consistent.
+ # Shared macros for the views that render a quote — every template under
+ # `Templates/{slug}/{pdf,email,preview}.html.twig`, plus the in-app and external
+ # views — to keep markup consistent.
  # Mirrors the invoice macros with quote semantics: no payments/balance and a
  # validity indicator instead of a due date.
  #}
@@ -230,3 +231,11 @@
         </div>
     {% endif %}
 {% endmacro %}
+
+{#
+ # line_description
+ #
+ # A line's description, under its name. A description is optional now that a line has a
+ # name, so every view that renders a line needs the same "omit it when absent" rule.
+ #}
+{% macro line_description(line) %}{% if line.description is not empty %}<div class="line-item-description" style="font-size: 0.85em; color: #64748b; margin-top: 3px;">{{ line.description|nl2br }}</div>{% endif %}{% endmacro %}

--- a/src/QuoteBundle/Resources/views/Templates/classic/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/classic/pdf.html.twig
@@ -55,7 +55,7 @@
     <tbody>
         {% for line in quote.lines %}
             <tr>
-                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/classic/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/classic/preview.html.twig
@@ -1,4 +1,6 @@
 {# Classic Professional preview — Bootstrap 5.3 / Tabler #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <div class="quote-template quote-template-classic">
@@ -39,7 +41,7 @@
                 <tbody>
                     {% for line in quote.lines %}
                         <tr>
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="text-end font-monospace">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end">{{ line.qty }}</td>
                             <td class="text-end font-monospace fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/compact/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/compact/pdf.html.twig
@@ -58,7 +58,7 @@
         {% for line in quote.lines %}
             <tr{% if loop.index0 is divisible by(2) %} style="background-color: #f8fafc;"{% endif %}>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: center; color: #64748b;">{{ loop.index }}</td>
-                <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.description|nl2br }}</td>
+                <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.name }}{{ q.line_description(line) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/compact/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/compact/preview.html.twig
@@ -1,4 +1,6 @@
 {# Compact Dense preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <div class="quote-template quote-template-compact">
@@ -49,7 +51,7 @@
                         {% for line in quote.lines %}
                             <tr>
                                 <td class="text-muted small">{{ loop.index }}</td>
-                                <td class="small">{{ line.description|nl2br }}</td>
+                                <td class="small">{{ line.name }}{{ q.line_description(line) }}</td>
                                 <td class="text-end font-monospace small">{{ line.qty }}</td>
                                 <td class="text-end font-monospace small">{{ line.price|formatCurrency(currency) }}</td>
                                 <td class="text-end font-monospace small fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/editorial/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/editorial/pdf.html.twig
@@ -49,7 +49,7 @@
     {% for line in quote.lines %}
         <tr>
             <td style="padding: 14px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; vertical-align: top;">
-                <em>{{ line.description|nl2br }}</em>
+                <em>{{ line.name }}</em>{{ q.line_description(line) }}
                 <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
             </td>
             <td style="padding: 14px 0; font-size: 13pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; text-align: right; vertical-align: top; width: 25%;">

--- a/src/QuoteBundle/Resources/views/Templates/editorial/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/editorial/preview.html.twig
@@ -1,4 +1,6 @@
 {# Editorial preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400;1,600&display=swap">
@@ -38,7 +40,7 @@
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #e8dcc4;">
                             <td>
-                                <em>{{ line.description|nl2br }}</em>
+                                <em>{{ line.name }}</em>{{ q.line_description(line) }}
                                 <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-5">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/friendly/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/friendly/pdf.html.twig
@@ -76,7 +76,7 @@
         <tbody>
             {% for line in quote.lines %}
                 <tr>
-                    <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.description|nl2br }}</td>
+                    <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.name }}{{ q.line_description(line) }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ line.qty }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
                 </tr>

--- a/src/QuoteBundle/Resources/views/Templates/friendly/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/friendly/preview.html.twig
@@ -1,4 +1,6 @@
 {# Freelancer Friendly preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 {% set primary = quote.users|first %}
 {% set greeting = primary is not empty and primary.firstName is not empty ? primary.firstName : quote.client.name %}
@@ -61,7 +63,7 @@
                 <tbody>
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #f1eada;">
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="text-end text-muted">{{ line.qty }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/Templates/modern/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/modern/pdf.html.twig
@@ -52,7 +52,7 @@
     <tbody>
         {% for line in quote.lines %}
             <tr>
-                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/modern/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/modern/preview.html.twig
@@ -1,4 +1,6 @@
 {# Modern Minimal preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <div class="quote-template quote-template-modern" style="background: #ffffff;">
@@ -46,7 +48,7 @@
                 <tbody>
                     {% for line in quote.lines %}
                         <tr class="border-bottom">
-                            <td class="py-3">{{ line.description|nl2br }}</td>
+                            <td class="py-3">{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="py-3 text-end">{{ line.qty }}</td>
                             <td class="py-3 text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="py-3 text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/monochrome/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/monochrome/pdf.html.twig
@@ -104,7 +104,7 @@
                             <tbody>
                                 {% for line in quote.lines %}
                                     <tr>
-                                        <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.description|nl2br }}</td>
+                                        <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.name }}{{ q.line_description(line) }}</td>
                                         <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
                                         <td style="padding: 12px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif; font-weight: bold;">{{ line.total|formatCurrency(currency) }}</td>
                                     </tr>

--- a/src/QuoteBundle/Resources/views/Templates/monochrome/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/monochrome/preview.html.twig
@@ -1,4 +1,6 @@
 {# Monochrome Luxury preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <div class="quote-template quote-template-monochrome" style="background: #0b0b0b; padding: 32px; border-radius: 8px;">
@@ -50,7 +52,7 @@
                 <tbody>
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #e0d8c8;">
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="text-muted text-end">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/Templates/photographer/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/photographer/pdf.html.twig
@@ -51,7 +51,7 @@
                 {% for line in quote.lines %}
                     <tr>
                         <td style="padding: 12px 0; font-size: 10pt; color: #2a2418; border-bottom: 1px solid #e8d7b8; vertical-align: top;">
-                            <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.description|nl2br }}</div>
+                            <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.name }}</div>{{ q.line_description(line) }}
                             <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                         </td>
                         <td style="padding: 12px 0; font-size: 12pt; color: #a2492b; border-bottom: 1px solid #e8d7b8; text-align: right; font-family: Georgia, serif; font-weight: bold; width: 28%;">

--- a/src/QuoteBundle/Resources/views/Templates/photographer/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/photographer/preview.html.twig
@@ -1,4 +1,6 @@
 {# Photographer preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap">
@@ -43,7 +45,7 @@
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #e8d7b8;">
                             <td>
-                                <div class="fs-5">{{ line.description|nl2br }}</div>
+                                <div class="fs-5">{{ line.name }}</div>{{ q.line_description(line) }}
                                 <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-4 fw-bold" style="color: #a2492b;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/studio/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/studio/pdf.html.twig
@@ -52,7 +52,7 @@
     <tbody>
         {% for line in quote.lines %}
             <tr>
-                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.description|nl2br }}</td>
+                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/Templates/studio/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/studio/preview.html.twig
@@ -1,4 +1,6 @@
 {# Studio / Agency preview #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
+
 {% set currency = quote.client.currency %}
 
 <div class="quote-template quote-template-studio">
@@ -48,7 +50,7 @@
                 <tbody>
                     {% for line in quote.lines %}
                         <tr>
-                            <td>{{ line.description|nl2br }}</td>
+                            <td>{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="text-end">{{ line.qty }}</td>
                             <td class="text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>

--- a/src/QuoteBundle/Resources/views/quote_template.html.twig
+++ b/src/QuoteBundle/Resources/views/quote_template.html.twig
@@ -6,6 +6,7 @@
  # This source file is subject to the MIT license that is bundled
  # with this source code in the file LICENSE.
  #}
+{% import '@SolidInvoiceQuote/Templates/_macros.html.twig' as q %}
 
 {% set currency = quote.client.currency %}
 
@@ -158,7 +159,7 @@
                                 <tbody>
                                     {% for item in quote.lines %}
                                         <tr>
-                                            <td class="item-description">{{ item.description|nl2br }}</td>
+                                            <td class="item-description">{{ item.name }}{{ q.line_description(item) }}</td>
                                             <td class="text-end item-amount">{{ item.price|formatCurrency(currency) }}</td>
                                             <td class="text-center">{{ item.qty }}</td>
                                             {% if quote.tax.positive %}

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
@@ -199,10 +199,11 @@ final class QuoteLineTest extends ApiTestCase
     }
 
     /**
-     * A one-line description is the whole name, so keeping it would print the same text
-     * twice on the invoice.
+     * A one-line description becomes the name in full, and is still stored. Not printing
+     * the same text twice is the `line_description` macro's job; the API keeps what it
+     * was sent.
      */
-    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    public function testASingleLineDescriptionBecomesTheNameAndIsKept(): void
     {
         $quote = QuoteFactory::createOne();
         $quoteId = $quote->getId()
@@ -215,7 +216,37 @@ final class QuoteLineTest extends ApiTestCase
         ]);
 
         self::assertSame('Website design', $result['name']);
-        self::assertNull($result['description']);
+        self::assertSame('Website design', $result['description']);
+    }
+
+    /**
+     * The serializer calls setters in payload key order, so a client that happens to
+     * serialise `description` first must not get a different line from one that does not.
+     */
+    public function testBothFieldsSurviveEitherKeyOrder(): void
+    {
+        $quote = QuoteFactory::createOne();
+        $quoteId = $quote->getId()
+            ->toString();
+
+        $descriptionFirst = $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
+            'description' => 'Consulting',
+            'name' => 'Widget',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        $nameFirst = $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
+            'name' => 'Widget',
+            'description' => 'Consulting',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Widget', $descriptionFirst['name']);
+        self::assertSame('Consulting', $descriptionFirst['description']);
+        self::assertSame($nameFirst['name'], $descriptionFirst['name']);
+        self::assertSame($nameFirst['description'], $descriptionFirst['description']);
     }
 
     /**

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
@@ -42,7 +42,7 @@ final class QuoteLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item 1',
+            'name' => 'Item 1',
             'price' => 1000,
             'qty' => 2.0,
         ];
@@ -51,7 +51,7 @@ final class QuoteLineTest extends ApiTestCase
 
         self::assertArrayHasKey('id', $result);
         self::assertTrue(Ulid::isValid($result['id'], Ulid::FORMAT_BASE_32));
-        self::assertSame('Item 1', $result['description']);
+        self::assertSame('Item 1', $result['name']);
         self::assertEquals(2.0, $result['qty']);
         self::assertArrayHasKey('total', $result);
     }
@@ -63,7 +63,7 @@ final class QuoteLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Test Item',
+            'name' => 'Test Item',
             'price' => 500,
             'qty' => 1.0,
         ];
@@ -73,7 +73,7 @@ final class QuoteLineTest extends ApiTestCase
 
         $data = $this->requestGet('/api/quotes/' . $quoteId . '/line/' . $lineId);
 
-        self::assertSame('Test Item', $data['description']);
+        self::assertSame('Test Item', $data['name']);
         self::assertSame($lineId, $data['id']);
         self::assertEquals(1.0, $data['qty']);
     }
@@ -85,7 +85,7 @@ final class QuoteLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Original Item',
+            'name' => 'Original Item',
             'price' => 300,
             'qty' => 1.0,
         ];
@@ -95,10 +95,10 @@ final class QuoteLineTest extends ApiTestCase
 
         $data = $this->requestPatch(
             '/api/quotes/' . $quoteId . '/line/' . $lineId,
-            ['description' => 'Updated Item']
+            ['name' => 'Updated Item']
         );
 
-        self::assertSame('Updated Item', $data['description']);
+        self::assertSame('Updated Item', $data['name']);
         self::assertSame($lineId, $data['id']);
     }
 
@@ -109,7 +109,7 @@ final class QuoteLineTest extends ApiTestCase
             ->toString();
 
         $lineData = [
-            'description' => 'Item To Delete',
+            'name' => 'Item To Delete',
             'price' => 100,
             'qty' => 1.0,
         ];
@@ -127,13 +127,13 @@ final class QuoteLineTest extends ApiTestCase
             ->toString();
 
         $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
-            'description' => 'Collection Item 1',
+            'name' => 'Collection Item 1',
             'price' => 100,
             'qty' => 1.0,
         ]);
 
         $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
-            'description' => 'Collection Item 2',
+            'name' => 'Collection Item 2',
             'price' => 200,
             'qty' => 2.0,
         ]);
@@ -176,6 +176,46 @@ final class QuoteLineTest extends ApiTestCase
         );
 
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * A client written before lines had a name sends only a description. It has to keep
+     * working, and the line it creates has to end up with a name all the same.
+     */
+    public function testCreateWithOnlyADescriptionDerivesTheName(): void
+    {
+        $quote = QuoteFactory::createOne();
+        $quoteId = $quote->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
+            'description' => "Website design\nIncluding two rounds of revisions.",
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertSame("Website design\nIncluding two rounds of revisions.", $result['description']);
+    }
+
+    /**
+     * A one-line description is the whole name, so keeping it would print the same text
+     * twice on the invoice.
+     */
+    public function testASingleLineDescriptionBecomesTheNameOutright(): void
+    {
+        $quote = QuoteFactory::createOne();
+        $quoteId = $quote->getId()
+            ->toString();
+
+        $result = $this->requestPost('/api/quotes/' . $quoteId . '/lines', [
+            'description' => 'Website design',
+            'price' => 1000,
+            'qty' => 1,
+        ]);
+
+        self::assertSame('Website design', $result['name']);
+        self::assertNull($result['description']);
     }
 
     /**

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
@@ -147,11 +147,13 @@ final class QuoteLineTest extends ApiTestCase
         // Both posts have to survive. Asserting only the collection's type let the second
         // post silently overwrite the first, because the response looked the same either way.
         self::assertSame(2, $data['totalItems']);
-        // Canonicalizing: the lines association carries no OrderBy, so collection order
-        // is unspecified. What matters here is that neither post replaced the other.
-        self::assertEqualsCanonicalizing(
+        // In the posted order, not canonicalized: the lines association carries an OrderBy
+        // on `position` now, so a posted line lands after the ones already there and the
+        // collection comes back in a specified order rather than whatever the database
+        // happened to return. Asserted on `name`, which is what these posts set.
+        self::assertSame(
             ['Collection Item 1', 'Collection Item 2'],
-            array_column($data['member'], 'description')
+            array_column($data['member'], 'name')
         );
     }
 

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
@@ -110,7 +110,7 @@ final class QuoteTest extends ApiTestCase
                 [
                     'price' => 100,
                     'qty' => 1,
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                 ],
             ],
         ];
@@ -128,10 +128,11 @@ final class QuoteTest extends ApiTestCase
             'due' => null,
             'lines' => [
                 [
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                     'price' => 100,
                     'qty' => 1,
                     'total' => 100,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -174,7 +175,7 @@ final class QuoteTest extends ApiTestCase
                 ->setValue(0),
             'lines' => [
                 new Line()
-                    ->setDescription('Test Item')
+                    ->setName('Test Item')
                     ->setQty(1)
                     ->setPrice(10000),
             ],
@@ -211,10 +212,11 @@ final class QuoteTest extends ApiTestCase
                         ->first()
                         ->getId()
                         ->toString(),
-                    'description' => 'Test Item',
+                    'name' => 'Test Item',
                     'price' => 100,
                     'qty' => 1,
                     'total' => 100,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -244,7 +246,7 @@ final class QuoteTest extends ApiTestCase
                 ->setValue(0),
             'lines' => [
                 new Line()
-                    ->setDescription('Test Item')
+                    ->setName('Test Item')
                     ->setQty(1)
                     ->setPrice(10000),
             ],
@@ -261,12 +263,12 @@ final class QuoteTest extends ApiTestCase
                     [
                         'price' => 10000,
                         'qty' => 1,
-                        'description' => 'Foo Item',
+                        'name' => 'Foo Item',
                     ],
                     [
                         'price' => 500,
                         'qty' => 5,
-                        'description' => 'Foo Items',
+                        'name' => 'Foo Items',
                     ],
                 ],
             ]
@@ -301,10 +303,11 @@ final class QuoteTest extends ApiTestCase
                         ->get(0)
                         ->getId()
                         ->toString(),
-                    'description' => 'Foo Item',
+                    'name' => 'Foo Item',
                     'price' => 10000,
                     'qty' => 1,
                     'total' => 10000,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 0,
                 ],
@@ -315,10 +318,11 @@ final class QuoteTest extends ApiTestCase
                         ->get(1)
                         ->getId()
                         ->toString(),
-                    'description' => 'Foo Items',
+                    'name' => 'Foo Items',
                     'price' => 500,
                     'qty' => 5,
                     'total' => 2500,
+                    'description' => null,
                     'taxes' => [],
                     'position' => 1,
                 ],

--- a/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -100,8 +100,8 @@ final class TemplatesRenderingTest extends KernelTestCase
             // PDF and preview render every line item, the client block and the
             // company logo — assert all surface so a regression that drops
             // `{% for line in quote.lines %}` or the logo block is caught.
-            'pdf' => $this->assertChannelContains($output, ['</html>', 'Sample line item', (string) $quote->getClient(), 'data:image/png;base64']),
-            'preview' => $this->assertChannelContains($output, ['Sample line item', (string) $quote->getClient(), 'data:image/png;base64']),
+            'pdf' => $this->assertChannelContains($output, ['</html>', 'Sample line item', 'Two rounds of revisions included.', (string) $quote->getClient(), 'data:image/png;base64']),
+            'preview' => $this->assertChannelContains($output, ['Sample line item', 'Two rounds of revisions included.', (string) $quote->getClient(), 'data:image/png;base64']),
             // Email is a summary addressed to the client (totals only, no
             // per-line breakdown or client block), so we verify the schema.org
             // payload + the displayed total instead.
@@ -169,7 +169,7 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureQuote(): Quote
+    private function createFixtureQuote(bool $withDescription = true): Quote
     {
         $this->seedCompanyLogo();
 
@@ -203,12 +203,47 @@ final class TemplatesRenderingTest extends KernelTestCase
                 ->setType(null),
             'lines' => [
                 new Line()
-                    ->setDescription('Sample line item')
+                    ->setName('Sample line item')
+                    ->setDescription($withDescription ? 'Two rounds of revisions included.' : null)
                     ->setPrice(BigInteger::of(75000))
                     ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
             ],
             'users' => [$contact],
         ]);
+    }
+
+    /**
+     * The description is optional, so the block that renders it has to disappear entirely
+     * for a line that has only a name — not leave an empty div under every item.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testTemplateOmitsAnEmptyDescription(string $slug, string $channel): void
+    {
+        $quote = $this->createFixtureQuote(withDescription: false);
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $output = $twig->render(
+            sprintf('@SolidInvoiceQuote/Templates/%s/%s.html.twig', $slug, $channel),
+            ['quote' => $quote]
+        );
+
+        self::assertStringContainsString('Sample line item', $output);
+        self::assertStringNotContainsString('line-item-description', $output);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function lineChannelProvider(): iterable
+    {
+        // Only the channels that render a line breakdown; email is a totals summary.
+        foreach (self::slugs() as $slug) {
+            foreach (['pdf', 'preview'] as $channel) {
+                yield sprintf('%s/%s', $slug, $channel) => [$slug, $channel];
+            }
+        }
     }
 }

--- a/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -169,7 +169,7 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureQuote(bool $withDescription = true): Quote
+    private function createFixtureQuote(?string $description = 'Two rounds of revisions included.'): Quote
     {
         $this->seedCompanyLogo();
 
@@ -204,7 +204,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             'lines' => [
                 new Line()
                     ->setName('Sample line item')
-                    ->setDescription($withDescription ? 'Two rounds of revisions included.' : null)
+                    ->setDescription($description)
                     ->setPrice(BigInteger::of(75000))
                     ->setQty(2)
                     ->setTotal(BigInteger::of(150000)),
@@ -220,7 +220,28 @@ final class TemplatesRenderingTest extends KernelTestCase
     #[DataProvider('lineChannelProvider')]
     public function testTemplateOmitsAnEmptyDescription(string $slug, string $channel): void
     {
-        $quote = $this->createFixtureQuote(withDescription: false);
+        $quote = $this->createFixtureQuote(null);
+
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        $output = $twig->render(
+            sprintf('@SolidInvoiceQuote/Templates/%s/%s.html.twig', $slug, $channel),
+            ['quote' => $quote]
+        );
+
+        self::assertStringContainsString('Sample line item', $output);
+        self::assertStringNotContainsString('line-item-description', $output);
+    }
+
+    /**
+     * A line whose description is the name over again — what a client that only knows about
+     * `description` produces — must print the text once, not twice.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testTemplateOmitsADescriptionThatRepeatsTheName(string $slug, string $channel): void
+    {
+        $quote = $this->createFixtureQuote('Sample line item');
 
         $twig = self::getContainer()->get('twig');
         self::assertInstanceOf(Environment::class, $twig);

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
@@ -95,7 +95,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                 <div class="column-total">Total</div>
@@ -104,12 +104,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>
@@ -138,12 +138,12 @@
                                 </div>
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="quote_lines_1_name" name="quote[lines][1][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="quote_lines_1_name" name="quote[lines][1][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="quote_lines_1_description" name="quote[lines][1][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="quote_lines_1_description" name="quote[lines][1][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1"},{"description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"},{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -105,8 +105,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>
@@ -134,8 +139,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="quote_lines_1_description" name="quote[lines][1][description]" class="input-medium quote-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="quote_lines_1_name" name="quote[lines][1][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="quote_lines_1_description" name="quote[lines][1][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
@@ -136,7 +136,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                 <div class="column-total">Total</div>
@@ -145,12 +145,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -146,8 +146,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -106,8 +106,13 @@
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
                                         <span class="mobile-label">Description</span>
-                                        <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-name form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
                                         
+                                        <details class="line-description">
+                                            <summary class="line-description-toggle">Add description</summary>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            
+                                        </details>
                                     </div>
                                     <div class="column-price">
                                         <span class="mobile-label">Price</span>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
@@ -95,7 +95,7 @@
                 <div class="billing-items-body">
                                                                                         <div class="billing-items-list" data-controller="line-reorder" data-action="keydown-&gt;line-reorder#keydown">
                             <div class="billing-items-header-row">
-                                <div class="column-description">Description</div>
+                                <div class="column-description">Item</div>
                                 <div class="column-price">Price</div>
                                 <div class="column-qty">Qty</div>
                                                                     <div class="column-tax">Tax</div>
@@ -105,12 +105,12 @@
 
                                                             <div class="billing-item-row" data-line-reorder-row>
                                     <div class="column-description">
-                                        <span class="mobile-label">Description</span>
-                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design">
+                                        <span class="mobile-label">Item</span>
+                                        <input type="text" id="quote_lines_0_name" name="quote[lines][0][name]" class="input-medium quote-item-name form-control" placeholder="e.g. Website design" aria-label="Item name">
                                         
                                         <details class="line-description">
                                             <summary class="line-description-toggle">Add description</summary>
-                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2"></textarea>
+                                            <textarea id="quote_lines_0_description" name="quote[lines][0][description]" class="input-medium quote-item-description form-control" placeholder="Describe the service or product..." rows="2" aria-label="Item description"></textarea>
                                             
                                         </details>
                                     </div>

--- a/src/SaasBundle/Templates/PreviewInvoiceFactory.php
+++ b/src/SaasBundle/Templates/PreviewInvoiceFactory.php
@@ -76,9 +76,9 @@ final readonly class PreviewInvoiceFactory
             ['Brand identity design', 120000, 1],
             ['Landing page implementation', 85000, 1],
             ['Consulting & support', 15000, 3],
-        ] as [$description, $price, $qty]) {
+        ] as [$name, $price, $qty]) {
             $line = new Line();
-            $line->setDescription($description);
+            $line->setName($name);
             $line->setPrice($price);
             $line->setQty($qty);
             $line->setTotal((int) ($price * $qty));

--- a/src/UserBundle/Onboarding/Manager/OnboardingManager.php
+++ b/src/UserBundle/Onboarding/Manager/OnboardingManager.php
@@ -215,9 +215,12 @@ final readonly class OnboardingManager
         $invoice->setInvoiceId('1');
         $invoice->setStatus(InvoiceStatus::Draft);
 
-        // Create a single line item
+        // Create a single line item. "Service Description" is a free-text area with no
+        // length limit, and this invoice is saved without ever being validated, so the
+        // text goes to the description — TEXT — and the line derives a name that fits
+        // its column instead of overflowing it on the last step of signup.
         $line = new Line();
-        $line->setName($data->invoiceDescription);
+        $line->setDescription($data->invoiceDescription);
 
         // Parse amount and create Money object
         $amount = BigNumber::of($data->invoiceAmount);

--- a/src/UserBundle/Onboarding/Manager/OnboardingManager.php
+++ b/src/UserBundle/Onboarding/Manager/OnboardingManager.php
@@ -217,7 +217,7 @@ final readonly class OnboardingManager
 
         // Create a single line item
         $line = new Line();
-        $line->setDescription($data->invoiceDescription);
+        $line->setName($data->invoiceDescription);
 
         // Parse amount and create Money object
         $amount = BigNumber::of($data->invoiceAmount);

--- a/src/UserBundle/Tests/Functional/OnboardingFlowTest.php
+++ b/src/UserBundle/Tests/Functional/OnboardingFlowTest.php
@@ -95,7 +95,7 @@ final class OnboardingFlowTest extends WebTestCase
         // Verify invoice was created
         $invoices = $this->em->getRepository(Invoice::class)->findBy(['company' => $user->getCompanies()->first()]);
         self::assertCount(1, $invoices);
-        self::assertSame('Website Design', $invoices[0]->getLines()->first()->getDescription());
+        self::assertSame('Website Design', $invoices[0]->getLines()->first()->getName());
     }
 
     public function testSkipClientStep(): void

--- a/src/UserBundle/Tests/Onboarding/Manager/OnboardingManagerTest.php
+++ b/src/UserBundle/Tests/Onboarding/Manager/OnboardingManagerTest.php
@@ -15,6 +15,7 @@ namespace SolidInvoice\UserBundle\Tests\Onboarding\Manager;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use SolidInvoice\ClientBundle\Repository\ClientRepository;
+use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Repository\CompanyRepository;
 use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
@@ -185,6 +186,39 @@ final class OnboardingManagerTest extends KernelTestCase
         $invoices = $this->invoiceRepository->findBy(['company' => $company]);
         self::assertCount(1, $invoices);
         self::assertSame('Test Service', $invoices[0]->getLines()->first()->getName());
+    }
+
+    /**
+     * "Service Description" is an unbounded textarea and this invoice is never validated,
+     * so a long answer has to fit the line's VARCHAR(255) name without being thrown away.
+     * The tests run on SQLite, which ignores the column width, so assert the length here —
+     * on MySQL the flush itself would fail.
+     */
+    public function testALongServiceDescriptionFitsTheLineName(): void
+    {
+        $user = $this->createUser('test-long-description@example.com');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $description = str_repeat('Consulting and advisory work, billed monthly. ', 10);
+
+        $data = new OnboardingData();
+        $data->companyName = 'Test Company';
+        $data->companyCurrency = 'USD';
+        $data->clientName = 'Test Client';
+        $data->clientEmail = 'client@example.com';
+        $data->invoiceDescription = $description;
+        $data->invoiceAmount = '1000.00';
+
+        $invoice = $this->manager->completeOnboarding($user, $data);
+
+        self::assertInstanceOf(Invoice::class, $invoice);
+
+        $line = $invoice->getLines()
+            ->first();
+
+        self::assertLessThanOrEqual(LineName::MAX_LENGTH, mb_strlen($line->getName()));
+        self::assertSame($description, $line->getDescription());
     }
 
     public function testCompleteOnboardingWithoutClientAndInvoice(): void

--- a/src/UserBundle/Tests/Onboarding/Manager/OnboardingManagerTest.php
+++ b/src/UserBundle/Tests/Onboarding/Manager/OnboardingManagerTest.php
@@ -184,7 +184,7 @@ final class OnboardingManagerTest extends KernelTestCase
         // Verify invoice was created
         $invoices = $this->invoiceRepository->findBy(['company' => $company]);
         self::assertCount(1, $invoices);
-        self::assertSame('Test Service', $invoices[0]->getLines()->first()->getDescription());
+        self::assertSame('Test Service', $invoices[0]->getLines()->first()->getName());
     }
 
     public function testCompleteOnboardingWithoutClientAndInvoice(): void

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -845,6 +845,7 @@ invoice:
     item:
         add: 'Add Item'
         description:
+            add: 'Add description'
             placeholder: 'Describe the service or product...'
         heading:
             description: Description
@@ -852,6 +853,8 @@ invoice:
             qty: Qty
             tax: Tax
             total: Total
+        name:
+            placeholder: 'e.g. Website design'
         number: 'Item %number%'
         reorder: 'Reorder item: drag it, or move it with the up and down arrow keys'
         remove: 'Remove Item'
@@ -1786,6 +1789,7 @@ quote:
     item:
         add: 'Add Item'
         description:
+            add: 'Add description'
             placeholder: 'Describe the service or product...'
         heading:
             description: Description
@@ -1793,6 +1797,8 @@ quote:
             qty: Qty
             tax: Tax
             total: Total
+        name:
+            placeholder: 'e.g. Website design'
         number: 'Item %number%'
         reorder: 'Reorder item: drag it, or move it with the up and down arrow keys'
         remove: 'Remove Item'

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -846,14 +846,17 @@ invoice:
         add: 'Add Item'
         description:
             add: 'Add description'
+            label: 'Item description'
             placeholder: 'Describe the service or product...'
         heading:
             description: Description
+            name: Item
             price: Price
             qty: Qty
             tax: Tax
             total: Total
         name:
+            label: 'Item name'
             placeholder: 'e.g. Website design'
         number: 'Item %number%'
         reorder: 'Reorder item: drag it, or move it with the up and down arrow keys'
@@ -1790,14 +1793,17 @@ quote:
         add: 'Add Item'
         description:
             add: 'Add description'
+            label: 'Item description'
             placeholder: 'Describe the service or product...'
         heading:
             description: Description
+            name: Item
             price: Price
             qty: Qty
             tax: Tax
             total: Total
         name:
+            label: 'Item name'
             placeholder: 'e.g. Website design'
         number: 'Item %number%'
         reorder: 'Reorder item: drag it, or move it with the up and down arrow keys'


### PR DESCRIPTION
Closes #2706.

Stacked PR 2 of the invoice line model work. **Base is `feature/2705-line-position`** (PR 1, line position — #2842), not `3.1.x` — review that one first. This branch is a single commit on top of it, so it reverts on its own.

## What changed

`Line` had one `description` (TEXT) doing two jobs. EN 16931 wants a name (BT-153) and a description (BT-154) separately, and a short name plus optional detail is what makes an invoice readable.

- **Entity + API** — `name` (VARCHAR 255, NOT NULL) on both `Line` entities and `LineInterface`, on the read/write groups. `description` becomes TEXT NULL and loses its `NotBlank`.
- **API back-compat** lives in `Line::setDescription()`: a line given a description but no name derives one from the description's first line. It has to happen during denormalisation rather than in a lifecycle callback — `name` is `NotBlank`, so it must hold a value by the time the payload is validated, long before persist. When the derived name turns out to be the whole description (whitespace aside), the description is nulled so the invoice doesn't print the same text twice. Every existing caller — cloners, MCP, onboarding, quote→invoice — keeps working through that one method.
- **Migration `Version30100_6`** adds the column, relaxes `description`, and backfills in `postUp()` paged at 500 rows. It restates the derivation rule rather than calling `LineName`, because a migration has to keep producing the result it produced the day it was written. No data loss: a description too long to be a name is truncated into `name` and left intact in `description`. `preDown()` restores a moved description before `down()` makes the column `NOT NULL` again.
- **Rendering** — a `line_description(line)` macro in each bundle's `_macros.html.twig`, called from all 40 render sites (8 templates × pdf/preview × 2 bundles, plus the in-app, external and `Pdf/` views). One definition instead of the same `{% if %}` forty times.
- **Editor** — the name is the primary input; the description sits behind a closed `<details>` disclosure that opens by itself when the line already has one. A one-line item still costs a single input, so the common case gains no step.
- `__toString()` prefers the name; search (`getLineDescriptions()`) covers both fields; PayPal's line-name field and the payment preview now use the name.

## Acceptance criteria

- [x] Lines have a `name` and an optional `description`.
- [x] The migration backfills `name` for every existing line with no data loss, verified against a fixture corpus.
- [x] The line editor keeps the simple case to a single field.
- [x] All 8 invoice templates render name and description, and omit the description cleanly when empty.
- [x] Existing API clients that post only `description` continue to work, with `name` derived.
- [x] Quotes get the same treatment as invoices.

## Verification

Run in a clean worktree off this branch:

- `bin/phpunit` — **2598 tests, 2583 passed, 15 skipped, 0 failures.**
- `bin/ecs check` — clean.
- `bin/phpstan analyse` — clean on every file this branch touches. Two remaining errors in `SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php` are pre-existing on `3.1.x` (verified by running PHPStan against that file on the mainline) and untouched here. Three now-stale baseline entries were removed; one of them was hiding a real defect — `str_replace` with int replacements in `InvoiceManager` — fixed rather than re-baselined.
- New tests: `LineNameTest` (6 derivation cases plus truncation, multi-byte and exact-width) and `LineNameMigrationTest` (the short/long/multi-line/blank fixture corpus the issue asks for, each asserting what happened to `description`, plus a 1200-row case proving the cursor advances past skipped rows, plus `preDown`).
- `TemplatesRenderingTest` in both bundles: the fixture line now carries both fields, so all 8 templates × pdf/preview assert both render; a new `testTemplateOmitsAnEmptyDescription` asserts the block disappears entirely for a line with only a name.
- API compatibility: `testCreateWithOnlyADescriptionDerivesTheName` and `testASingleLineDescriptionBecomesTheNameOutright` on all three line resources.
- Snapshots regenerated for the three Live Component tests.
- `bun run dev` compiles.

## Still needs a human

**Browser verification of the editor disclosure.** I verified the markup through the regenerated Live Component snapshots — one `<input>` per line for the name, with a closed `<details class="line-description">` wrapping the textarea — but did not drive a browser. Steps: create an invoice and confirm one input per line; click **+ Add description**, type, save; re-open and confirm the disclosure is open with the description intact; view the invoice and its PDF; repeat on a quote and a recurring invoice.

One deliberate omission: the line column header still reads "Description" (`invoice.item.heading.description`). Renaming the key churns every locale on Crowdin for a cosmetic gain, so I left it.

