### PR TITLE
Repin codeql-action/autobuild to match init and analyze

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # init/autobuild/analyze are separate dependencies to Dependabot, but CodeQL
+      # refuses to run when they are on different versions. Bump them in one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "gomod"
     directory: "/frankenphp"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,15 +42,15 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
   #qodana:
   #  permissions:


### PR DESCRIPTION
Fixes SOL-41.

`Analyze (javascript)` has been failing on every branch and PR — mainline, feature branches, and Dependabot branches — with:

```
Loaded a configuration file for version '4.37.4', but running version '4.36.2'
```

## Cause

Dependabot treats `github/codeql-action/init`, `/autobuild` and `/analyze` as three separate dependencies and opens a PR per sub-action. Two of the three were bumped to v4.37.4 (45acb1695, 12e016144); `autobuild` was left on v4.36.2. `init` writes a v4.37.4 config file that the older `autobuild` binary then refuses to load, which also produced the *"Not all workflow steps that use `github/codeql-action` actions use the same version"* warning.

SHAs verified against the upstream tags:

| Step | Was | Now |
| --- | --- | --- |
| `init` | `f205ea1` (v4.37.4) | unchanged |
| `autobuild` | `8aad20d` (**v4.36.2**) | `f205ea1` (v4.37.4) |
| `analyze` | `f205ea1` (v4.37.4) | unchanged |

## Changes

- Repin `autobuild` to `f205ea1c3313d32999d8d6a48b4f6530d4437b38`, matching `init` and `analyze`.
- Add `# v4.37.4` comments to all three pins so a future mismatch is visible in the diff rather than only in a failed run.
- Group `github/codeql-action*` in `dependabot.yml` so the sub-actions bump together in one PR. This is the guardrail — without it the next release desyncs them again the same way.

`scorecards.yml` still pins `upload-sarif` at v4.37.0. It is the only codeql-action step in that workflow, so it neither mismatches nor warns; the new Dependabot group will bring it along on the next bump.

## Verification

- Resolved both SHAs via the GitHub API to confirm the version mapping (`8aad20d` = v4.36.2, `f205ea1` = v4.37.4).
- Both YAML files parse, and the Dependabot `groups` key resolves to the documented shape.
- Full pre-commit suite passed in the worktree: PHP lint, `bin/ecs check`, `bin/rector --dry-run`, `lint:yaml`.
- The real proof is CI on this PR: `Analyze (javascript)` should pass and the mismatched-version warning should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)