### PR TITLE
Resolve the owner through the CompanyFilter when posting a line

### DIFF
--- a/src/ApiBundle/State/Processor/InvoiceLinePersistProcessor.php
+++ b/src/ApiBundle/State/Processor/InvoiceLinePersistProcessor.php
@@ -34,7 +34,10 @@ final readonly class InvoiceLinePersistProcessor implements ProcessorInterface
         assert($data instanceof Line);
 
         $invoiceId = $uriVariables['invoiceId'] ?? null;
-        $invoice = $this->invoiceRepository->find($invoiceId);
+        // findOneBy() rather than find(): the CompanyFilter applies to both, but find() can
+        // answer from the identity map without querying, and 0a27718dc left this lookup as the
+        // only check between a posted line and its owner. See CompanyFilter's docblock.
+        $invoice = $this->invoiceRepository->findOneBy(['id' => $invoiceId]);
 
         if ($invoice === null) {
             throw new NotFoundHttpException(sprintf('Invoice "%s" not found.', $invoiceId));

--- a/src/ApiBundle/State/Processor/QuoteLinePersistProcessor.php
+++ b/src/ApiBundle/State/Processor/QuoteLinePersistProcessor.php
@@ -34,7 +34,10 @@ final readonly class QuoteLinePersistProcessor implements ProcessorInterface
         assert($data instanceof Line);
 
         $quoteId = $uriVariables['quoteId'] ?? null;
-        $quote = $this->quoteRepository->find($quoteId);
+        // findOneBy() rather than find(): the CompanyFilter applies to both, but find() can
+        // answer from the identity map without querying, and 0a27718dc left this lookup as the
+        // only check between a posted line and its owner. See CompanyFilter's docblock.
+        $quote = $this->quoteRepository->findOneBy(['id' => $quoteId]);
 
         if ($quote === null) {
             throw new NotFoundHttpException(sprintf('Quote "%s" not found.', $quoteId));

--- a/src/ApiBundle/State/Processor/RecurringInvoiceLinePersistProcessor.php
+++ b/src/ApiBundle/State/Processor/RecurringInvoiceLinePersistProcessor.php
@@ -34,7 +34,10 @@ final readonly class RecurringInvoiceLinePersistProcessor implements ProcessorIn
         assert($data instanceof RecurringInvoiceLine);
 
         $invoiceId = $uriVariables['invoiceId'] ?? null;
-        $recurringInvoice = $this->recurringInvoiceRepository->find($invoiceId);
+        // findOneBy() rather than find(): the CompanyFilter applies to both, but find() can
+        // answer from the identity map without querying, and 0a27718dc left this lookup as the
+        // only check between a posted line and its owner. See CompanyFilter's docblock.
+        $recurringInvoice = $this->recurringInvoiceRepository->findOneBy(['id' => $invoiceId]);
 
         if ($recurringInvoice === null) {
             throw new NotFoundHttpException(sprintf('Recurring invoice "%s" not found.', $invoiceId));

--- a/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/InvoiceLineTest.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\InvoiceBundle\Tests\Functional\Api;
 
 use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InvoiceBundle\Entity\Line;
 use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -207,6 +209,34 @@ final class InvoiceLineTest extends ApiTestCase
             url: '/api/invoices/' . $missingId . '/lines',
             options: [
                 'json' => ['description' => 'Orphan', 'price' => 100, 'qty' => 1.0],
+                'headers' => [
+                    'content-type' => 'application/ld+json',
+                    'accept' => 'application/ld+json',
+                ],
+            ]
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Seeding the other tenant through this EntityManager leaves its invoice managed, so a
+     * find() lookup in the processor would answer from the identity map and skip the
+     * CompanyFilter. That is the case this guards; see CompanyFilterLookupTest for why a
+     * cold request filters either way.
+     */
+    public function testCannotCreateLineOnAnInvoiceFromADifferentCompany(): void
+    {
+        $otherCompany = CompanyFactory::new()->create();
+        self::getContainer()->get(CompanySelector::class)->switchCompany($otherCompany->getId());
+        $foreignInvoice = InvoiceFactory::createOne(['company' => $otherCompany]);
+        self::getContainer()->get(CompanySelector::class)->switchCompany($this->company->getId());
+
+        self::$client->request(
+            method: Request::METHOD_POST,
+            url: '/api/invoices/' . $foreignInvoice->getId()->toString() . '/lines',
+            options: [
+                'json' => ['description' => 'Hacker', 'price' => 100, 'qty' => 1.0],
                 'headers' => [
                     'content-type' => 'application/ld+json',
                     'accept' => 'application/ld+json',

--- a/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
+++ b/src/InvoiceBundle/Tests/Functional/Api/RecurringInvoiceLineTest.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\InvoiceBundle\Tests\Functional\Api;
 
 use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\InvoiceBundle\Entity\RecurringInvoiceLine;
 use SolidInvoice\InvoiceBundle\Test\Factory\RecurringInvoiceFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -162,6 +164,34 @@ final class RecurringInvoiceLineTest extends ApiTestCase
             url: '/api/recurring-invoices/' . $missingId . '/lines',
             options: [
                 'json' => ['description' => 'Orphan', 'price' => 100, 'qty' => 1.0],
+                'headers' => [
+                    'content-type' => 'application/ld+json',
+                    'accept' => 'application/ld+json',
+                ],
+            ]
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Seeding the other tenant through this EntityManager leaves its recurring invoice managed, so a
+     * find() lookup in the processor would answer from the identity map and skip the
+     * CompanyFilter. That is the case this guards; see CompanyFilterLookupTest for why a
+     * cold request filters either way.
+     */
+    public function testCannotCreateLineOnARecurringInvoiceFromADifferentCompany(): void
+    {
+        $otherCompany = CompanyFactory::new()->create();
+        self::getContainer()->get(CompanySelector::class)->switchCompany($otherCompany->getId());
+        $foreignInvoice = RecurringInvoiceFactory::createOne(['company' => $otherCompany]);
+        self::getContainer()->get(CompanySelector::class)->switchCompany($this->company->getId());
+
+        self::$client->request(
+            method: Request::METHOD_POST,
+            url: '/api/recurring-invoices/' . $foreignInvoice->getId()->toString() . '/lines',
+            options: [
+                'json' => ['description' => 'Hacker', 'price' => 100, 'qty' => 1.0],
                 'headers' => [
                     'content-type' => 'application/ld+json',
                     'accept' => 'application/ld+json',

--- a/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
+++ b/src/QuoteBundle/Tests/Functional/Api/QuoteLineTest.php
@@ -15,6 +15,8 @@ namespace SolidInvoice\QuoteBundle\Tests\Functional\Api;
 
 use PHPUnit\Framework\Attributes\Group;
 use SolidInvoice\ApiBundle\Test\ApiTestCase;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
 use SolidInvoice\QuoteBundle\Entity\Line;
 use SolidInvoice\QuoteBundle\Test\Factory\QuoteFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -162,6 +164,34 @@ final class QuoteLineTest extends ApiTestCase
             url: '/api/quotes/' . $missingId . '/lines',
             options: [
                 'json' => ['description' => 'Orphan', 'price' => 100, 'qty' => 1.0],
+                'headers' => [
+                    'content-type' => 'application/ld+json',
+                    'accept' => 'application/ld+json',
+                ],
+            ]
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Seeding the other tenant through this EntityManager leaves its quote managed, so a
+     * find() lookup in the processor would answer from the identity map and skip the
+     * CompanyFilter. That is the case this guards; see CompanyFilterLookupTest for why a
+     * cold request filters either way.
+     */
+    public function testCannotCreateLineOnAQuoteFromADifferentCompany(): void
+    {
+        $otherCompany = CompanyFactory::new()->create();
+        self::getContainer()->get(CompanySelector::class)->switchCompany($otherCompany->getId());
+        $foreignQuote = QuoteFactory::createOne(['company' => $otherCompany]);
+        self::getContainer()->get(CompanySelector::class)->switchCompany($this->company->getId());
+
+        self::$client->request(
+            method: Request::METHOD_POST,
+            url: '/api/quotes/' . $foreignQuote->getId()->toString() . '/lines',
+            options: [
+                'json' => ['description' => 'Hacker', 'price' => 100, 'qty' => 1.0],
                 'headers' => [
                     'content-type' => 'application/ld+json',
                     'accept' => 'application/ld+json',


### PR DESCRIPTION
> **Stacked on #2848** — review that one first; it establishes the facts this PR relies on.

## Correction to the original version of this PR

This PR previously claimed `POST /api/invoices/{id}/lines` was a **live cross-tenant write** and that `find()` bypasses the `CompanyFilter`. A reviewer challenged that, and the reviewer was right.

`find()` **is** filtered — `BasicEntityPersister::getSelectSQL()` appends every enabled filter at `:1146` and ANDs it into the WHERE at `:1149-1153`, and `findOneBy()` reaches that same line via the same `load()`. #2848 traces it in full and proves it against a real database.

The original probe answered `201` because the probe had **warmed the identity map** by seeding both tenants through one EntityManager. `EntityManager::find()` returns a managed instance at `EntityManager.php:325-347` before any SQL exists, so no filter runs. Re-probed with `$em->clear()` before the request — the shape of a real request — `find()` answers **404**.

**So there was no production cross-tenant hole here.** I should not have claimed one without clearing the identity map first.

## What this PR is now

Still worth landing, on narrower and honest grounds.

`0a27718dc` moved the 404 for a missing owner off the framework's read and onto these three processors, making that lookup the only thing between a posted line and its owner. `findOneBy(['id' => ...])` is immune to a warm identity map; `find()` is not. That matters for paths that can run warm — message handlers and worker-mode requests — and it is what **every other `uriVariables` consumer in the bundle already does** (`RecordPaymentProcessor`, `InvoiceTransitionProvider`, `QuoteItemProvider`, `RecurringInvoiceItemProvider`). These three were the outliers.

**Defence in depth and consistency, not a security fix.**

## Changes

- Three processors resolve the owner with `findOneBy(['id' => ...])`; comments now state the identity-map reason and point at `CompanyFilter`'s docblock.
- One regression test per endpoint, each carrying a docblock saying the condition it pins is the identity-map one — so the next reader does not re-derive "production cross-tenant write" from a passing test.

## Verification

- `bin/phpunit` — `InvoiceLineTest`, `RecurringInvoiceLineTest`, `QuoteLineTest`, `CompanyFilterLookupTest`: 25 passed / 156 assertions.
- Probe matrix on the real HTTP path: `find()` + warm map → 201; `find()` + `$em->clear()` → 404; `findOneBy()` → 404 either way.
- `bin/phpstan` clean on the six touched files; `bin/ecs` and `bin/rector --dry-run` clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)