### PR TITLE
Settle what find() does with the CompanyFilter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,29 @@ Currencies come from Client entity. Never use default currency.
 - PCI-compliant payments via Payum
 - Use env vars for secrets
 
+### `find()` applies the CompanyFilter
+
+Doctrine SQL filters are applied in the WHERE clause of every generated SELECT, including the one
+`find()` produces. `find()` is **not** a filter bypass and swapping it for `findOneBy(['id' => ...])`
+is **not** a cross-tenant fix. Do not write otherwise without reading the source first:
+
+| Path | Filtered? | Where |
+|------|-----------|-------|
+| `find()` / `findOneBy()` / `findBy()` / `findAll()` | yes | `BasicEntityPersister::getSelectSQL()` — `vendor/doctrine/orm/src/Persisters/Entity/BasicEntityPersister.php:1146` |
+| DQL / QueryBuilder | yes | `SqlWalker::generateFilterConditionSQL()` — `vendor/doctrine/orm/src/Query/SqlWalker.php:454` |
+| `find()` on an **already-managed** entity | no | returns from the identity map before any SQL — `vendor/doctrine/orm/src/EntityManager.php:325-347` |
+| `getReference()` | on initialisation | the proxy emits no SQL until used, then loads via `loadById()` and throws `EntityNotFoundException` if filtered out — `vendor/doctrine/orm/src/Proxy/ProxyFactory.php:223,295` |
+
+The identity-map row is the only real difference between `find()` and `findOneBy()`. It is why
+`findOneBy(['id' => ...])` is still the better default where the EntityManager may be warm (message
+handlers, worker-mode requests, and functional tests that seed more than one tenant) — defence in
+depth, not a live vulnerability.
+
+`CompanyFilter`'s class docblock carries the full trace, and
+`CoreBundle/Tests/Functional/CompanyFilterLookupTest` proves all four combinations of
+{`find`, `findOneBy`} × {warm, cold identity map} against a real database. Cite those rather than
+guessing.
+
 ---
 
 ## Quick Reference

--- a/src/ClientBundle/Api/Processor/ContactPersistProcessor.php
+++ b/src/ClientBundle/Api/Processor/ContactPersistProcessor.php
@@ -37,7 +37,8 @@ final readonly class ContactPersistProcessor implements ProcessorInterface
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
         if ($data instanceof Contact && isset($uriVariables['clientId'])) {
-            // findOneBy (not find) ensures the global CompanyFilter is applied, preventing cross-company access.
+            // findOneBy() rather than find(): the CompanyFilter applies to both, but findOneBy()
+            // cannot answer from the identity map. See CompanyFilter's docblock.
             $client = $this->clientRepository->findOneBy(['id' => $uriVariables['clientId']]);
             if (! $client instanceof Client) {
                 throw new NotFoundHttpException(sprintf('Client "%s" not found.', $uriVariables['clientId']));

--- a/src/ClientBundle/Serializer/Normalilzer/AddressNormalizer.php
+++ b/src/ClientBundle/Serializer/Normalilzer/AddressNormalizer.php
@@ -50,9 +50,9 @@ final class AddressNormalizer implements NormalizerAwareInterface, NormalizerInt
 
         if (isset($context['uri_variables']['clientId'])) {
             $clientId = $context['uri_variables']['clientId'];
-            // findOneBy() and not find(), so the CompanyFilter applies: find() bypasses it,
-            // and the address post has no persist processor to re-check, so a post to another
-            // company's client URI attached the address to that client and returned 201.
+            // findOneBy() rather than find(): the CompanyFilter applies to both, but find() can
+            // answer from the identity map without querying when the client is already managed,
+            // and this post has no persist processor behind it. See CompanyFilter's docblock.
             $client = $this->registry->getRepository(Client::class)
                 ->findOneBy(['id' => $clientId]);
 

--- a/src/ClientBundle/Serializer/Normalilzer/ContactNormalizer.php
+++ b/src/ClientBundle/Serializer/Normalilzer/ContactNormalizer.php
@@ -50,8 +50,9 @@ final class ContactNormalizer implements NormalizerAwareInterface, NormalizerInt
 
         if (isset($context['uri_variables']['clientId'])) {
             $clientId = $context['uri_variables']['clientId'];
-            // findOneBy() and not find(), so the CompanyFilter applies, matching what
-            // ContactPersistProcessor already does rather than relying on it.
+            // findOneBy() rather than find(), matching ContactPersistProcessor rather than
+            // relying on it. The CompanyFilter applies to both; findOneBy() additionally cannot
+            // answer from the identity map. See CompanyFilter's docblock.
             $client = $this->registry->getRepository(Client::class)
                 ->findOneBy(['id' => $clientId]);
 

--- a/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
+++ b/src/CoreBundle/Doctrine/Filter/CompanyFilter.php
@@ -21,7 +21,43 @@ use SolidInvoice\UserBundle\Entity\User;
 use function sprintf;
 
 /**
+ * Scopes every company-aware entity to the active company.
+ *
+ * ---------------------------------------------------------------------------
+ * `find()` applies this filter. It is not a cross-tenant hole.
+ * ---------------------------------------------------------------------------
+ *
+ * This gets re-litigated often enough to be worth settling here, with line numbers rather
+ * than adjectives. In the Doctrine ORM this repo has installed:
+ *
+ *  - `EntityRepository::find()` (vendor/doctrine/orm/src/EntityRepository.php:86) delegates to
+ *    `EntityManager::find()` (vendor/doctrine/orm/src/EntityManager.php:274).
+ *  - Missing the identity map, it calls `loadById()` -> `load()`
+ *    (vendor/doctrine/orm/src/Persisters/Entity/BasicEntityPersister.php:754, then :725), which
+ *    builds its SQL in `getSelectSQL()` (:1109). Line :1146 collects every enabled filter's
+ *    constraint and :1149-1153 ANDs it into the WHERE clause. The filter is in the query.
+ *  - `findOneBy()` (EntityRepository.php:125) calls that *same* `load()`, so it is filtered by
+ *    the same line. `find()` and `findOneBy()` are not stronger or weaker than each other here.
+ *
+ * Every other read path reaches the same `getSelectSQL()` — `refresh()` (:851), `loadAll()`
+ * (:884), `loadCriteria()` (:961), and the collection loads (:1103, :1869) — and DQL applies
+ * filters in `SqlWalker::generateFilterConditionSQL()` (vendor/doctrine/orm/src/Query/SqlWalker.php:454).
+ *
+ * The one genuine difference: `EntityManager::find()` checks the identity map first
+ * (EntityManager.php:325-347) and returns a hit without emitting SQL, so no filter runs.
+ * `findOneBy()` has no such shortcut. That only matters where an entity can already be managed,
+ * which in a normal request means it was loaded through a path the filter already allowed. It
+ * bites in functional tests, which seed several tenants through one EntityManager, and it is the
+ * reason to prefer `findOneBy(['id' => ...])` in code that may run with a warm EntityManager
+ * (message handlers, worker-mode requests) — defence in depth, not a fix for a live hole.
+ *
+ * Before writing "find() bypasses the filter" in a comment or a commit message, read
+ * {@see \SolidInvoice\CoreBundle\Tests\Functional\CompanyFilterLookupTest}, which proves all four
+ * combinations of {find, findOneBy} x {warm, cold identity map} against a real database.
+ *
  * @see \SolidInvoice\CoreBundle\Tests\Doctrine\Filter\CompanyFilterTest
+ * @see \SolidInvoice\CoreBundle\Tests\Functional\CompanyFilterLookupTest
+ * @see \SolidInvoice\CoreBundle\Tests\Functional\AccountIsolationTest
  */
 class CompanyFilter extends SQLFilter
 {

--- a/src/CoreBundle/Tests/Functional/CompanyFilterLookupTest.php
+++ b/src/CoreBundle/Tests/Functional/CompanyFilterLookupTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidInvoice project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidInvoice\CoreBundle\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use SolidInvoice\ClientBundle\Enum\ClientStatus;
+use SolidInvoice\ClientBundle\Test\Factory\ClientFactory;
+use SolidInvoice\CoreBundle\Company\CompanySelector;
+use SolidInvoice\CoreBundle\Entity\Company;
+use SolidInvoice\CoreBundle\Test\Factory\CompanyFactory;
+use SolidInvoice\CoreBundle\Test\Traits\DoctrineTestTrait;
+use SolidInvoice\InvoiceBundle\Entity\Invoice;
+use SolidInvoice\InvoiceBundle\Enum\InvoiceStatus;
+use SolidInvoice\InvoiceBundle\Test\Factory\InvoiceFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Executable specification for one question that keeps getting answered wrong:
+ * does {@see \Doctrine\ORM\EntityRepository::find()} apply the CompanyFilter?
+ *
+ * It does. `find()` is not a filter bypass, and swapping it for `findOneBy(['id' => ...])`
+ * is not a cross-tenant fix. The one and only difference between them is the identity map.
+ *
+ * The paths, in the vendor code this repo has installed:
+ *
+ *  - `EntityRepository::find()` (vendor/doctrine/orm/src/EntityRepository.php:86) delegates to
+ *    `EntityManager::find()` (vendor/doctrine/orm/src/EntityManager.php:274).
+ *  - `EntityManager::find()` checks the identity map first
+ *    (vendor/doctrine/orm/src/EntityManager.php:325-347). On a hit it returns the managed
+ *    object and never touches the database, so no filter can run. This is the only bypass.
+ *  - On a miss it calls `loadById()` -> `load()`
+ *    (vendor/doctrine/orm/src/Persisters/Entity/BasicEntityPersister.php:754, 725), which builds
+ *    its SQL with `getSelectSQL()` (:1109). That method appends every enabled filter's
+ *    constraint at :1146 and ANDs it into the WHERE at :1149-1153.
+ *  - `EntityRepository::findOneBy()` (EntityRepository.php:125) calls the same `load()`, so it
+ *    reaches the same `getSelectSQL()` and the same filter. It has no identity-map shortcut,
+ *    which is why it is unaffected by a warm identity map.
+ *
+ * Every other read path lands on `getSelectSQL()` too — `refresh()` (:851), `loadAll()` (:884),
+ * `loadCriteria()` (:961) and the collection loads (:1103, :1869) — and DQL applies filters in
+ * `SqlWalker::generateFilterConditionSQL()` (vendor/doctrine/orm/src/Query/SqlWalker.php:454).
+ *
+ * @see \SolidInvoice\CoreBundle\Doctrine\Filter\CompanyFilter
+ * @see \SolidInvoice\CoreBundle\Tests\Functional\AccountIsolationTest
+ */
+#[Group('functional')]
+final class CompanyFilterLookupTest extends WebTestCase
+{
+    use DoctrineTestTrait;
+
+    /**
+     * The claim under test: with nothing in the identity map — the shape of a real request —
+     * `find()` filters exactly like `findOneBy()`, and neither returns another company's row.
+     */
+    public function testFindAppliesTheCompanyFilterWhenItReachesTheDatabase(): void
+    {
+        [$alpha, $beta] = $this->seedTwoCompanies();
+
+        // A real HTTP request starts here: nothing of either tenant is managed yet.
+        $this->em->clear();
+        $this->switchTo($alpha['company']);
+
+        $invoices = $this->em->getRepository(Invoice::class);
+
+        self::assertNull(
+            $invoices->find($beta['invoice']->getId()),
+            "find() must not return another company's invoice: the filter is in the WHERE clause."
+        );
+        self::assertNull(
+            $invoices->findOneBy(['id' => $beta['invoice']->getId()]),
+            'findOneBy() must not return it either — same load(), same filter.'
+        );
+
+        self::assertNotNull(
+            $invoices->find($alpha['invoice']->getId()),
+            "The active company's own invoice must still load, or the test proves nothing."
+        );
+    }
+
+    /**
+     * The only real difference. An entity already managed by the EntityManager is returned by
+     * `find()` from the identity map, without SQL and therefore without the filter, while
+     * `findOneBy()` still issues a filtered query and finds nothing.
+     *
+     * This is what makes `find()` look like a filter bypass in a functional test: the test
+     * seeds both tenants through the same EntityManager, so the foreign row is already managed
+     * before the request runs. Clearing the identity map — the last assertion — makes `find()`
+     * agree with `findOneBy()` again, which is the proof that the filter was never the variable.
+     */
+    public function testFindReturnsAnAlreadyManagedEntityWithoutConsultingTheFilter(): void
+    {
+        [$alpha, $beta] = $this->seedTwoCompanies();
+
+        // Deliberately no clear(): both tenants are still managed from seeding.
+        $this->switchTo($alpha['company']);
+
+        $invoices = $this->em->getRepository(Invoice::class);
+
+        self::assertNotNull(
+            $invoices->find($beta['invoice']->getId()),
+            'An identity-map hit returns before any query is built (EntityManager.php:325-347).'
+        );
+        self::assertNull(
+            $invoices->findOneBy(['id' => $beta['invoice']->getId()]),
+            'findOneBy() has no such shortcut, so the filtered query returns nothing.'
+        );
+
+        $this->em->clear();
+
+        self::assertNull(
+            $invoices->find($beta['invoice']->getId()),
+            'With the identity map cleared, find() filters too. The identity map was the difference.'
+        );
+    }
+
+    private function switchTo(Company $company): void
+    {
+        $selector = self::getContainer()->get(CompanySelector::class);
+        self::assertInstanceOf(CompanySelector::class, $selector);
+
+        $selector->switchCompany($company->getId());
+    }
+
+    /**
+     * @return array{0: array{company: Company, invoice: Invoice}, 1: array{company: Company, invoice: Invoice}}
+     */
+    private function seedTwoCompanies(): array
+    {
+        $filters = $this->em->getFilters();
+        $wasEnabled = $filters->isEnabled('company');
+
+        if ($wasEnabled) {
+            $filters->disable('company');
+        }
+
+        $seed = static function (string $slug): array {
+            $company = CompanyFactory::createOne(['name' => $slug . ' Inc']);
+
+            $client = ClientFactory::createOne([
+                'company' => $company,
+                'name' => $slug . ' Client',
+                'status' => ClientStatus::Active,
+            ]);
+
+            return [
+                'company' => $company,
+                'invoice' => InvoiceFactory::createOne([
+                    'company' => $company,
+                    'client' => $client,
+                    'status' => InvoiceStatus::Pending,
+                ]),
+            ];
+        };
+
+        $accounts = [$seed('alpha'), $seed('beta')];
+
+        if ($wasEnabled) {
+            $filters->enable('company');
+        }
+
+        return $accounts;
+    }
+}


### PR DESCRIPTION
## Why

A reviewer pushed back on a comment I wrote — *"findOneBy() and not find(), so the CompanyFilter applies: find() bypasses it"* — pointing out this is not the first time an agent has claimed `find()` is a cross-tenant hole, and asking that it be verified in the source and documented so future changes cite a line instead of guessing.

**The reviewer is right. `find()` applies Doctrine SQL filters.** I had it backwards.

The repo currently contradicts itself, which is a good part of why the question keeps getting re-answered from memory:

| Site | Said |
|---|---|
| `AddressNormalizer`, `ContactNormalizer`, `ContactPersistProcessor` | `find()` bypasses the filter ❌ |
| `UserInvitationRepository`, `CustomFieldReorderAction` | `find()` is filtered ✅ |

## What the source says

Traced in the ORM this repo has installed, not recalled:

```
EntityRepository::find()          EntityRepository.php:86
  -> EntityManager::find()        EntityManager.php:274
  -> loadById() -> load()         BasicEntityPersister.php:754, :725
  -> getSelectSQL()               BasicEntityPersister.php:1109
```

`getSelectSQL()` collects every enabled filter at **:1146** and ANDs it into the WHERE at **:1149-1153**. `findOneBy()` (`EntityRepository.php:125`) calls that **same** `load()`, so it is filtered by the same line. Neither is stronger than the other. `refresh()` (:851), `loadAll()` (:884), `loadCriteria()` (:961) and the collection loads (:1103, :1869) all land on `getSelectSQL()` too; DQL filters in `SqlWalker::generateFilterConditionSQL()` (`SqlWalker.php:454`); `getReference()` proxies filter on initialisation via `loadById()` (`ProxyFactory.php:223,295`).

**The one real difference is the identity map.** `EntityManager::find()` returns a managed instance at **`EntityManager.php:325-347`** before any SQL exists, so no filter can run. `findOneBy()` has no such shortcut.

## Verified, not argued

`CompanyFilterLookupTest` proves all four combinations against a real database:

| | warm identity map | cold identity map |
|---|---|---|
| `find()` | returns foreign row | **null** |
| `findOneBy()` | **null** | **null** |

The load-bearing assertion is the last one: clearing the identity map makes `find()` agree with `findOneBy()`. That is what shows the filter was never the variable.

I also probed it end-to-end over HTTP on #2847's endpoint. With `find()` restored **and** `$em->clear()` before the request — the shape of a real request — the cross-tenant POST answers **404**. It only answers 201 because the functional test seeds both tenants through one EntityManager and never clears it.

So `findOneBy(['id' => ...])` is still the better default where the EntityManager may be warm (message handlers, worker-mode requests, functional tests) — **defence in depth, not a live vulnerability.**

## Changes

- `CompanyFilterLookupTest` — executable spec, the durable artefact; every claim above is an assertion.
- `CompanyFilter` docblock — the full trace with line numbers, where an agent touching multi-tenancy lands.
- `CLAUDE.md` — a path/filtered/where table under Security, read before the first change.
- The three backwards comments now point at the docblock. The two already-correct sites are left alone.

## Verification

- `bin/phpunit` — `CompanyFilterLookupTest`, `AccountIsolationTest`, `CompanyFilterTest`: 14 passed / 41 assertions.
- `bin/phpunit` — `ContactTest`, `AddressTest`, `CrossTenantTest`: 21 passed / 101 assertions.
- `bin/ecs`, `bin/phpstan`, `bin/rector --dry-run` clean; pre-commit hooks passed.

## Follow-up

#2847 carries the same wrong reasoning in three comments and is rebased onto this branch to correct it. Its behaviour stands; only the justification changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)