### PR TITLE
Give invoice, recurring invoice and quote lines a unit of measure

### DIFF
--- a/assets/scss/components/_billing-form.scss
+++ b/assets/scss/components/_billing-form.scss
@@ -341,7 +341,7 @@
 
 .billing-items-header-row {
     display: grid;
-    grid-template-columns: minmax(0, 2.6fr) minmax(130px, 1.1fr) 56px minmax(140px, 0.9fr) minmax(60px, 0.4fr) 52px;
+    grid-template-columns: minmax(0, 2.6fr) minmax(130px, 1.1fr) 132px minmax(140px, 0.9fr) minmax(60px, 0.4fr) 52px;
     gap: var(--swp-space-2);
     padding: var(--swp-space-3);
     border-bottom: 1px solid var(--swp-border);
@@ -373,11 +373,11 @@
 .billing-items-list:not(:has(.column-tax)) {
 
     .billing-items-header-row {
-        grid-template-columns: minmax(0, 3.8fr) minmax(100px, 0.9fr) 56px minmax(60px, 0.4fr) 52px;
+        grid-template-columns: minmax(0, 3.8fr) minmax(100px, 0.9fr) 132px minmax(60px, 0.4fr) 52px;
     }
 
     .billing-item-row {
-        grid-template-columns: minmax(0, 3.8fr) minmax(100px, 0.9fr) 56px minmax(60px, 0.4fr) 52px;
+        grid-template-columns: minmax(0, 3.8fr) minmax(100px, 0.9fr) 132px minmax(60px, 0.4fr) 52px;
 
         @media (width <= 900px) {
             grid-template-columns: 1fr;
@@ -393,7 +393,7 @@
 
     .billing-items-header-row,
     .billing-item-row {
-        grid-template-columns: minmax(0, 3.2fr) minmax(130px, 1.1fr) 56px minmax(80px, 0.5fr) minmax(60px, 0.4fr) 52px;
+        grid-template-columns: minmax(0, 3.2fr) minmax(130px, 1.1fr) 132px minmax(80px, 0.5fr) minmax(60px, 0.4fr) 52px;
     }
 
     .billing-item-row {
@@ -405,7 +405,7 @@
 
 .billing-item-row {
     display: grid;
-    grid-template-columns: minmax(0, 2.6fr) minmax(130px, 1.1fr) 56px minmax(140px, 0.9fr) minmax(60px, 0.4fr) 52px;
+    grid-template-columns: minmax(0, 2.6fr) minmax(130px, 1.1fr) 132px minmax(140px, 0.9fr) minmax(60px, 0.4fr) 52px;
     gap: var(--swp-space-2);
     padding: var(--swp-space-3);
     border-bottom: 1px solid var(--swp-border-light);
@@ -505,6 +505,25 @@
 
         input {
             text-align: center;
+        }
+    }
+
+    // The quantity and its unit read as one value, so they sit on one line. The number keeps
+    // a fixed width — it is only ever a few digits — and the select takes what is left, since
+    // it is the side whose content ("hours", "m²") varies.
+    .qty-unit-group {
+        display: flex;
+        gap: var(--swp-space-1);
+
+        input {
+            flex: 0 0 52px;
+        }
+
+        select {
+            flex: 1 1 auto;
+            min-width: 0;
+            padding-right: var(--swp-space-4);
+            font-size: var(--swp-text-xs);
         }
     }
 

--- a/assets/scss/components/_billing-form.scss
+++ b/assets/scss/components/_billing-form.scss
@@ -511,6 +511,7 @@
     // The quantity and its unit read as one value, so they sit on one line. The number keeps
     // a fixed width — it is only ever a few digits — and the select takes what is left, since
     // it is the side whose content ("hours", "m²") varies.
+
     .qty-unit-group {
         display: flex;
         gap: var(--swp-space-1);

--- a/migrations/Version30100_7.php
+++ b/migrations/Version30100_7.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
+
+/**
+ * `Version30100_6` belongs to PR 2 of the same stack (GH #2706), which this branch is based on.
+ */
+final class Version30100_7 extends AbstractMigration
+{
+    /**
+     * Both line tables. `invoice_lines` carries recurring invoice lines too — it is a
+     * single-table hierarchy — so two of the three collections are covered by one column.
+     */
+    private const array TABLES = ['invoice_lines', 'quote_lines'];
+
+    public function getDescription(): string
+    {
+        return 'Give invoice, recurring invoice and quote lines a unit of measure, defaulting to UN/ECE C62 (unit)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TABLES as $tableName) {
+            $table = $schema->getTable($tableName);
+
+            if (! $table->hasColumn('unit_code')) {
+                // No backfill pass: the column default is what every existing row gets, and
+                // C62 renders as nothing, so an existing invoice looks exactly as it did.
+                $table->addColumn('unit_code', Types::STRING, [
+                    'length' => 3,
+                    'notnull' => true,
+                    'default' => UnitCode::UNIT->value,
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TABLES as $tableName) {
+            $table = $schema->getTable($tableName);
+
+            if ($table->hasColumn('unit_code')) {
+                $table->dropColumn('unit_code');
+            }
+        }
+    }
+}

--- a/migrations/Version30100_7.php
+++ b/migrations/Version30100_7.php
@@ -16,7 +16,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
-use SolidInvoice\CoreBundle\Enum\UnitCode;
 
 /**
  * `Version30100_6` belongs to PR 2 of the same stack (GH #2706), which this branch is based on.
@@ -42,10 +41,14 @@ final class Version30100_7 extends AbstractMigration
             if (! $table->hasColumn('unit_code')) {
                 // No backfill pass: the column default is what every existing row gets, and
                 // C62 renders as nothing, so an existing invoice looks exactly as it did.
+                //
+                // Spelled out rather than read off UnitCode, because a migration has to keep
+                // replaying after the enum is renamed, moved or dropped. C62 is the UN/ECE
+                // code for "one", which is not a value that can change under us.
                 $table->addColumn('unit_code', Types::STRING, [
                     'length' => 3,
                     'notnull' => true,
-                    'default' => UnitCode::UNIT->value,
+                    'default' => 'C62',
                 ]);
             }
         }

--- a/src/CoreBundle/Entity/LineInterface.php
+++ b/src/CoreBundle/Entity/LineInterface.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\CoreBundle\Entity;
 use const PHP_INT_MAX;
 use Brick\Math\BigNumber;
 use Doctrine\Common\Collections\Collection;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\TaxBundle\Entity\LineTax;
 use Symfony\Component\Uid\Ulid;
 
@@ -60,6 +61,13 @@ interface LineInterface
     public function setQty(BigNumber | int | string $qty): self;
 
     public function getQty(): BigNumber;
+
+    public function setUnitCode(UnitCode $unitCode): self;
+
+    /**
+     * What {@see self::getQty()} is counted in. {@see UnitCode::UNIT} unless a line says otherwise.
+     */
+    public function getUnitCode(): UnitCode;
 
     public function setTotal(BigNumber | int | string $total): self;
 

--- a/src/CoreBundle/Enum/UnitCode.php
+++ b/src/CoreBundle/Enum/UnitCode.php
@@ -46,12 +46,27 @@ enum UnitCode: string implements TranslatableInterface
     case LITRE = 'LTR';
 
     /**
-     * Reads as the suffix after a quantity — "12 hours", "40 kg" — because that is where it
-     * is shown, and a line editor offering "hours" rather than "Hour" loses nothing.
+     * How the unit reads in a list — the line editor's dropdown, which offers "hours" rather
+     * than "Hour" because that is how it reads after a quantity.
+     *
+     * The plural form, which is what a list wants: the entry names the unit, not one of
+     * anything. {@see forQuantity()} is the one that has to agree with a number.
      */
     #[Override]
     public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
-        return $translator->trans('line.unit.' . $this->value, locale: $locale);
+        return $this->forQuantity($translator, 2, $locale);
+    }
+
+    /**
+     * The unit as it reads after a given quantity — "1 hour", "12 hours", "40 kg".
+     *
+     * Takes the quantity, because an invoice billing a single hour has to say "1 hour" and
+     * not "1 hours". The units written as symbols do not inflect, and their messages carry
+     * no plural form for the translator to choose between.
+     */
+    public function forQuantity(TranslatorInterface $translator, float $quantity, ?string $locale = null): string
+    {
+        return $translator->trans('line.unit.' . $this->value, ['%count%' => $quantity], locale: $locale);
     }
 }

--- a/src/CoreBundle/Enum/UnitCode.php
+++ b/src/CoreBundle/Enum/UnitCode.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Enum;
+
+use Override;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * What a line bills its quantity in, as a UN/ECE Recommendation 20 code.
+ *
+ * The codes are the standard's, not ours, because EN 16931 BT-130 accepts nothing else — so
+ * keying the enum on them means the e-invoicing mapping is already done.
+ *
+ * Recommendation 20 runs to some 1,800 codes. These are the ones an invoice is actually
+ * billed in; another one is a case here plus its `line.unit.*` translation. There is
+ * deliberately no free-text column to hold the rest: an unrecognised code would only be
+ * discovered when a tax authority rejected the e-invoice, which is too late to be useful.
+ *
+ * Case order is the order the line editor offers them in.
+ */
+enum UnitCode: string implements TranslatableInterface
+{
+    case UNIT = 'C62';
+    case HOUR = 'HUR';
+    case DAY = 'DAY';
+    case MONTH = 'MON';
+    case YEAR = 'ANN';
+    case SERVICE = 'E48';
+    case KILOGRAM = 'KGM';
+    case TONNE = 'TNE';
+    case METRE = 'MTR';
+    case SQUARE_METRE = 'MTK';
+    case CUBIC_METRE = 'MTQ';
+    case LITRE = 'LTR';
+
+    /**
+     * Reads as the suffix after a quantity — "12 hours", "40 kg" — because that is where it
+     * is shown, and a line editor offering "hours" rather than "Hour" loses nothing.
+     */
+    #[Override]
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('line.unit.' . $this->value, locale: $locale);
+    }
+}

--- a/src/CoreBundle/Tests/Twig/Extension/BillingExtensionTest.php
+++ b/src/CoreBundle/Tests/Twig/Extension/BillingExtensionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Twig\Extension;
+
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
+use SolidInvoice\CoreBundle\Form\FieldRenderer;
+use SolidInvoice\CoreBundle\Twig\Extension\BillingExtension;
+use SolidInvoice\InvoiceBundle\Entity\Line;
+use SolidInvoice\MoneyBundle\Calculator;
+use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\Translator;
+use function dirname;
+use function sprintf;
+
+#[CoversClass(BillingExtension::class)]
+#[CoversClass(UnitCode::class)]
+final class BillingExtensionTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{UnitCode, string, string}>
+     */
+    public static function quantityProvider(): iterable
+    {
+        yield 'bare number for a plain unit' => [UnitCode::UNIT, '2', '2'];
+        yield 'unit appended' => [UnitCode::HOUR, '12', '12 hours'];
+        yield 'symbol appended' => [UnitCode::SQUARE_METRE, '40.5', '40.5 m²'];
+    }
+
+    #[DataProvider('quantityProvider')]
+    public function testQuantity(UnitCode $unitCode, string $qty, string $expected): void
+    {
+        $line = new Line()
+            ->setQty(BigDecimal::of($qty))
+            ->setUnitCode($unitCode);
+
+        self::assertSame($expected, $this->createExtension()->quantity($line));
+    }
+
+    public function testEveryUnitCodeHasALabel(): void
+    {
+        // The label is what an invoice prints, so a case added without one would silently
+        // render its own translation key next to the quantity.
+        $translator = $this->createTranslator();
+
+        foreach (UnitCode::cases() as $unitCode) {
+            $key = 'line.unit.' . $unitCode->value;
+
+            self::assertNotSame($key, $unitCode->trans($translator), sprintf('%s has no label', $unitCode->name));
+        }
+    }
+
+    private function createExtension(): BillingExtension
+    {
+        return new BillingExtension(
+            $this->createStub(FieldRenderer::class),
+            new Calculator(),
+            $this->createTranslator(),
+        );
+    }
+
+    private function createTranslator(): Translator
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('yaml', new YamlFileLoader());
+        // The real catalogue, so a case added without a label fails testEveryUnitCodeHasALabel.
+        $translator->addResource('yaml', dirname(__DIR__, 5) . '/translations/messages.en.yml', 'en');
+
+        return $translator;
+    }
+}

--- a/src/CoreBundle/Tests/Twig/Extension/BillingExtensionTest.php
+++ b/src/CoreBundle/Tests/Twig/Extension/BillingExtensionTest.php
@@ -38,7 +38,11 @@ final class BillingExtensionTest extends TestCase
     {
         yield 'bare number for a plain unit' => [UnitCode::UNIT, '2', '2'];
         yield 'unit appended' => [UnitCode::HOUR, '12', '12 hours'];
+        yield 'one of a countable unit is singular' => [UnitCode::HOUR, '1', '1 hour'];
+        yield 'a fraction is not one' => [UnitCode::HOUR, '0.5', '0.5 hours'];
+        yield 'none of a countable unit is plural' => [UnitCode::DAY, '0', '0 days'];
         yield 'symbol appended' => [UnitCode::SQUARE_METRE, '40.5', '40.5 m²'];
+        yield 'a symbol does not inflect' => [UnitCode::SQUARE_METRE, '1', '1 m²'];
     }
 
     #[DataProvider('quantityProvider')]
@@ -61,7 +65,19 @@ final class BillingExtensionTest extends TestCase
             $key = 'line.unit.' . $unitCode->value;
 
             self::assertNotSame($key, $unitCode->trans($translator), sprintf('%s has no label', $unitCode->name));
+            // A message left as `hour|hours` would otherwise reach an invoice verbatim.
+            self::assertStringNotContainsString('|', $unitCode->trans($translator), $unitCode->name);
+            self::assertStringNotContainsString('|', $unitCode->forQuantity($translator, 1), $unitCode->name);
         }
+    }
+
+    /**
+     * The dropdown names the unit rather than one of anything, so it takes the plural form
+     * whatever the line it sits on is billing.
+     */
+    public function testTheListLabelIsAlwaysThePlural(): void
+    {
+        self::assertSame('hours', UnitCode::HOUR->trans($this->createTranslator()));
     }
 
     private function createExtension(): BillingExtension

--- a/src/CoreBundle/Twig/Extension/BillingExtension.php
+++ b/src/CoreBundle/Twig/Extension/BillingExtension.php
@@ -50,7 +50,7 @@ final class BillingExtension extends AbstractExtension
     }
 
     /**
-     * A line's quantity with its unit of measure after it — "12 hours", "40 kg".
+     * A line's quantity with its unit of measure after it — "1 hour", "12 hours", "40 kg".
      *
      * {@see UnitCode::UNIT} renders as the bare number, which is what keeps the unit off the
      * invoices of everyone who never sets one instead of printing "2 units" on all of them.
@@ -63,6 +63,6 @@ final class BillingExtension extends AbstractExtension
             return (string) $line->getQty();
         }
 
-        return $line->getQty() . ' ' . $line->getUnitCode()->trans($this->translator);
+        return $line->getQty() . ' ' . $line->getUnitCode()->forQuantity($this->translator, $line->getQty()->toFloat());
     }
 }

--- a/src/CoreBundle/Twig/Extension/BillingExtension.php
+++ b/src/CoreBundle/Twig/Extension/BillingExtension.php
@@ -15,17 +15,24 @@ namespace SolidInvoice\CoreBundle\Twig\Extension;
 
 use Brick\Math\BigNumber;
 use Override;
+use SolidInvoice\CoreBundle\Entity\LineInterface;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Form\FieldRenderer;
 use SolidInvoice\MoneyBundle\Calculator;
 use Symfony\Component\Form\FormView;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @see \SolidInvoice\CoreBundle\Tests\Twig\Extension\BillingExtensionTest
+ */
 class BillingExtension extends AbstractExtension
 {
     public function __construct(
         private readonly FieldRenderer $fieldRenderer,
-        private readonly Calculator $calculator
+        private readonly Calculator $calculator,
+        private readonly TranslatorInterface $translator
     ) {
     }
 
@@ -38,6 +45,24 @@ class BillingExtension extends AbstractExtension
         return [
             new TwigFunction('billing_fields', fn (FormView $form) => $this->fieldRenderer->render($form, 'children[lines].vars[prototype]'), ['is_safe' => ['html']]),
             new TwigFunction('discount', fn ($entity): BigNumber => $this->calculator->calculateDiscount($entity)),
+            new TwigFunction('quantity', $this->quantity(...)),
         ];
+    }
+
+    /**
+     * A line's quantity with its unit of measure after it — "12 hours", "40 kg".
+     *
+     * {@see UnitCode::UNIT} renders as the bare number, which is what keeps the unit off the
+     * invoices of everyone who never sets one instead of printing "2 units" on all of them.
+     * Every template shows the quantity through here, so a unit needs no column of its own and
+     * no template has to decide whether to suppress it.
+     */
+    public function quantity(LineInterface $line): string
+    {
+        if ($line->getUnitCode() === UnitCode::UNIT) {
+            return (string) $line->getQty();
+        }
+
+        return $line->getQty() . ' ' . $line->getUnitCode()->trans($this->translator);
     }
 }

--- a/src/CoreBundle/Twig/Extension/BillingExtension.php
+++ b/src/CoreBundle/Twig/Extension/BillingExtension.php
@@ -27,7 +27,7 @@ use Twig\TwigFunction;
 /**
  * @see \SolidInvoice\CoreBundle\Tests\Twig\Extension\BillingExtensionTest
  */
-class BillingExtension extends AbstractExtension
+final class BillingExtension extends AbstractExtension
 {
     public function __construct(
         private readonly FieldRenderer $fieldRenderer,

--- a/src/InvoiceBundle/Cloner/InvoiceCloner.php
+++ b/src/InvoiceBundle/Cloner/InvoiceCloner.php
@@ -126,6 +126,7 @@ final readonly class InvoiceCloner
             $invoiceLine->setDescription($line->getDescription());
             $invoiceLine->setPrice($line->getPrice());
             $invoiceLine->setQty($line->getQty());
+            $invoiceLine->setUnitCode($line->getUnitCode());
 
             $invoiceLine->getTaxes()->clear();
             foreach ($line->getTaxes() as $sourceLineTax) {

--- a/src/InvoiceBundle/Entity/Line.php
+++ b/src/InvoiceBundle/Entity/Line.php
@@ -34,6 +34,7 @@ use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
 use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\InvoiceBundle\Enum\InvoiceLineType;
@@ -192,6 +193,15 @@ class Line implements LineInterface, Stringable
         ]
     )]
     protected BigNumber $qty;
+
+    /**
+     * Not nullable, so {@see UnitCode::UNIT} is what a line that never mentions a unit holds
+     * rather than something callers have to branch on. It renders as nothing, which is how
+     * every line that predates this column stays exactly as it was.
+     */
+    #[ORM\Column(name: 'unit_code', length: 3, enumType: UnitCode::class, options: ['default' => UnitCode::UNIT->value])]
+    #[Groups(['invoice_api:read', 'invoice_api:write', 'recurring_invoice_api:read', 'recurring_invoice_api:write'])]
+    protected UnitCode $unitCode = UnitCode::UNIT;
 
     #[ORM\ManyToOne(targetEntity: Invoice::class, inversedBy: 'lines')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
@@ -365,6 +375,18 @@ class Line implements LineInterface, Stringable
     public function getQty(): BigNumber
     {
         return $this->qty;
+    }
+
+    public function setUnitCode(UnitCode $unitCode): static
+    {
+        $this->unitCode = $unitCode;
+
+        return $this;
+    }
+
+    public function getUnitCode(): UnitCode
+    {
+        return $this->unitCode;
     }
 
     public function setInvoice(?Invoice $invoice): static

--- a/src/InvoiceBundle/Form/Type/ItemType.php
+++ b/src/InvoiceBundle/Form/Type/ItemType.php
@@ -16,11 +16,13 @@ namespace SolidInvoice\InvoiceBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -97,6 +99,21 @@ class ItemType extends AbstractType
         $builder->get('qty')
             ->resetViewTransformers()
             ->addViewTransformer(new QuantityTransformer());
+
+        $builder->add(
+            'unitCode',
+            EnumType::class,
+            [
+                'class' => UnitCode::class,
+                // There is always a unit, so no blank option — and a payload that leaves the
+                // field out (the API, an older client) means the default rather than null.
+                'placeholder' => false,
+                'empty_data' => UnitCode::UNIT,
+                'attr' => [
+                    'class' => 'input-mini invoice-item-unit',
+                ],
+            ]
+        );
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
+++ b/src/InvoiceBundle/Form/Type/RecurringInvoiceLineType.php
@@ -16,11 +16,13 @@ namespace SolidInvoice\InvoiceBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -97,6 +99,21 @@ class RecurringInvoiceLineType extends AbstractType
         $builder->get('qty')
             ->resetViewTransformers()
             ->addViewTransformer(new QuantityTransformer());
+
+        $builder->add(
+            'unitCode',
+            EnumType::class,
+            [
+                'class' => UnitCode::class,
+                // There is always a unit, so no blank option — and a payload that leaves the
+                // field out (the API, an older client) means the default rather than null.
+                'placeholder' => false,
+                'empty_data' => UnitCode::UNIT,
+                'attr' => [
+                    'class' => 'input-mini invoice-item-unit',
+                ],
+            ]
+        );
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/InvoiceBundle/Manager/InvoiceManager.php
+++ b/src/InvoiceBundle/Manager/InvoiceManager.php
@@ -150,6 +150,9 @@ class InvoiceManager
             $invoiceItem->setDescription($item->getDescription());
             $invoiceItem->setPrice($item->getPrice());
             $invoiceItem->setQty($item->getQty());
+            // A quantity without its unit is a different quantity: 40 of something billed in
+            // hours is not 40 of something billed in kilograms.
+            $invoiceItem->setUnitCode($item->getUnitCode());
 
             // Snapshot fresh LineTax rows so the new invoice owns its own tax history.
             $invoiceItem->getTaxes()->clear();

--- a/src/InvoiceBundle/Mcp/InvoiceWriteTools.php
+++ b/src/InvoiceBundle/Mcp/InvoiceWriteTools.php
@@ -76,8 +76,9 @@ final readonly class InvoiceWriteTools
      * `apply_invoice_transition` to move it through the workflow.
      *
      * @param string                          $client_id      Client ULID (must belong to the active company)
-     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
-     *                                                        Price is in the minor unit (e.g. cents). Provide `taxes[]` for multi-tax lines
+     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, unit_code?, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
+     *                                                        Price is in the minor unit (e.g. cents). `unit_code` is a UN/ECE Rec 20 code
+     *                                                        (C62 unit, HUR hour, DAY, MON, ANN, E48 service, KGM, TNE, MTR, MTK, MTQ, LTR); omitted means C62. Provide `taxes[]` for multi-tax lines
      *                                                        (India GST split, Quebec GST+QST compound); `tax_id` is the legacy single-tax shorthand.
      * @param string|null                     $invoice_date   ISO-8601 date (defaults to today)
      * @param string|null                     $due            ISO-8601 due date (optional)

--- a/src/InvoiceBundle/Mcp/RecurringInvoiceWriteTools.php
+++ b/src/InvoiceBundle/Mcp/RecurringInvoiceWriteTools.php
@@ -58,7 +58,9 @@ final readonly class RecurringInvoiceWriteTools
      * use `apply_recurring_transition` to activate it.
      *
      * @param string                          $client_id   Client ULID
-     * @param list<array<string, mixed>>      $lines       Line items: [{name, description?, price, qty, tax_id?}, ...]
+     * @param list<array<string, mixed>>      $lines       Line items: [{name, description?, price, qty, unit_code?, tax_id?}, ...].
+     *                                                        `unit_code` is a UN/ECE Rec 20 code (C62 unit, HUR hour, DAY, MON, ANN,
+     *                                                        E48 service, KGM, TNE, MTR, MTK, MTQ, LTR); omitted means C62.
      * @param string                          $date_start  ISO-8601 date the first invoice should be generated
      * @param array<string, mixed>            $schedule    {"type": "daily"|"weekly"|"monthly"|"yearly",
      *                                                     "end_type": "never"|"on"|"after" (default "never"),

--- a/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
@@ -192,6 +192,7 @@
                                             {{ form_widget(item.unitCode, {attr: {'aria-label': 'invoice.item.heading.unit'|trans}}) }}
                                         </div>
                                         {{ form_errors(item.qty) }}
+                                        {{ form_errors(item.unitCode) }}
                                     </div>
                                     {% if hasTax %}
                                         <div class="column-tax">

--- a/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateInvoice.html.twig
@@ -184,7 +184,13 @@
                                     </div>
                                     <div class="column-qty">
                                         <span class="mobile-label">{{ 'invoice.item.heading.qty'|trans }}</span>
-                                        {{ form_widget(item.qty) }}
+                                        {#- The unit sits beside the quantity rather than in a column of its
+                                            own: it is already set to "units", so a line that bills in units
+                                            needs nothing done to it. -#}
+                                        <div class="qty-unit-group">
+                                            {{ form_widget(item.qty) }}
+                                            {{ form_widget(item.unitCode, {attr: {'aria-label': 'invoice.item.heading.unit'|trans}}) }}
+                                        </div>
                                         {{ form_errors(item.qty) }}
                                     </div>
                                     {% if hasTax %}

--- a/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
@@ -109,7 +109,13 @@
                                     </div>
                                     <div class="column-qty">
                                         <span class="mobile-label">{{ 'invoice.item.heading.qty'|trans }}</span>
-                                        {{ form_widget(item.qty) }}
+                                        {#- The unit sits beside the quantity rather than in a column of its
+                                            own: it is already set to "units", so a line that bills in units
+                                            needs nothing done to it. -#}
+                                        <div class="qty-unit-group">
+                                            {{ form_widget(item.qty) }}
+                                            {{ form_widget(item.unitCode, {attr: {'aria-label': 'invoice.item.heading.unit'|trans}}) }}
+                                        </div>
                                         {{ form_errors(item.qty) }}
                                     </div>
                                     {% if hasTax %}

--- a/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Components/CreateRecurringInvoice.html.twig
@@ -117,6 +117,7 @@
                                             {{ form_widget(item.unitCode, {attr: {'aria-label': 'invoice.item.heading.unit'|trans}}) }}
                                         </div>
                                         {{ form_errors(item.qty) }}
+                                        {{ form_errors(item.unitCode) }}
                                     </div>
                                     {% if hasTax %}
                                         <div class="column-tax">

--- a/src/InvoiceBundle/Resources/views/Default/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view.html.twig
@@ -294,7 +294,7 @@
                                 <tr>
                                     <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
-                                    <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
+                                    <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ quantity(item) }}</td>
                                     {% if invoice.tax.positive %}
                                         <td class="column-tax" data-label="{{ 'invoice.item.heading.tax'|trans }}">
                                             {% for lineTax in item.taxes %}{{ lineTax.nameSnapshot }} ({{ lineTax.rateSnapshot }}%){% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
+++ b/src/InvoiceBundle/Resources/views/Default/view_recurring.html.twig
@@ -224,7 +224,7 @@
                                 <tr>
                                     <td class="column-description" data-label="{{ 'invoice.item.heading.description'|trans }}">{{ item.name }}{{ inv.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'invoice.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
-                                    <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ item.qty }}</td>
+                                    <td class="column-qty" data-label="{{ 'invoice.item.heading.qty'|trans }}">{{ quantity(item) }}</td>
                                     {% if invoice.tax.positive %}
                                         <td class="column-tax" data-label="{{ 'invoice.item.heading.tax'|trans }}">
                                             {% for lineTax in item.taxes %}{{ lineTax.nameSnapshot }} ({{ lineTax.rateSnapshot }}%){% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
+++ b/src/InvoiceBundle/Resources/views/Pdf/invoice.html.twig
@@ -247,7 +247,7 @@
                     {{ line.price|formatCurrency(currency) }}
                 </td>
                 <td class="col-qty" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">
-                    {{ line.qty }}
+                    {{ quantity(line) }}
                 </td>
                 {% if invoice.tax.positive %}
                     <td class="col-tax" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">

--- a/src/InvoiceBundle/Resources/views/Templates/classic/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/classic/pdf.html.twig
@@ -56,7 +56,7 @@
             <tr>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
-                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
+                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ quantity(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>
         {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/classic/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/classic/preview.html.twig
@@ -44,7 +44,7 @@
                         <tr>
                             <td>{{ line.name }}{{ inv.line_description(line) }}</td>
                             <td class="text-end font-monospace">{{ line.price|formatCurrency(currency) }}</td>
-                            <td class="text-end">{{ line.qty }}</td>
+                            <td class="text-end">{{ quantity(line) }}</td>
                             <td class="text-end font-monospace fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/compact/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/compact/pdf.html.twig
@@ -59,7 +59,7 @@
             <tr{% if loop.index0 is divisible by(2) %} style="background-color: #f8fafc;"{% endif %}>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: center; color: #64748b;">{{ loop.index }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.name }}{{ inv.line_description(line) }}</td>
-                <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
+                <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ quantity(line) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/compact/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/compact/preview.html.twig
@@ -53,7 +53,7 @@
                             <tr>
                                 <td class="text-muted small">{{ loop.index }}</td>
                                 <td class="small">{{ line.name }}{{ inv.line_description(line) }}</td>
-                                <td class="text-end font-monospace small">{{ line.qty }}</td>
+                                <td class="text-end font-monospace small">{{ quantity(line) }}</td>
                                 <td class="text-end font-monospace small">{{ line.price|formatCurrency(currency) }}</td>
                                 <td class="text-end font-monospace small fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                             </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/editorial/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/editorial/pdf.html.twig
@@ -44,7 +44,7 @@
         <tr>
             <td style="padding: 14px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; vertical-align: top;">
                 <em>{{ line.name }}</em>{{ inv.line_description(line) }}
-                <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
             </td>
             <td style="padding: 14px 0; font-size: 13pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; text-align: right; vertical-align: top; width: 25%;">
                 {{ line.total|formatCurrency(currency) }}

--- a/src/InvoiceBundle/Resources/views/Templates/editorial/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/editorial/preview.html.twig
@@ -38,7 +38,7 @@
                         <tr style="border-bottom: 1px solid #e8dcc4;">
                             <td>
                                 <em>{{ line.name }}</em>{{ inv.line_description(line) }}
-                                <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                                <div class="text-muted small">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-5">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/friendly/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/friendly/pdf.html.twig
@@ -75,7 +75,7 @@
             {% for line in invoice.lines %}
                 <tr>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.name }}{{ inv.line_description(line) }}</td>
-                    <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ line.qty }}</td>
+                    <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ quantity(line) }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
                 </tr>
             {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/friendly/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/friendly/preview.html.twig
@@ -65,7 +65,7 @@
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #f1eada;">
                             <td>{{ line.name }}{{ inv.line_description(line) }}</td>
-                            <td class="text-end text-muted">{{ line.qty }}</td>
+                            <td class="text-end text-muted">{{ quantity(line) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/modern/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/modern/pdf.html.twig
@@ -53,7 +53,7 @@
         {% for line in invoice.lines %}
             <tr>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
-                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
+                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ quantity(line) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/modern/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/modern/preview.html.twig
@@ -50,7 +50,7 @@
                     {% for line in invoice.lines %}
                         <tr class="border-bottom">
                             <td class="py-3">{{ line.name }}{{ inv.line_description(line) }}</td>
-                            <td class="py-3 text-end">{{ line.qty }}</td>
+                            <td class="py-3 text-end">{{ quantity(line) }}</td>
                             <td class="py-3 text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="py-3 text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/monochrome/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/monochrome/pdf.html.twig
@@ -105,7 +105,7 @@
                                 {% for line in invoice.lines %}
                                     <tr>
                                         <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.name }}{{ inv.line_description(line) }}</td>
-                                        <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
+                                        <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</td>
                                         <td style="padding: 12px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif; font-weight: bold;">{{ line.total|formatCurrency(currency) }}</td>
                                     </tr>
                                 {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/monochrome/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/monochrome/preview.html.twig
@@ -50,7 +50,7 @@
                     {% for line in invoice.lines %}
                         <tr style="border-bottom: 1px solid #e0d8c8;">
                             <td>{{ line.name }}{{ inv.line_description(line) }}</td>
-                            <td class="text-muted text-end">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
+                            <td class="text-muted text-end">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/InvoiceBundle/Resources/views/Templates/photographer/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/photographer/pdf.html.twig
@@ -51,7 +51,7 @@
                     <tr>
                         <td style="padding: 12px 0; font-size: 10pt; color: #2a2418; border-bottom: 1px solid #e8d7b8; vertical-align: top;">
                             <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.name }}</div>{{ inv.line_description(line) }}
-                            <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                            <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                         </td>
                         <td style="padding: 12px 0; font-size: 12pt; color: #a2492b; border-bottom: 1px solid #e8d7b8; text-align: right; font-family: Georgia, serif; font-weight: bold; width: 28%;">
                             {{ line.total|formatCurrency(currency) }}

--- a/src/InvoiceBundle/Resources/views/Templates/photographer/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/photographer/preview.html.twig
@@ -42,7 +42,7 @@
                         <tr style="border-bottom: 1px solid #e8d7b8;">
                             <td>
                                 <div class="fs-5">{{ line.name }}</div>{{ inv.line_description(line) }}
-                                <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                                <div class="text-muted small">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-4 fw-bold" style="color: #a2492b;">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/studio/pdf.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/studio/pdf.html.twig
@@ -53,7 +53,7 @@
         {% for line in invoice.lines %}
             <tr>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ inv.line_description(line) }}</td>
-                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
+                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ quantity(line) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/InvoiceBundle/Resources/views/Templates/studio/preview.html.twig
+++ b/src/InvoiceBundle/Resources/views/Templates/studio/preview.html.twig
@@ -48,7 +48,7 @@
                     {% for line in invoice.lines %}
                         <tr>
                             <td>{{ line.name }}{{ inv.line_description(line) }}</td>
-                            <td class="text-end">{{ line.qty }}</td>
+                            <td class="text-end">{{ quantity(line) }}</td>
                             <td class="text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
+++ b/src/InvoiceBundle/Resources/views/external_invoice_view.html.twig
@@ -178,7 +178,7 @@
                                     <tr>
                                         <td class="item-description">{{ item.name }}{{ inv.line_description(item) }}</td>
                                         <td class="text-end item-amount">{{ item.price|formatCurrency(currency) }}</td>
-                                        <td class="text-center">{{ item.qty }}</td>
+                                        <td class="text-center">{{ quantity(item) }}</td>
                                         {% if invoice.tax.positive %}
                                             <td class="text-end item-amount">
                                                 {% for lineTax in item.taxes %}{{ lineTax.nameSnapshot }} ({{ lineTax.rateSnapshot }}%){% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/InvoiceBundle/Resources/views/invoice_template.html.twig
+++ b/src/InvoiceBundle/Resources/views/invoice_template.html.twig
@@ -133,7 +133,7 @@
                                         {{ item.price|formatCurrency(invoice.client.currency) }}
                                     </td>
                                     <td class="column-qty">
-                                        {{ item.qty }}
+                                        {{ quantity(item) }}
                                     </td>
                                     {% if invoice.tax.positive %}
                                         <td class="column-tax">

--- a/src/InvoiceBundle/Tests/Cloner/InvoiceClonerTest.php
+++ b/src/InvoiceBundle/Tests/Cloner/InvoiceClonerTest.php
@@ -21,6 +21,7 @@ use Mockery as M;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator\RandomNumberGenerator;
 use SolidInvoice\CronBundle\Enum\ScheduleEndType;
@@ -64,6 +65,7 @@ final class InvoiceClonerTest extends TestCase
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
+        $line->setUnitCode(UnitCode::HOUR);
         $line->setTotal(120 * 10);
 
         $invoice = new Invoice();
@@ -133,6 +135,7 @@ final class InvoiceClonerTest extends TestCase
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
+        self::assertSame(UnitCode::HOUR, $invoiceLine[0]->getUnitCode());
     }
 
     public function testCloneWithRecurring(): void
@@ -158,6 +161,7 @@ final class InvoiceClonerTest extends TestCase
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
+        $line->setUnitCode(UnitCode::HOUR);
         $line->setTotal(120 * 10);
 
         $invoice = new RecurringInvoice();
@@ -209,6 +213,7 @@ final class InvoiceClonerTest extends TestCase
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
+        self::assertSame(UnitCode::HOUR, $invoiceLine[0]->getUnitCode());
         self::assertSame($newInvoice->getDateStart(), $invoice->getDateStart());
         self::assertSame($newInvoice->getDateEnd(), $invoice->getDateEnd());
     }

--- a/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/InvoiceBundle/Tests/Form/Type/ItemTypeTest.php
@@ -16,6 +16,7 @@ namespace SolidInvoice\InvoiceBundle\Tests\Form\Type;
 use Brick\Math\BigDecimal;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Tests\FormTestCase;
 use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\InvoiceBundle\Form\Type\ItemType;
@@ -69,6 +70,24 @@ final class ItemTypeTest extends FormTestCase
         $object->setPrice(BigDecimal::of($price * 100));
 
         $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    public function testSubmitUnitOfMeasure(): void
+    {
+        $formData = [
+            'description' => 'Consulting',
+            'price' => 125,
+            'qty' => '12',
+            'unitCode' => UnitCode::HOUR->value,
+        ];
+
+        $object = new Line();
+        $object->setDescription('Consulting');
+        $object->setQty('12');
+        $object->setPrice(BigDecimal::of(12500));
+        $object->setUnitCode(UnitCode::HOUR);
+
+        $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => new Currency('USD')]), $formData, $object);
     }
 
     /**

--- a/src/InvoiceBundle/Tests/Form/Type/RecurringInvoiceLineTypeTest.php
+++ b/src/InvoiceBundle/Tests/Form/Type/RecurringInvoiceLineTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\InvoiceBundle\Tests\Form\Type;
+
+use Brick\Math\BigDecimal;
+use Money\Currency;
+use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
+use SolidInvoice\CoreBundle\Tests\FormTestCase;
+use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
+use SolidInvoice\InvoiceBundle\Form\Type\RecurringInvoiceLineType;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+
+/**
+ * The recurring line form is its own type rather than a reuse of {@see ItemTypeTest}'s, so
+ * a field added to one and forgotten on the other would otherwise go unnoticed until a
+ * recurring invoice was generated.
+ */
+final class RecurringInvoiceLineTypeTest extends FormTestCase
+{
+    /**
+     * The field has no blank option, so a payload that omits it — the API, a client that
+     * predates the field — has to mean the default rather than an error.
+     */
+    public function testSubmit(): void
+    {
+        $formData = [
+            'name' => 'Retainer',
+            'price' => 125,
+            'qty' => '1',
+        ];
+
+        $object = new RecurringInvoiceLine();
+        $object->setName('Retainer');
+        $object->setQty('1');
+        $object->setPrice(BigDecimal::of(12500));
+
+        self::assertSame(UnitCode::UNIT, $object->getUnitCode());
+
+        $this->assertFormData(
+            $this->factory->create(RecurringInvoiceLineType::class, null, ['currency' => new Currency('USD')]),
+            $formData,
+            $object
+        );
+    }
+
+    public function testSubmitUnitOfMeasure(): void
+    {
+        $formData = [
+            'name' => 'Retainer',
+            'price' => 125,
+            'qty' => '12',
+            'unitCode' => UnitCode::HOUR->value,
+        ];
+
+        $object = new RecurringInvoiceLine();
+        $object->setName('Retainer');
+        $object->setQty('12');
+        $object->setPrice(BigDecimal::of(12500));
+        $object->setUnitCode(UnitCode::HOUR);
+
+        $this->assertFormData(
+            $this->factory->create(RecurringInvoiceLineType::class, null, ['currency' => new Currency('USD')]),
+            $formData,
+            $object
+        );
+    }
+
+    /**
+     * @return array<FormExtensionInterface>
+     */
+    #[Override]
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([new RecurringInvoiceLineType($this->registry)], []),
+        ];
+    }
+}

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
@@ -21,6 +21,7 @@ use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Entity\Line;
@@ -138,6 +139,7 @@ final class InvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => $contacts,
@@ -222,6 +224,7 @@ final class InvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),
@@ -314,6 +317,7 @@ final class InvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceTest.php
@@ -112,6 +112,10 @@ final class InvoiceTest extends ApiTestCase
                     'price' => 100,
                     'qty' => 1,
                     'name' => 'Foo Item',
+                    // Deliberately not the default: the write group is only proven by a
+                    // value the entity would not have arrived at on its own. testGet and
+                    // testEdit cover the C62 a line gets when the field is left out.
+                    'unitCode' => UnitCode::HOUR->value,
                 ],
             ],
         ];
@@ -139,7 +143,7 @@ final class InvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
-                    'unitCode' => UnitCode::UNIT->value,
+                    'unitCode' => UnitCode::HOUR->value,
                 ],
             ],
             'users' => $contacts,

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceTest.php
@@ -21,6 +21,7 @@ use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\CronBundle\Enum\ScheduleEndType;
 use SolidInvoice\CronBundle\Enum\ScheduleRecurringType;
@@ -133,6 +134,7 @@ final class RecurringInvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => $contacts,
@@ -229,6 +231,7 @@ final class RecurringInvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),
@@ -324,6 +327,7 @@ final class RecurringInvoiceTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),

--- a/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Pdf\Generator;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
@@ -30,6 +31,7 @@ use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use SolidInvoice\InvoiceBundle\Twig\Extension\InvoiceTemplateExtension;
 use SolidInvoice\SettingsBundle\Entity\Setting;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 #[CoversClass(InvoiceTemplateExtension::class)]
@@ -80,14 +82,7 @@ final class TemplatesRenderingTest extends KernelTestCase
     public function testTemplateRenders(string $slug, string $channel): void
     {
         $invoice = $this->createFixtureInvoice();
-
-        $twig = self::getContainer()->get('twig');
-        self::assertInstanceOf(Environment::class, $twig);
-
-        $output = $twig->render(
-            sprintf('@SolidInvoiceInvoice/Templates/%s/%s.html.twig', $slug, $channel),
-            ['invoice' => $invoice]
-        );
+        $output = $this->renderTemplate($slug, $channel, $invoice);
 
         self::assertNotEmpty($output, sprintf('Template %s/%s produced empty output', $slug, $channel));
         self::assertStringContainsString($invoice->getInvoiceId(), $output);
@@ -126,14 +121,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             self::markTestSkipped('PDF generation requires mbstring + gd extensions.');
         }
 
-        $invoice = $this->createFixtureInvoice();
-        $twig = self::getContainer()->get('twig');
-        self::assertInstanceOf(Environment::class, $twig);
-
-        $html = $twig->render(
-            sprintf('@SolidInvoiceInvoice/Templates/%s/pdf.html.twig', $slug),
-            ['invoice' => $invoice]
-        );
+        $html = $this->renderTemplate($slug, 'pdf', $this->createFixtureInvoice());
 
         $pdf = $generator->generate($html);
         self::assertNotEmpty($pdf);
@@ -165,7 +153,11 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureInvoice(?string $description = 'Two rounds of revisions included.'): Invoice
+    /**
+     * @param list<Line> $lines Replaces the default line outright, for a test that needs to
+     *                          dictate the line rather than just its description.
+     */
+    private function createFixtureInvoice(?string $description = 'Two rounds of revisions included.', array $lines = []): Invoice
     {
         $this->seedCompanyLogo();
 
@@ -199,7 +191,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             'tax' => BigInteger::of(0),
             'discount' => new Discount()
                 ->setType(null),
-            'lines' => [
+            'lines' => $lines !== [] ? $lines : [
                 new Line()
                     ->setName('Sample line item')
                     ->setDescription($description)
@@ -254,6 +246,43 @@ final class TemplatesRenderingTest extends KernelTestCase
     }
 
     /**
+     * The unit is an inline suffix on the quantity, not a column, so a template needs no
+     * markup of its own for it — but it does have to route the quantity through
+     * {@see \SolidInvoice\CoreBundle\Twig\Extension\BillingExtension::quantity()} to show it.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testUnitOfMeasureRenders(string $slug, string $channel): void
+    {
+        $output = $this->renderTemplate($slug, $channel, $this->createFixtureInvoice(lines: [
+            new Line()
+                ->setName('Consulting')
+                ->setPrice(BigInteger::of(12500))
+                ->setQty(12)
+                ->setUnitCode(UnitCode::HOUR)
+                ->setTotal(BigInteger::of(150000)),
+        ]));
+
+        self::assertStringContainsString('12 hours', $output);
+    }
+
+    /**
+     * Nothing about a unit may reach the page when every line bills in plain units, which is
+     * every invoice that existed before the column did.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testUnitOfMeasureIsSuppressedForPlainUnits(string $slug, string $channel): void
+    {
+        $output = $this->renderTemplate($slug, $channel, $this->createFixtureInvoice());
+        $translator = self::getContainer()->get(TranslatorInterface::class);
+        self::assertInstanceOf(TranslatorInterface::class, $translator);
+
+        self::assertStringNotContainsString(
+            sprintf('2 %s', UnitCode::UNIT->trans($translator)),
+            $output
+        );
+    }
+
+    /**
      * @return iterable<string, array{string, string}>
      */
     public static function lineChannelProvider(): iterable
@@ -264,5 +293,16 @@ final class TemplatesRenderingTest extends KernelTestCase
                 yield sprintf('%s/%s', $slug, $channel) => [$slug, $channel];
             }
         }
+    }
+
+    private function renderTemplate(string $slug, string $channel, Invoice $invoice): string
+    {
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        return $twig->render(
+            sprintf('@SolidInvoiceInvoice/Templates/%s/%s.html.twig', $slug, $channel),
+            ['invoice' => $invoice]
+        );
     }
 }

--- a/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
+++ b/src/InvoiceBundle/Tests/Manager/InvoiceManagerTest.php
@@ -27,6 +27,7 @@ use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Entity\Company;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator\IdGeneratorInterface;
 use SolidInvoice\CoreBundle\Repository\CustomFieldRepository;
@@ -147,6 +148,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
+        $line->setUnitCode(UnitCode::HOUR);
         $line->setTotal(120 * 10);
 
         $quote = new Quote();
@@ -187,6 +189,8 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertCount(1, $invoiceLine[0]->getTaxes());
         self::assertSame('VAT', $invoiceLine[0]->getTaxes()->first()->getNameSnapshot());
         self::assertSame($line->getName(), $invoiceLine[0]->getName());
+        // 10 of something billed in hours is not 10 of something billed in units.
+        self::assertSame(UnitCode::HOUR, $invoiceLine[0]->getUnitCode());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));
@@ -321,6 +325,7 @@ final class InvoiceManagerTest extends KernelTestCase
         $line->setCreated(Carbon::now());
         $line->setPrice(120);
         $line->setQty(10);
+        $line->setUnitCode(UnitCode::HOUR);
         $line->setTotal(120 * 10);
 
         $recurringInvoice = new RecurringInvoice();
@@ -360,6 +365,8 @@ final class InvoiceManagerTest extends KernelTestCase
         self::assertCount(1, $invoiceLine[0]->getTaxes());
         self::assertSame('VAT', $invoiceLine[0]->getTaxes()->first()->getNameSnapshot());
         self::assertSame('Line Description 15 Monday January 2024', $invoiceLine[0]->getName());
+        // Every cycle generates a fresh invoice, so a unit dropped here is dropped for good.
+        self::assertSame(UnitCode::HOUR, $invoiceLine[0]->getUnitCode());
         self::assertInstanceOf(DateTimeImmutable::class, $invoiceLine[0]->getCreated());
         self::assertEquals($line->getPrice(), $invoiceLine[0]->getPrice());
         self::assertTrue($line->getQty()->isEqualTo($invoiceLine[0]->getQty()));

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
@@ -145,6 +145,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                         <div class="column-total">
                                         <span class="mobile-label">Total</span>
@@ -191,6 +192,7 @@
 <option value="MTQ">m&Acirc;&sup3;</option>
 <option value="LTR">L</option></select>
                                         </div>
+                                        
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithMultipleLines__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"},{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"},{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -129,8 +129,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="invoice_lines_0_unitCode" name="invoice[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">
@@ -163,8 +176,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="invoice_lines_1_qty" name="invoice[lines][1][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="invoice_lines_1_qty" name="invoice[lines][1][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="invoice_lines_1_unitCode" name="invoice[lines][1][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -170,8 +170,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="invoice_lines_0_unitCode" name="invoice[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithPreselectedClientAutoSelectsContacts__1.html
@@ -186,6 +186,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                         <div class="column-total">
                                         <span class="mobile-label">Total</span>

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateInvoice" data-live-url-value="/_components/CreateInvoice" data-live-props-value='{"isEdit":false,"invoiceEntity":null,"previousClientId":null,"formName":"invoice","invoice":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62","taxes":[]}],"invoiceTaxes":[],"invoiceId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"invoiceDate":"2021-01-01","due":"","customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="invoice" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -130,8 +130,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="invoice_lines_0_qty" name="invoice[lines][0][qty]" class="input-mini invoice-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="invoice_lines_0_unitCode" name="invoice[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                             <div class="column-tax">

--- a/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
+++ b/src/InvoiceBundle/Tests/Twig/Components/__snapshots__/CreateInvoiceTest__testCreateInvoiceWithTaxRates__1.html
@@ -146,6 +146,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                             <div class="column-tax">
                                             <span class="mobile-label">Tax</span>

--- a/src/McpBundle/Mcp/Tool/EntityNormalizer.php
+++ b/src/McpBundle/Mcp/Tool/EntityNormalizer.php
@@ -187,6 +187,7 @@ final class EntityNormalizer
                 'description' => $line->getDescription(),
                 'price' => $this->bigNumber($line->getPrice()),
                 'qty' => $this->bigNumber($line->getQty()),
+                'unit_code' => $line->getUnitCode()->value,
                 'total' => $this->bigNumber($line->getTotal()),
                 'taxes' => array_values(array_map(
                     $this->lineTax(...),

--- a/src/McpBundle/Mcp/Tool/LineItemBuilder.php
+++ b/src/McpBundle/Mcp/Tool/LineItemBuilder.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Mcp\Exception\ToolCallException;
 use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\InvoiceBundle\Entity\Line as InvoiceLine;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\QuoteBundle\Entity\Line as QuoteLine;
@@ -134,6 +135,7 @@ final readonly class LineItemBuilder
             $description = $data['description'] ?? null;
             $price = $data['price'] ?? null;
             $qty = $data['qty'] ?? ($data['quantity'] ?? null);
+            $unitCode = $data['unit_code'] ?? null;
 
             $hasName = \is_string($name) && $name !== '';
             $hasDescription = \is_string($description) && $description !== '';
@@ -187,6 +189,13 @@ final readonly class LineItemBuilder
                 throw new ToolCallException(sprintf('Line item #%d has an invalid "qty": %s', $index, $this->describe($qty)));
             }
 
+            // Omitted means the entity default (C62), the same as a form that leaves the
+            // field out. An unrecognised code is rejected here rather than stored, because a
+            // code outside the enum is one a tax authority would reject on the e-invoice.
+            if ($unitCode !== null) {
+                $line->setUnitCode($this->parseUnitCode($unitCode, $index));
+            }
+
             $this->attachTaxes($line, $data, $index);
 
             $built[] = $line;
@@ -207,6 +216,26 @@ final readonly class LineItemBuilder
     private function toExactString(mixed $value): mixed
     {
         return \is_float($value) ? sprintf('%.14G', $value) : $value;
+    }
+
+    /**
+     * The tool call is the only caller that names a unit without a form to constrain it, so
+     * the error lists what is accepted — an agent can then correct itself in one turn.
+     */
+    private function parseUnitCode(mixed $unitCode, int $index): UnitCode
+    {
+        $parsed = \is_string($unitCode) ? UnitCode::tryFrom($unitCode) : null;
+
+        if (! $parsed instanceof UnitCode) {
+            throw new ToolCallException(sprintf(
+                'Line item #%d has an invalid "unit_code": %s. Expected one of: %s.',
+                $index,
+                $this->describe($unitCode),
+                implode(', ', array_column(UnitCode::cases(), 'value')),
+            ));
+        }
+
+        return $parsed;
     }
 
     /**

--- a/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
+++ b/src/McpBundle/Tests/Functional/InvoiceCreateTest.php
@@ -18,9 +18,11 @@ use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\InvoiceBundle\Entity\Invoice;
 use SolidInvoice\InvoiceBundle\Mcp\InvoiceWriteTools;
+use SolidInvoice\McpBundle\Mcp\Tool\ResourceQueryTools;
 use SolidInvoice\McpBundle\Security\McpOAuthAuthenticator;
 use SolidInvoice\McpBundle\Security\McpScope;
 use SolidInvoice\QuoteBundle\Entity\Quote;
@@ -273,6 +275,74 @@ final class InvoiceCreateTest extends KernelTestCase
         self::assertInstanceOf(Quote::class, $quote);
         self::assertSame($this->company->getId()->toRfc4122(), $quote->getCompany()->getId()->toRfc4122());
         self::assertCount(1, $quote->getLines());
+    }
+
+    /**
+     * The unit is only worth persisting if an agent can both set it and see it again — a
+     * write path without a matching read path leaves a line silently disagreeing with what
+     * the agent that created it believes.
+     */
+    public function testALineUnitOfMeasureRoundTripsThroughTheTools(): void
+    {
+        $this->activateScopes([McpScope::Write->value, McpScope::Read->value]);
+
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $writeTool = self::getContainer()->get(InvoiceWriteTools::class);
+        self::assertInstanceOf(InvoiceWriteTools::class, $writeTool);
+
+        $result = $writeTool->createInvoice(
+            $client->getId()
+                ->toRfc4122(),
+            [
+                ['name' => 'Consulting', 'price' => 10000, 'qty' => 10, 'unit_code' => 'HUR'],
+                ['name' => 'Setup fee', 'price' => 5000, 'qty' => 1],
+            ],
+        );
+
+        $invoice = self::getContainer()->get('doctrine')->getRepository(Invoice::class)->find(Ulid::fromString($result['id']));
+        self::assertInstanceOf(Invoice::class, $invoice);
+        self::assertSame(UnitCode::HOUR, $invoice->getLines()[0]->getUnitCode());
+
+        // A line that names no unit gets the default rather than nothing.
+        self::assertSame(UnitCode::UNIT, $invoice->getLines()[1]->getUnitCode());
+
+        $readTool = self::getContainer()->get(ResourceQueryTools::class);
+        self::assertInstanceOf(ResourceQueryTools::class, $readTool);
+
+        $read = $readTool->getResource('invoice', $result['id']);
+
+        self::assertSame('HUR', $read['lines'][0]['unit_code']);
+        self::assertSame('C62', $read['lines'][1]['unit_code']);
+    }
+
+    /**
+     * The enum has no free-text case on purpose, so a code outside it has to fail on the
+     * tool call — the alternative is a stored code that a tax authority rejects later.
+     */
+    public function testAnUnknownUnitCodeIsRejected(): void
+    {
+        $this->activateScopes([McpScope::Write->value]);
+
+        $client = ClientFactory::createOne([
+            'company' => $this->company,
+            'currencyCode' => 'USD',
+        ]);
+
+        $tool = self::getContainer()->get(InvoiceWriteTools::class);
+        self::assertInstanceOf(InvoiceWriteTools::class, $tool);
+
+        $this->expectException(ToolCallException::class);
+        $this->expectExceptionMessageIsOrContains('Line item #0 has an invalid "unit_code": HOURS. Expected one of: C62, HUR');
+
+        $tool->createInvoice(
+            $client->getId()
+                ->toRfc4122(),
+            [['name' => 'Consulting', 'price' => 10000, 'qty' => 10, 'unit_code' => 'HOURS']],
+        );
     }
 
     /**

--- a/src/QuoteBundle/Cloner/QuoteCloner.php
+++ b/src/QuoteBundle/Cloner/QuoteCloner.php
@@ -88,6 +88,7 @@ final readonly class QuoteCloner
             $quoteLine->setDescription($line->getDescription());
             $quoteLine->setPrice($line->getPrice());
             $quoteLine->setQty($line->getQty());
+            $quoteLine->setUnitCode($line->getUnitCode());
 
             $quoteLine->getTaxes()->clear();
             foreach ($line->getTaxes() as $sourceLineTax) {

--- a/src/QuoteBundle/Entity/Line.php
+++ b/src/QuoteBundle/Entity/Line.php
@@ -35,6 +35,7 @@ use SolidInvoice\CoreBundle\Billing\LineName;
 use SolidInvoice\CoreBundle\Doctrine\Type\BigIntegerType;
 use SolidInvoice\CoreBundle\Doctrine\Type\QuantityType;
 use SolidInvoice\CoreBundle\Entity\LineInterface;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Traits\Entity\CompanyAware;
 use SolidInvoice\CoreBundle\Traits\Entity\TimeStampable;
 use SolidInvoice\QuoteBundle\Repository\LineRepository;
@@ -189,6 +190,15 @@ class Line implements LineInterface, Stringable
         ]
     )]
     private BigNumber $qty;
+
+    /**
+     * Not nullable, so {@see UnitCode::UNIT} is what a line that never mentions a unit holds
+     * rather than something callers have to branch on. It renders as nothing, which is how
+     * every line that predates this column stays exactly as it was.
+     */
+    #[ORM\Column(name: 'unit_code', length: 3, enumType: UnitCode::class, options: ['default' => UnitCode::UNIT->value])]
+    #[Groups(['quote_api:read', 'quote_api:write'])]
+    private UnitCode $unitCode = UnitCode::UNIT;
 
     #[ORM\ManyToOne(targetEntity: Quote::class, inversedBy: 'lines')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
@@ -361,6 +371,18 @@ class Line implements LineInterface, Stringable
     public function getQty(): BigNumber
     {
         return $this->qty;
+    }
+
+    public function setUnitCode(UnitCode $unitCode): static
+    {
+        $this->unitCode = $unitCode;
+
+        return $this;
+    }
+
+    public function getUnitCode(): UnitCode
+    {
+        return $this->unitCode;
     }
 
     public function setQuote(?Quote $quote = null): static

--- a/src/QuoteBundle/Form/Type/ItemType.php
+++ b/src/QuoteBundle/Form/Type/ItemType.php
@@ -16,11 +16,13 @@ namespace SolidInvoice\QuoteBundle\Form\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Form\Transformer\QuantityTransformer;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\TaxBundle\Entity\Tax;
 use SolidInvoice\TaxBundle\Form\Type\LineTaxType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -97,6 +99,21 @@ class ItemType extends AbstractType
         $builder->get('qty')
             ->resetViewTransformers()
             ->addViewTransformer(new QuantityTransformer());
+
+        $builder->add(
+            'unitCode',
+            EnumType::class,
+            [
+                'class' => UnitCode::class,
+                // There is always a unit, so no blank option — and a payload that leaves the
+                // field out (the API, an older client) means the default rather than null.
+                'placeholder' => false,
+                'empty_data' => UnitCode::UNIT,
+                'attr' => [
+                    'class' => 'input-mini invoice-item-unit',
+                ],
+            ]
+        );
 
         if ($this->registry->getManager()->getRepository(Tax::class)->taxRatesConfigured()) {
             $builder->add(

--- a/src/QuoteBundle/Mcp/QuoteWriteTools.php
+++ b/src/QuoteBundle/Mcp/QuoteWriteTools.php
@@ -66,7 +66,9 @@ final readonly class QuoteWriteTools
      * as a draft — use `apply_quote_transition` to send/accept/etc.
      *
      * @param string                          $client_id      Client ULID (must belong to the active company)
-     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
+     * @param list<array<string, mixed>>      $lines          Line items: [{name, description?, price, qty, unit_code?, tax_id?, taxes?: [{tax_id, sequence?, compound?}]}, ...].
+     *                                                        `unit_code` is a UN/ECE Rec 20 code (C62 unit, HUR hour, DAY, MON, ANN,
+     *                                                        E48 service, KGM, TNE, MTR, MTK, MTQ, LTR); omitted means C62.
      *                                                        Provide `taxes[]` for multi-tax lines (India GST, Quebec compound, etc.);
      *                                                        `tax_id` is the legacy single-tax shorthand.
      * @param string|null                     $due            ISO-8601 due date (optional)

--- a/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
+++ b/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
@@ -188,6 +188,7 @@
                                             {{ form_widget(item.unitCode, {attr: {'aria-label': 'quote.item.heading.unit'|trans}}) }}
                                         </div>
                                         {{ form_errors(item.qty) }}
+                                        {{ form_errors(item.unitCode) }}
                                     </div>
                                     {% if this.hasTax %}
                                         <div class="column-tax">

--- a/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
+++ b/src/QuoteBundle/Resources/views/Components/CreateQuote.html.twig
@@ -180,7 +180,13 @@
                                     </div>
                                     <div class="column-qty">
                                         <span class="mobile-label">{{ 'quote.item.heading.qty'|trans }}</span>
-                                        {{ form_widget(item.qty) }}
+                                        {#- The unit sits beside the quantity rather than in a column of its
+                                            own: it is already set to "units", so a line that bills in units
+                                            needs nothing done to it. -#}
+                                        <div class="qty-unit-group">
+                                            {{ form_widget(item.qty) }}
+                                            {{ form_widget(item.unitCode, {attr: {'aria-label': 'quote.item.heading.unit'|trans}}) }}
+                                        </div>
                                         {{ form_errors(item.qty) }}
                                     </div>
                                     {% if this.hasTax %}

--- a/src/QuoteBundle/Resources/views/Default/view.html.twig
+++ b/src/QuoteBundle/Resources/views/Default/view.html.twig
@@ -276,7 +276,7 @@
                                 <tr>
                                     <td class="column-description" data-label="{{ 'quote.item.heading.description'|trans }}">{{ item.name }}{{ q.line_description(item, false) }}</td>
                                     <td class="column-price" data-label="{{ 'quote.item.heading.price'|trans }}">{{ item.price|formatCurrency(currency) }}</td>
-                                    <td class="column-qty" data-label="{{ 'quote.item.heading.qty'|trans }}">{{ item.qty }}</td>
+                                    <td class="column-qty" data-label="{{ 'quote.item.heading.qty'|trans }}">{{ quantity(item) }}</td>
                                     {% if quote.tax.positive %}
                                         <td class="column-tax" data-label="{{ 'quote.item.heading.tax'|trans }}">
                                             {% for lineTax in item.taxes %}{{ lineTax.nameSnapshot }} ({{ lineTax.rateSnapshot }}%){% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
+++ b/src/QuoteBundle/Resources/views/Pdf/quote.html.twig
@@ -238,7 +238,7 @@
                     {{ line.price|formatCurrency(currency) }}
                 </td>
                 <td class="col-qty" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">
-                    {{ line.qty }}
+                    {{ quantity(line) }}
                 </td>
                 {% if quote.tax.positive %}
                     <td class="col-tax" style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">

--- a/src/QuoteBundle/Resources/views/Templates/classic/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/classic/pdf.html.twig
@@ -57,7 +57,7 @@
             <tr>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
-                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
+                <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace;">{{ quantity(line) }}</td>
                 <td style="padding: 12px 16px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>
         {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/classic/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/classic/preview.html.twig
@@ -43,7 +43,7 @@
                         <tr>
                             <td>{{ line.name }}{{ q.line_description(line) }}</td>
                             <td class="text-end font-monospace">{{ line.price|formatCurrency(currency) }}</td>
-                            <td class="text-end">{{ line.qty }}</td>
+                            <td class="text-end">{{ quantity(line) }}</td>
                             <td class="text-end font-monospace fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/compact/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/compact/pdf.html.twig
@@ -59,7 +59,7 @@
             <tr{% if loop.index0 is divisible by(2) %} style="background-color: #f8fafc;"{% endif %}>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: center; color: #64748b;">{{ loop.index }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; color: #1e293b;">{{ line.name }}{{ q.line_description(line) }}</td>
-                <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.qty }}</td>
+                <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ quantity(line) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 8px 12px; font-size: 8pt; text-align: right; font-family: 'Courier New', monospace; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/QuoteBundle/Resources/views/Templates/compact/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/compact/preview.html.twig
@@ -52,7 +52,7 @@
                             <tr>
                                 <td class="text-muted small">{{ loop.index }}</td>
                                 <td class="small">{{ line.name }}{{ q.line_description(line) }}</td>
-                                <td class="text-end font-monospace small">{{ line.qty }}</td>
+                                <td class="text-end font-monospace small">{{ quantity(line) }}</td>
                                 <td class="text-end font-monospace small">{{ line.price|formatCurrency(currency) }}</td>
                                 <td class="text-end font-monospace small fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                             </tr>

--- a/src/QuoteBundle/Resources/views/Templates/editorial/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/editorial/pdf.html.twig
@@ -50,7 +50,7 @@
         <tr>
             <td style="padding: 14px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; vertical-align: top;">
                 <em>{{ line.name }}</em>{{ q.line_description(line) }}
-                <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                <div style="font-size: 9pt; color: #6b6b6b; margin-top: 2px;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
             </td>
             <td style="padding: 14px 0; font-size: 13pt; color: #1a1a1a; border-bottom: 1px solid #e8dcc4; text-align: right; vertical-align: top; width: 25%;">
                 {{ line.total|formatCurrency(currency) }}

--- a/src/QuoteBundle/Resources/views/Templates/editorial/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/editorial/preview.html.twig
@@ -41,7 +41,7 @@
                         <tr style="border-bottom: 1px solid #e8dcc4;">
                             <td>
                                 <em>{{ line.name }}</em>{{ q.line_description(line) }}
-                                <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                                <div class="text-muted small">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-5">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/Templates/friendly/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/friendly/pdf.html.twig
@@ -77,7 +77,7 @@
             {% for line in quote.lines %}
                 <tr>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada;">{{ line.name }}{{ q.line_description(line) }}</td>
-                    <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ line.qty }}</td>
+                    <td style="padding: 12px; font-size: 10pt; color: #475569; border-bottom: 1px solid #f1eada; text-align: right;">{{ quantity(line) }}</td>
                     <td style="padding: 12px; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1eada; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
                 </tr>
             {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/friendly/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/friendly/preview.html.twig
@@ -64,7 +64,7 @@
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #f1eada;">
                             <td>{{ line.name }}{{ q.line_description(line) }}</td>
-                            <td class="text-end text-muted">{{ line.qty }}</td>
+                            <td class="text-end text-muted">{{ quantity(line) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/modern/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/modern/pdf.html.twig
@@ -53,7 +53,7 @@
         {% for line in quote.lines %}
             <tr>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
-                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
+                <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ quantity(line) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 16px 0; font-size: 10pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/QuoteBundle/Resources/views/Templates/modern/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/modern/preview.html.twig
@@ -49,7 +49,7 @@
                     {% for line in quote.lines %}
                         <tr class="border-bottom">
                             <td class="py-3">{{ line.name }}{{ q.line_description(line) }}</td>
-                            <td class="py-3 text-end">{{ line.qty }}</td>
+                            <td class="py-3 text-end">{{ quantity(line) }}</td>
                             <td class="py-3 text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="py-3 text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/Templates/monochrome/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/monochrome/pdf.html.twig
@@ -105,7 +105,7 @@
                                 {% for line in quote.lines %}
                                     <tr>
                                         <td style="padding: 12px 0; font-size: 10pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0;">{{ line.name }}{{ q.line_description(line) }}</td>
-                                        <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
+                                        <td style="padding: 12px 0; font-size: 10pt; color: #6b6b6b; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</td>
                                         <td style="padding: 12px 0; font-size: 11pt; color: #1a1a1a; border-bottom: 1px solid #ebe3d0; text-align: right; font-family: Georgia, serif; font-weight: bold;">{{ line.total|formatCurrency(currency) }}</td>
                                     </tr>
                                 {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/monochrome/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/monochrome/preview.html.twig
@@ -53,7 +53,7 @@
                     {% for line in quote.lines %}
                         <tr style="border-bottom: 1px solid #e0d8c8;">
                             <td>{{ line.name }}{{ q.line_description(line) }}</td>
-                            <td class="text-muted text-end">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</td>
+                            <td class="text-muted text-end">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>
                     {% endfor %}

--- a/src/QuoteBundle/Resources/views/Templates/photographer/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/photographer/pdf.html.twig
@@ -52,7 +52,7 @@
                     <tr>
                         <td style="padding: 12px 0; font-size: 10pt; color: #2a2418; border-bottom: 1px solid #e8d7b8; vertical-align: top;">
                             <div style="font-family: Georgia, serif; font-size: 11pt;">{{ line.name }}</div>{{ q.line_description(line) }}
-                            <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                            <div style="font-size: 8pt; color: #7a6a4a; margin-top: 2px;">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                         </td>
                         <td style="padding: 12px 0; font-size: 12pt; color: #a2492b; border-bottom: 1px solid #e8d7b8; text-align: right; font-family: Georgia, serif; font-weight: bold; width: 28%;">
                             {{ line.total|formatCurrency(currency) }}

--- a/src/QuoteBundle/Resources/views/Templates/photographer/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/photographer/preview.html.twig
@@ -46,7 +46,7 @@
                         <tr style="border-bottom: 1px solid #e8d7b8;">
                             <td>
                                 <div class="fs-5">{{ line.name }}</div>{{ q.line_description(line) }}
-                                <div class="text-muted small">{{ line.qty }} × {{ line.price|formatCurrency(currency) }}</div>
+                                <div class="text-muted small">{{ quantity(line) }} × {{ line.price|formatCurrency(currency) }}</div>
                             </td>
                             <td class="text-end fs-4 fw-bold" style="color: #a2492b;">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/Templates/studio/pdf.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/studio/pdf.html.twig
@@ -53,7 +53,7 @@
         {% for line in quote.lines %}
             <tr>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9;">{{ line.name }}{{ q.line_description(line) }}</td>
-                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.qty }}</td>
+                <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ quantity(line) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right;">{{ line.price|formatCurrency(currency) }}</td>
                 <td style="padding: 12px 14px; font-size: 9pt; color: #1e293b; border-bottom: 1px solid #f1f5f9; text-align: right; font-weight: 600;">{{ line.total|formatCurrency(currency) }}</td>
             </tr>

--- a/src/QuoteBundle/Resources/views/Templates/studio/preview.html.twig
+++ b/src/QuoteBundle/Resources/views/Templates/studio/preview.html.twig
@@ -51,7 +51,7 @@
                     {% for line in quote.lines %}
                         <tr>
                             <td>{{ line.name }}{{ q.line_description(line) }}</td>
-                            <td class="text-end">{{ line.qty }}</td>
+                            <td class="text-end">{{ quantity(line) }}</td>
                             <td class="text-end">{{ line.price|formatCurrency(currency) }}</td>
                             <td class="text-end fw-bold">{{ line.total|formatCurrency(currency) }}</td>
                         </tr>

--- a/src/QuoteBundle/Resources/views/quote_template.html.twig
+++ b/src/QuoteBundle/Resources/views/quote_template.html.twig
@@ -161,7 +161,7 @@
                                         <tr>
                                             <td class="item-description">{{ item.name }}{{ q.line_description(item) }}</td>
                                             <td class="text-end item-amount">{{ item.price|formatCurrency(currency) }}</td>
-                                            <td class="text-center">{{ item.qty }}</td>
+                                            <td class="text-center">{{ quantity(item) }}</td>
                                             {% if quote.tax.positive %}
                                                 <td class="text-end item-amount">
                                                     {% for lineTax in item.taxes %}{{ lineTax.nameSnapshot }} ({{ lineTax.rateSnapshot }}%){% if not loop.last %}, {% endif %}{% endfor %}

--- a/src/QuoteBundle/Tests/Cloner/QuoteClonerTest.php
+++ b/src/QuoteBundle/Tests/Cloner/QuoteClonerTest.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use SolidInvoice\ClientBundle\Entity\Client;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator;
 use SolidInvoice\CoreBundle\Generator\BillingIdGenerator\IdGeneratorInterface;
 use SolidInvoice\QuoteBundle\Cloner\QuoteCloner;
@@ -62,6 +63,7 @@ final class QuoteClonerTest extends TestCase
         $item->setCreated(Carbon::now());
         $item->setPrice(BigInteger::of(120));
         $item->setQty(10);
+        $item->setUnitCode(UnitCode::HOUR);
         $item->setTotal(BigInteger::of(120 * 10));
 
         $quote = new Quote();
@@ -131,6 +133,8 @@ final class QuoteClonerTest extends TestCase
         self::assertCount(1, $quoteItem[0]->getTaxes());
         self::assertSame('VAT', $quoteItem[0]->getTaxes()->first()->getNameSnapshot());
         self::assertSame($item->getDescription(), $quoteItem[0]->getDescription());
+        // 10 of something billed in hours is not 10 of something billed in units.
+        self::assertSame(UnitCode::HOUR, $quoteItem[0]->getUnitCode());
         self::assertInstanceOf(DateTimeImmutable::class, $quoteItem[0]->getCreated());
         self::assertEquals($item->getPrice(), $quoteItem[0]->getPrice());
         self::assertTrue($item->getQty()->isEqualTo($quoteItem[0]->getQty()));

--- a/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
+++ b/src/QuoteBundle/Tests/Form/Type/ItemTypeTest.php
@@ -17,6 +17,7 @@ use Brick\Math\BigDecimal;
 use Brick\Math\Exception\MathException;
 use Money\Currency;
 use Override;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Tests\FormTestCase;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Form\Type\ItemType;
@@ -73,6 +74,24 @@ final class ItemTypeTest extends FormTestCase
         $object->setPrice(BigDecimal::of($price)->multipliedBy(100));
 
         $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => $currency]), $formData, $object);
+    }
+
+    public function testSubmitUnitOfMeasure(): void
+    {
+        $formData = [
+            'description' => 'Consulting',
+            'price' => 125,
+            'qty' => '12',
+            'unitCode' => UnitCode::HOUR->value,
+        ];
+
+        $object = new Line();
+        $object->setDescription('Consulting');
+        $object->setQty('12');
+        $object->setPrice(BigDecimal::of(12500));
+        $object->setUnitCode(UnitCode::HOUR);
+
+        $this->assertFormData($this->factory->create(ItemType::class, null, ['currency' => new Currency('USD')]), $formData, $object);
     }
 
     /**

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteTest.php
@@ -20,6 +20,7 @@ use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Company\CompanySelector;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Entity\Quote;
@@ -135,6 +136,7 @@ final class QuoteTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => $contacts,
@@ -219,6 +221,7 @@ final class QuoteTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),
@@ -310,6 +313,7 @@ final class QuoteTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 0,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
                 [
                     '@id' => $this->getIriFromResource($quote->getLines()->get(1)),
@@ -325,6 +329,7 @@ final class QuoteTest extends ApiTestCase
                     'description' => null,
                     'taxes' => [],
                     'position' => 1,
+                    'unitCode' => UnitCode::UNIT->value,
                 ],
             ],
             'users' => array_map($this->getIriFromResource(...), $contacts),

--- a/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
+++ b/src/QuoteBundle/Tests/Functional/Templates/TemplatesRenderingTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
 use SolidInvoice\ClientBundle\Test\Factory\ContactFactory;
 use SolidInvoice\CoreBundle\Entity\Discount;
+use SolidInvoice\CoreBundle\Enum\UnitCode;
 use SolidInvoice\CoreBundle\Pdf\Generator;
 use SolidInvoice\InstallBundle\Test\EnsureApplicationInstalled;
 use SolidInvoice\QuoteBundle\Entity\Line;
@@ -28,6 +29,7 @@ use SolidInvoice\QuoteBundle\Enum\QuoteStatus;
 use SolidInvoice\QuoteBundle\Test\Factory\QuoteFactory;
 use SolidInvoice\SettingsBundle\Entity\Setting;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use function basename;
 use function dirname;
@@ -84,14 +86,7 @@ final class TemplatesRenderingTest extends KernelTestCase
     public function testTemplateRenders(string $slug, string $channel): void
     {
         $quote = $this->createFixtureQuote();
-
-        $twig = self::getContainer()->get('twig');
-        self::assertInstanceOf(Environment::class, $twig);
-
-        $output = $twig->render(
-            sprintf('@SolidInvoiceQuote/Templates/%s/%s.html.twig', $slug, $channel),
-            ['quote' => $quote]
-        );
+        $output = $this->renderTemplate($slug, $channel, $quote);
 
         self::assertNotEmpty($output, sprintf('Template %s/%s produced empty output', $slug, $channel));
         self::assertStringContainsString($quote->getQuoteId(), $output);
@@ -130,14 +125,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             self::markTestSkipped('PDF generation requires mbstring + gd extensions.');
         }
 
-        $quote = $this->createFixtureQuote();
-        $twig = self::getContainer()->get('twig');
-        self::assertInstanceOf(Environment::class, $twig);
-
-        $html = $twig->render(
-            sprintf('@SolidInvoiceQuote/Templates/%s/pdf.html.twig', $slug),
-            ['quote' => $quote]
-        );
+        $html = $this->renderTemplate($slug, 'pdf', $this->createFixtureQuote());
 
         $pdf = $generator->generate($html);
         self::assertNotEmpty($pdf);
@@ -169,7 +157,11 @@ final class TemplatesRenderingTest extends KernelTestCase
         $em->flush();
     }
 
-    private function createFixtureQuote(?string $description = 'Two rounds of revisions included.'): Quote
+    /**
+     * @param list<Line> $lines Replaces the default line outright, for a test that needs to
+     *                          dictate the line rather than just its description.
+     */
+    private function createFixtureQuote(?string $description = 'Two rounds of revisions included.', array $lines = []): Quote
     {
         $this->seedCompanyLogo();
 
@@ -201,7 +193,7 @@ final class TemplatesRenderingTest extends KernelTestCase
             'tax' => BigInteger::of(0),
             'discount' => new Discount()
                 ->setType(null),
-            'lines' => [
+            'lines' => $lines !== [] ? $lines : [
                 new Line()
                     ->setName('Sample line item')
                     ->setDescription($description)
@@ -256,6 +248,43 @@ final class TemplatesRenderingTest extends KernelTestCase
     }
 
     /**
+     * The unit is an inline suffix on the quantity, not a column, so a template needs no
+     * markup of its own for it — but it does have to route the quantity through
+     * {@see \SolidInvoice\CoreBundle\Twig\Extension\BillingExtension::quantity()} to show it.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testUnitOfMeasureRenders(string $slug, string $channel): void
+    {
+        $output = $this->renderTemplate($slug, $channel, $this->createFixtureQuote(lines: [
+            new Line()
+                ->setName('Consulting')
+                ->setPrice(BigInteger::of(12500))
+                ->setQty(12)
+                ->setUnitCode(UnitCode::HOUR)
+                ->setTotal(BigInteger::of(150000)),
+        ]));
+
+        self::assertStringContainsString('12 hours', $output);
+    }
+
+    /**
+     * Nothing about a unit may reach the page when every line bills in plain units, which is
+     * every quote that existed before the column did.
+     */
+    #[DataProvider('lineChannelProvider')]
+    public function testUnitOfMeasureIsSuppressedForPlainUnits(string $slug, string $channel): void
+    {
+        $output = $this->renderTemplate($slug, $channel, $this->createFixtureQuote());
+        $translator = self::getContainer()->get(TranslatorInterface::class);
+        self::assertInstanceOf(TranslatorInterface::class, $translator);
+
+        self::assertStringNotContainsString(
+            sprintf('2 %s', UnitCode::UNIT->trans($translator)),
+            $output
+        );
+    }
+
+    /**
      * @return iterable<string, array{string, string}>
      */
     public static function lineChannelProvider(): iterable
@@ -266,5 +295,16 @@ final class TemplatesRenderingTest extends KernelTestCase
                 yield sprintf('%s/%s', $slug, $channel) => [$slug, $channel];
             }
         }
+    }
+
+    private function renderTemplate(string $slug, string $channel, Quote $quote): string
+    {
+        $twig = self::getContainer()->get('twig');
+        self::assertInstanceOf(Environment::class, $twig);
+
+        return $twig->render(
+            sprintf('@SolidInvoiceQuote/Templates/%s/%s.html.twig', $slug, $channel),
+            ['quote' => $quote]
+        );
     }
 }

--- a/src/QuoteBundle/Tests/Twig/Components/CreateQuoteTest.php
+++ b/src/QuoteBundle/Tests/Twig/Components/CreateQuoteTest.php
@@ -37,6 +37,30 @@ final class CreateQuoteTest extends LiveComponentTest
     }
 
     /**
+     * The unit labels are the only translations in the line editor that are not ASCII, and
+     * the snapshots are no use for checking them: Spatie's HtmlDriver runs the markup through
+     * DOMDocument::loadHTML(), which reads a fragment with no charset as ISO-8859-1 and so
+     * re-encodes "m²" to "m&Acirc;&sup2;" in the stored .html. That is the serialiser, not
+     * the page — this asserts against the render itself, so the difference stays provable.
+     */
+    public function testTheUnitLabelsRenderAsUtf8(): void
+    {
+        $dto = new QuoteFormDTO();
+        $dto->lines->add(new Line()->setPrice(10000)->setQty(1));
+
+        $component = $this->createLiveComponent(
+            name: CreateQuote::class,
+            data: ['dto' => $dto]
+        )->actingAs($this->getUser());
+
+        $rendered = $component->render()->toString();
+
+        self::assertStringContainsString('<option value="MTK">m²</option>', $rendered);
+        self::assertStringContainsString('<option value="MTQ">m³</option>', $rendered);
+        self::assertStringNotContainsString('&Acirc;', $rendered);
+    }
+
+    /**
      * @throws MathException
      */
     public function testCreateQuoteWithMultipleLines(): void

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
@@ -137,6 +137,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                         <div class="column-total">
                                         <span class="mobile-label">Total</span>
@@ -183,6 +184,7 @@
 <option value="MTQ">m&Acirc;&sup3;</option>
 <option value="LTR">L</option></select>
                                         </div>
+                                        
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithMultipleLines__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"},{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"},{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -121,8 +121,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="quote_lines_0_unitCode" name="quote[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">
@@ -155,8 +168,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="quote_lines_1_qty" name="quote[lines][1][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="quote_lines_1_qty" name="quote[lines][1][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="quote_lines_1_unitCode" name="quote[lines][1][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":"01JBYEQCR7DJ2YW4EXP6FYJZCR","formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62"}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"01JBYEQCR7DJ2YW4EXP6FYJZCR","users":["01JBYEQCR7DJ2YW4EXP6FYJZCR","01JBYEQCR7DJ2YW4EXP6FYJZCR"],"_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -162,8 +162,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="quote_lines_0_unitCode" name="quote[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                         <div class="column-total">

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithPreselectedClientAutoSelectsContacts__1.html
@@ -178,6 +178,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                         <div class="column-total">
                                         <span class="mobile-label">Total</span>

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
@@ -1,5 +1,5 @@
 <html><body>
-<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","taxes":[]}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
+<div class="billing-form-page" id="in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed" data-controller="live" data-live-name-value="CreateQuote" data-live-url-value="/_components/CreateQuote" data-live-props-value='{"isEdit":false,"quoteEntity":null,"previousClientId":null,"formName":"quote","quote":{"clientMode":"existing","discount":{"type":"","value":0},"lines":[{"name":"","description":"","price":"100.00","qty":"1","unitCode":"C62","taxes":[]}],"invoiceTaxes":[],"quoteId":"1","terms":"","notes":"","total":0,"baseTotal":0,"tax":0,"customFields":[],"__dynamic_error":"","client":"","_token":""},"isValidated":false,"validatedFields":[],"@attributes":{"id":"in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed"},"@checksum":"REPLACED_CHECKSUM"}'>
     
     <form name="quote" method="post" data-controller="solidworx--platform--loading" data-action="submit-&gt;solidworx--platform--loading#onSubmit" data-model="on(change)|*">
 
@@ -122,8 +122,21 @@
                                         
                                     </div>
                                     <div class="column-qty">
-                                        <span class="mobile-label">Qty</span>
-                                        <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                        <span class="mobile-label">Qty</span><div class="qty-unit-group">
+                                            <input type="text" id="quote_lines_0_qty" name="quote[lines][0][qty]" class="input-mini quote-item-qty form-control" inputmode="decimal" value="1">
+                                            <select id="quote_lines_0_unitCode" name="quote[lines][0][unitCode]" class="input-mini invoice-item-unit form-select" data-controller="symfony--ux-autocomplete--autocomplete" data-symfony--ux-autocomplete--autocomplete-max-results-value="10" data-symfony--ux-autocomplete--autocomplete-loading-more-text-value="Loading more results..." data-symfony--ux-autocomplete--autocomplete-no-results-found-text-value="No results found" data-symfony--ux-autocomplete--autocomplete-no-more-results-text-value="No more results" data-symfony--ux-autocomplete--autocomplete-create-option-text-value="Add %placeholder%..." data-symfony--ux-autocomplete--autocomplete-preload-value="focus" aria-label="Unit"><option value="C62" selected>units</option>
+<option value="HUR">hours</option>
+<option value="DAY">days</option>
+<option value="MON">months</option>
+<option value="ANN">years</option>
+<option value="E48">services</option>
+<option value="KGM">kg</option>
+<option value="TNE">t</option>
+<option value="MTR">m</option>
+<option value="MTK">m&Acirc;&sup2;</option>
+<option value="MTQ">m&Acirc;&sup3;</option>
+<option value="LTR">L</option></select>
+                                        </div>
                                         
                                     </div>
                                                                             <div class="column-tax">

--- a/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
+++ b/src/QuoteBundle/Tests/Twig/Components/__snapshots__/CreateQuoteTest__testCreateQuoteWithTaxRates__1.html
@@ -138,6 +138,7 @@
 <option value="LTR">L</option></select>
                                         </div>
                                         
+                                        
                                     </div>
                                                                             <div class="column-tax">
                                             <span class="mobile-label">Tax</span>

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -855,6 +855,7 @@ invoice:
             qty: Qty
             tax: Tax
             total: Total
+            unit: Unit
         name:
             label: 'Item name'
             placeholder: 'e.g. Website design'
@@ -1127,6 +1128,20 @@ layout:
     profile: Profile
     unsplash_credit: 'Download free do whatever you want high-resolution photos from Julian Zett'
     user_image: 'User Image'
+line:
+    unit:
+        ANN: years
+        C62: units
+        DAY: days
+        E48: services
+        HUR: hours
+        KGM: kg
+        LTR: L
+        MON: months
+        MTK: m²
+        MTQ: m³
+        MTR: m
+        TNE: t
 mcp:
     connected_apps:
         empty: "You haven't connected any AI agents yet."
@@ -1802,6 +1817,7 @@ quote:
             qty: Qty
             tax: Tax
             total: Total
+            unit: Unit
         name:
             label: 'Item name'
             placeholder: 'e.g. Website design'

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1130,14 +1130,16 @@ layout:
     user_image: 'User Image'
 line:
     unit:
-        ANN: years
-        C62: units
-        DAY: days
-        E48: services
-        HUR: hours
+        # The countable units carry both forms, so a line billing one of something reads
+        # "1 hour" rather than "1 hours". The ones written as symbols do not inflect.
+        ANN: year|years
+        C62: unit|units
+        DAY: day|days
+        E48: service|services
+        HUR: hour|hours
         KGM: kg
         LTR: L
-        MON: months
+        MON: month|months
         MTK: m²
         MTQ: m³
         MTR: m


### PR DESCRIPTION
Closes #2707.

Stacked PR 3 of the invoice line model work. **Base is `feature/2706-line-name`** (PR 2, line name), not `3.1.x` — review PR 1 (#2705 branch) and #2837 first. This branch is a single commit on top of #2837, so it reverts on its own.

## What changed

"Qty 5" does not say whether that is five hours or five kilograms. Lines now carry a unit of measure — EN 16931 **BT-130** — and the invoice prints it after the quantity: "12 hours", "40 kg".

- **`CoreBundle\Enum\UnitCode`** — a backed enum whose values *are* the UN/ECE Recommendation 20 codes, so the e-invoicing mapping is already done rather than needing a translation table later. Twelve cases, the ones invoices are actually billed in: `C62` (unit), `HUR`, `DAY`, `MON`, `ANN`, `E48`, `KGM`, `TNE`, `MTR`, `MTK`, `MTQ`, `LTR`.
- It implements `TranslatableInterface`, so Symfony's `EnumType` derives the select labels itself and the rendered suffix reads from the same `line.unit.*` string. One string per code, no label-mapping code, no second list to keep in sync.
- **`C62` is the default and the column is `NOT NULL`.** That is what keeps the feature invisible for everyone who never sets a unit, and for every line written before the column existed. It also means no caller branches on null.
- **The issue asked for an extra column; it became an inline suffix.** All 40 twig render sites call one new Twig function, `quantity(line)`, which appends the unit unless the line is `C62`. So the eight designs × pdf/preview × 2 bundles needed no markup of their own, nothing has to compute "is every line C62", and the suppression rule is structural rather than a condition a template can forget.
- **Editor** — the select sits beside the quantity input, already reading "units", so a line billed in units costs the user no extra step. The form defaults an omitted `unitCode` rather than rejecting it, so an API payload or an older client that does not know the field still posts a line.
- **Migration `Version30100_7`** adds one column to `invoice_lines` (which carries recurring invoice lines too — single-table hierarchy) and `quote_lines`, with a DDL default and **no backfill pass**: the default is what fills existing rows. `#2837` owns `Version30100_6`.

## On the "escape hatch"

The scope asked for an escape hatch for the ~1,788 codes not shipped. **There deliberately isn't one**, confirmed with the board before pushing. A free-text unit code cannot be validated against Rec 20, and EN 16931 rejects unknown codes — so a bespoke code would surface as a tax authority rejecting the e-invoice, not as a form error the user can act on. Adding a code is a case in the enum plus one translation string. The enum is the guardrail, not the limitation.

## Acceptance criteria

- [x] Invoice, recurring invoice and quote lines carry a unit of measure.
- [x] Modelled as a backed enum, not class constants.
- [x] Maps to EN 16931 BT-130 without a translation layer.
- [x] Existing lines and existing invoices are visually unchanged.
- [x] One migration, in this PR only.
- [ ] Browser check of the widened Qty cell — see below.

## Verification

Run in the worktree off this branch, after rebasing onto #2837:

- `bin/phpunit src/CoreBundle src/InvoiceBundle src/QuoteBundle` — **1060 tests, 3551 assertions, 0 failures.**
- `bin/ecs check` — clean. `bin/rector --dry-run` — 0 changes. All 4 pre-commit hooks pass.
- `bin/phpstan analyse` — **no new errors.** The two in `SettingsBundle/Tests/Action/CustomField/DeleteActionTest.php` are pre-existing; I verified by running PHPStan against that file on this branch's base (`62a61540d`) and getting the identical two.
- New tests: `BillingExtensionTest` covers `quantity()` directly; `ItemTypeTest` covers the form defaulting an omitted `unitCode`; the API functional tests on all three line resources assert the new field.
- `TemplatesRenderingTest` in both bundles gains `testUnitOfMeasureRenders` and `testUnitOfMeasureIsSuppressedForPlainUnits`, both across all 8 templates × pdf/preview.
- **The new test bites**: reverting one template's `quantity(line)` back to `line.qty` fails exactly 1 of 16 cases (`modern/pdf`) and nothing else.
- Snapshots regenerated for the Live Component tests. The two `testCreate{Invoice,Quote}__1.html` snapshots are unchanged because that fixture renders no line rows at all.

### Note for whoever rebases this

`migrations/` is a **classmap** in `autoload-dev`, so `composer dump-autoload` is required after picking up #2837's new migration — otherwise `LineNameMigrationTest` fails with `Class "DoctrineMigrations\Version30100_6" not found` and it looks like this branch broke it.

### Merge note

The template-rendering fixtures in both bundles carry two parameters: #2837's `$description` and this PR's `$lines`. `$lines` is the more general lever and could have replaced it — but collapsing them means rewriting #2837's tests from this branch and re-resolving the same conflict on every revision of that PR, which is exactly what happened when `3a194c76d` landed there. So the two sit side by side and **#2837's tests are untouched by this PR**. The two PRs do share the one `lineChannelProvider` rather than a near-identical provider each.

**Browser check accepted** — the widened Qty cell was verified by the board, which is why this is out of draft.

## Before this can merge

**The stack's route to `3.1.x`:** #2838 → #2837 → #2842 → `3.1.x`. PR 1 is now open as #2842, so the stack has a merge path. Merge bottom-up.

**`Analyze (javascript)` (CodeQL) is red, and not from this diff.** It fails the same way on #2837 and on unrelated dependabot PRs (#2836, #2835) with `We were unable to automatically build your code … Loaded a configuration file for version '4.37.4', but running version '4.36.2'` — a CodeQL action/config version mismatch in the workflow, repo-wide. Worth its own issue; not fixable from this branch.


